### PR TITLE
[codex] Add E02 SDK identity and package foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,11 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -44,6 +49,7 @@ jobs:
         run: |
           pnpm --filter @cubid/core test
           pnpm --filter @cubid/core typecheck
+          pnpm --filter @cubid/core deno:check
           pnpm --filter @cubid/core build
           pnpm --filter @cubid/core pack:dry-run
           pnpm --filter @cubid/core jsr:dry-run

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3010,3 +3010,29 @@ Mark `E02.2.1` completed after the additional runtime-agnostic SDK wrappers and 
 #### Follow-up
 
 - publish the branch for review or proceed to E02.4 package validation/docs if the SDK surface is ready for broader release work
+
+### session: v105
+
+- timestamp: 2026-04-29T17:41:47Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`5626b19`**
+- session name: **Start E02.4 Deno and integration DX**
+
+#### Objective
+
+Start E02.4 to add Deno/Supabase Edge validation, integration guidance, examples, and stability notes for `@cubid/core` before publication.
+
+#### Actions Taken
+
+- marked `E02.4` started on the current SDK feature branch
+- inspected existing package scripts, CI, docs, and local Deno availability
+- selected local source Deno validation plus JSR dry-run validation because `@cubid/core` is not yet published on JSR
+
+#### Verification
+
+- confirmed the repo is clean before E02.4 implementation changes
+
+#### Follow-up
+
+- add package-level Deno checks, CI wiring, integration docs, examples, and closeout metadata

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2827,3 +2827,28 @@ Address Copilot review comments on PR #150 for `@cubid/core` base URL validation
 #### Follow-up
 
 - push the Copilot review fixes, reply to and resolve the review threads, then re-check PR CI and review state
+
+### session: v98
+
+- timestamp: 2026-04-29T16:07:20Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`397c376`**
+- session name: **Capture SDK v2 cherry-pick roadmap follow-ups**
+
+#### Objective
+
+Commit the todo-only roadmap update that preserves the useful SDK comparison insights before starting E02.2 implementation work.
+
+#### Actions Taken
+
+- added `E02.2.1` to direct future `@cubid/core` work toward normalized responses, malformed-response handling, endpoint-aware errors, and selected low-level wrappers from the older SDK
+- added `E02.3.1` to preserve useful web2, React, and wallet adapter prototype ideas while translating them into the new target package model
+
+#### Verification
+
+- reviewed `agent-context/todo.md` diff for roadmap-only scope
+
+#### Follow-up
+
+- commit the roadmap-only update, then mark `E02.2` started on this branch with a separate session-log entry and commit

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3064,3 +3064,29 @@ Add the Deno/Supabase Edge validation and integration guidance needed before pub
 #### Follow-up
 
 - commit the E02.4 implementation, then close E02.4 metadata with the implementation head
+
+### session: v107
+
+- timestamp: 2026-04-29T17:45:07Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`9fe5a52`**
+- session name: **Close E02.4 integration DX**
+
+#### Objective
+
+Mark `E02.4` completed after the Deno validation, CI wiring, and integration docs landed.
+
+#### Actions Taken
+
+- updated `agent-context/todo.md` with the E02.4 completion timestamp
+- recorded the implementation commit as the E02.4 head
+- attached the start, implementation, and closeout session-log references to the todo
+
+#### Verification
+
+- confirmed the E02.4 metadata points at implementation head `9fe5a52`
+
+#### Follow-up
+
+- publish the branch for review, then configure trusted npm/JSR publishing once merged

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2905,3 +2905,29 @@ Implement the `@cubid/core` E02.2 server-facing identity sync helpers with norma
 #### Follow-up
 
 - commit the implementation, then close out E02.2 metadata with the implementation commit head
+
+### session: v101
+
+- timestamp: 2026-04-29T16:41:13Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`2727a8e`**
+- session name: **Close E02.2 metadata**
+
+#### Objective
+
+Mark `E02.2` completed after the `@cubid/core` identity sync helper implementation and focused validation landed.
+
+#### Actions Taken
+
+- updated `agent-context/todo.md` with the E02.2 completion timestamp
+- recorded the implementation commit as the E02.2 head
+- attached the start, implementation, and closeout session-log references to the todo
+
+#### Verification
+
+- confirmed the E02.2 metadata points at implementation head `2727a8e`
+
+#### Follow-up
+
+- continue with `E02.2.1` to port additional runtime-agnostic ergonomics from `cubid-sdk-v2`, or publish the current branch for review first

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2984,3 +2984,29 @@ Complete `E02.2.1` by porting the remaining useful runtime-agnostic SDK ergonomi
 #### Follow-up
 
 - commit the implementation, then close `E02.2.1` metadata with the implementation commit head
+
+### session: v104
+
+- timestamp: 2026-04-29T17:31:33Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`e995f0e`**
+- session name: **Close E02.2.1 SDK ergonomics port**
+
+#### Objective
+
+Mark `E02.2.1` completed after the additional runtime-agnostic SDK wrappers and safety tests landed.
+
+#### Actions Taken
+
+- updated `agent-context/todo.md` with the E02.2.1 completion timestamp
+- recorded the implementation commit as the E02.2.1 head
+- attached the start, implementation, and closeout session-log references to the todo
+
+#### Verification
+
+- confirmed the E02.2.1 metadata points at implementation head `e995f0e`
+
+#### Follow-up
+
+- publish the branch for review or proceed to E02.4 package validation/docs if the SDK surface is ready for broader release work

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3150,3 +3150,30 @@ Implement the missing E02.3 package slice with publishable React profile-complet
 #### Follow-up
 
 - commit the E02.3 implementation, then mark E02.3 completed with the implementation head
+
+### session: v116
+
+- timestamp: 2026-04-29T19:39:33Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`b7b6c36`**
+- session name: **Close E02.3 SDK package foundations**
+
+#### Objective
+
+Mark E02.3 and its SDK-v2 adaptation subtask complete after the React and chain package foundations landed.
+
+#### Actions Taken
+
+- updated `agent-context/todo.md` to mark `E02.3` completed
+- updated `E02.3.1` as completed because the implemented package slice used the older web2, React, and wallet SDK prototypes as source material for the new package model
+- recorded implementation head `b7b6c36` and attached the E02.3 start, implementation, and closeout session references
+
+#### Verification
+
+- confirmed implementation head `b7b6c36` exists
+- relied on the E02.3 validation recorded in `session: v115`
+
+#### Follow-up
+
+- publish the E02 branch for review, then configure trusted publishing before any live package release

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2931,3 +2931,29 @@ Mark `E02.2` completed after the `@cubid/core` identity sync helper implementati
 #### Follow-up
 
 - continue with `E02.2.1` to port additional runtime-agnostic ergonomics from `cubid-sdk-v2`, or publish the current branch for review first
+
+### session: v102
+
+- timestamp: 2026-04-29T17:27:43Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`b78ae9e`**
+- session name: **Start E02.2.1 SDK ergonomics port**
+
+#### Objective
+
+Start the follow-on SDK ergonomics slice that ports the remaining runtime-agnostic, security-compatible helpers from `cubid-sdk-v2` into `@cubid/core`.
+
+#### Actions Taken
+
+- marked `E02.2.1` started on the current feature branch
+- inspected the older SDK API client and current Passport v2 routes for wrapper compatibility
+- confirmed the port should focus on `addStamp`, location/user-data/search, and safe OTP response helpers without exposing plaintext OTP values
+
+#### Verification
+
+- reviewed `agent-context/todo.md` metadata and current package route coverage before implementation
+
+#### Follow-up
+
+- add the compatible wrappers, tests, docs, and closeout metadata for `E02.2.1`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2878,3 +2878,30 @@ Mark `E02.2` started on the new feature branch before implementing the `@cubid/c
 #### Follow-up
 
 - implement the `@cubid/core` identity sync helpers, normalized response models, and malformed-response handling guided by `E02.2` and `E02.2.1`
+
+### session: v100
+
+- timestamp: 2026-04-29T16:40:48Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`f47e98a`**
+- session name: **Implement E02.2 core identity helpers**
+
+#### Objective
+
+Implement the `@cubid/core` E02.2 server-facing identity sync helpers with normalized response models and safer malformed-response handling.
+
+#### Actions Taken
+
+- added normalized camelCase response models for create-user, identity, score, and stamp responses while retaining raw payloads for debugging
+- added `ensureUserByEmail` and `syncIdentitySnapshot` to the runtime-agnostic client
+- expanded `CubidApiError` with optional code and endpoint metadata, including `MALFORMED_RESPONSE` and `NETWORK_ERROR`
+- updated package tests, README guidance, and the engineering package contract doc for the new helper surface
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck && pnpm --filter @cubid/core build'`
+
+#### Follow-up
+
+- commit the implementation, then close out E02.2 metadata with the implementation commit head

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3090,3 +3090,29 @@ Mark `E02.4` completed after the Deno validation, CI wiring, and integration doc
 #### Follow-up
 
 - publish the branch for review, then configure trusted npm/JSR publishing once merged
+
+### session: v114
+
+- timestamp: 2026-04-29T19:27:57Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`36f121b`**
+- session name: **Start E02.3 React and chain SDK packages**
+
+#### Objective
+
+Start the missing E02.3 package slice after confirming E02.2 and E02.4 were already completed on this branch.
+
+#### Actions Taken
+
+- verified `E02.2` and `E02.4` are completed in the E02 branch metadata and backed by implementation commits
+- confirmed `E02.3` remains unimplemented and marked it started
+- scoped the implementation to publishable `@cubid/react` profile-completion primitives plus chain-package boundaries that keep chain dependencies out of `@cubid/core`
+
+#### Verification
+
+- inspected `agent-context/todo.md`, `agent-context/session-log.md`, and git history for E02 evidence
+
+#### Follow-up
+
+- add package-ready React and chain SDK workspaces, tests, docs, validation, and closeout metadata

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3116,3 +3116,37 @@ Start the missing E02.3 package slice after confirming E02.2 and E02.4 were alre
 #### Follow-up
 
 - add package-ready React and chain SDK workspaces, tests, docs, validation, and closeout metadata
+
+### session: v115
+
+- timestamp: 2026-04-29T19:38:55Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`789e3a5`**
+- session name: **Implement E02.3 React and chain SDK package foundations**
+
+#### Objective
+
+Implement the missing E02.3 package slice with publishable React profile-completion primitives and chain-specific package boundaries.
+
+#### Actions Taken
+
+- added `@cubid/react` with React provider/hooks, `PhoneOtpForm`, provider connect buttons, AllowPage URL helpers, callback-state helpers, and missing recommended credential summaries
+- added publishable chain package workspaces for `@cubid/evm`, `@cubid/solana`, `@cubid/cardano`, `@cubid/sui`, and `@cubid/near`
+- added `@cubid/wagmi` as the wagmi-only package boundary with EVM stamp-data integration helpers
+- kept heavy chain SDKs out of this first package slice so `@cubid/core` and `@cubid/react` remain cleanly bounded
+- updated the SDK target-state doc with the implemented E02 package layering
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/react test && pnpm --filter @cubid/react typecheck && pnpm --filter @cubid/react build'`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/evm test && pnpm --filter @cubid/evm typecheck && pnpm --filter @cubid/evm build'`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/solana typecheck && pnpm --filter @cubid/solana build && pnpm --filter @cubid/cardano typecheck && pnpm --filter @cubid/cardano build && pnpm --filter @cubid/sui typecheck && pnpm --filter @cubid/sui build'`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/near typecheck && pnpm --filter @cubid/near build && pnpm --filter @cubid/wagmi typecheck && pnpm --filter @cubid/wagmi build'`
+- `npx -p node@24 -c 'node --version && pnpm test'`
+- `npx -p node@24 -c 'node --version && pnpm typecheck'`
+- `npx -p node@24 -c 'node --version && pnpm build'`
+
+#### Follow-up
+
+- commit the E02.3 implementation, then mark E02.3 completed with the implementation head

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3177,3 +3177,32 @@ Mark E02.3 and its SDK-v2 adaptation subtask complete after the React and chain 
 #### Follow-up
 
 - publish the E02 branch for review, then configure trusted publishing before any live package release
+
+### session: v117
+
+- timestamp: 2026-04-29T22:49:55Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`592038c`**
+- session name: **Address PR 151 SDK review feedback**
+
+#### Objective
+
+Resolve the actionable Copilot and Codex review comments on PR #151 before continuing the publish workflow.
+
+#### Actions Taken
+
+- removed `this`-dependent SDK helper calls so destructured `@cubid/core` methods remain callable
+- validated callback providers in `@cubid/react`, disabled verified OTP resubmission, and added handled provider-connect errors
+- preserved EVM and Solana connection metadata in stamp payloads so wagmi connector metadata is not dropped
+- added focused regression coverage for destructured core helpers, invalid callback providers, and EVM metadata preservation
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck'`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/react test && pnpm --filter @cubid/react typecheck && pnpm --filter @cubid/react build'`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/evm test && pnpm --filter @cubid/evm typecheck && pnpm --filter @cubid/evm build && pnpm --filter @cubid/solana typecheck && pnpm --filter @cubid/wagmi typecheck'`
+
+#### Follow-up
+
+- commit and push the review fixes, comment with the solutions, resolve the PR threads, and recheck CI

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3036,3 +3036,31 @@ Start E02.4 to add Deno/Supabase Edge validation, integration guidance, examples
 #### Follow-up
 
 - add package-level Deno checks, CI wiring, integration docs, examples, and closeout metadata
+
+### session: v106
+
+- timestamp: 2026-04-29T17:44:44Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`6dbd328`**
+- session name: **Add E02.4 Deno and Edge integration validation**
+
+#### Objective
+
+Add the Deno/Supabase Edge validation and integration guidance needed before publishing `@cubid/core`.
+
+#### Actions Taken
+
+- added a package-level Deno smoke check that imports local `@cubid/core` TypeScript source and models a Supabase Edge Function
+- wired Deno setup into CI and the manual publish workflow, and added `deno:check` to the root core-package validation contract
+- added a Next.js plus Supabase Edge integration guide with copy-paste examples for user resolution, identity snapshots, OTP flows, and post-return refresh
+- updated `@cubid/core` README and engineering docs with Deno validation and JSR usage guidance
+
+#### Verification
+
+- `pnpm --filter @cubid/core deno:check`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck && pnpm --filter @cubid/core deno:check && pnpm --filter @cubid/core build && pnpm --filter @cubid/core pack:dry-run && pnpm --filter @cubid/core jsr:dry-run && pnpm check:core-package'`
+
+#### Follow-up
+
+- commit the E02.4 implementation, then close E02.4 metadata with the implementation head

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2957,3 +2957,30 @@ Start the follow-on SDK ergonomics slice that ports the remaining runtime-agnost
 #### Follow-up
 
 - add the compatible wrappers, tests, docs, and closeout metadata for `E02.2.1`
+
+### session: v103
+
+- timestamp: 2026-04-29T17:31:12Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`10bdeb8`**
+- session name: **Port runtime-agnostic SDK wrappers**
+
+#### Objective
+
+Complete `E02.2.1` by porting the remaining useful runtime-agnostic SDK ergonomics from `cubid-sdk-v2` into the new `@cubid/core` package.
+
+#### Actions Taken
+
+- added normalized `@cubid/core` wrappers for `addStamp`, location fetches, user-data fetch, location search, and email/phone OTP send/verify flows
+- preserved the newer security posture by omitting raw OTP codes from SDK responses even when legacy server payloads contain one
+- added tests for endpoint paths, normalized legacy response shapes, malformed search responses, and safe OTP metadata
+- updated package README and engineering docs to describe the expanded wrapper surface
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck && pnpm --filter @cubid/core build'`
+
+#### Follow-up
+
+- commit the implementation, then close `E02.2.1` metadata with the implementation commit head

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2852,3 +2852,29 @@ Commit the todo-only roadmap update that preserves the useful SDK comparison ins
 #### Follow-up
 
 - commit the roadmap-only update, then mark `E02.2` started on this branch with a separate session-log entry and commit
+
+### session: v99
+
+- timestamp: 2026-04-29T16:07:42Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-2-core-identity-sync**
+- head: **`4cf2f89`**
+- session name: **Start E02.2 core identity sync**
+
+#### Objective
+
+Mark `E02.2` started on the new feature branch before implementing the `@cubid/core` high-level identity sync helpers.
+
+#### Actions Taken
+
+- updated `agent-context/todo.md` so `E02.2` is started on `codex/e02-2-core-identity-sync`
+- recorded the roadmap commit SHA as the starting head for the task
+- kept implementation work out of the metadata-start commit
+
+#### Verification
+
+- reviewed the E02.2 metadata fields after editing
+
+#### Follow-up
+
+- implement the `@cubid/core` identity sync helpers, normalized response models, and malformed-response handling guided by `E02.2` and `E02.2.1`

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -572,23 +572,23 @@ Use the older `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/api` implementat
 
 ### E02.3 Publish `@cubid/react` and chain SDK packages with profile-completion primitives
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-04-29T19:27:57Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-04-29T19:39:33Z
 - Feature branch: codex/e02-2-core-identity-sync
-- Head: 36f121b
-- Session-log reference(s): session: v114
+- Head: b7b6c36
+- Session-log reference(s): session: v114, session: v115, session: v116
 
 Turn the browser-side and ecosystem-specific integration layers into publishable packages that downstream apps can consume without local tarballs or repo-coupled wrappers. `@cubid/react` should own React hooks, components, AllowPage integration helpers, and profile-completion primitives, while chain packages such as `@cubid/evm`, `@cubid/wagmi`, `@cubid/solana`, `@cubid/cardano`, `@cubid/sui`, and `@cubid/near` isolate wallet and signing dependencies. The React flow should make inline phone capture, provider/stamp connection, and post-return refresh patterns easy without each app owning Cubid OAuth and callback complexity. Provide primitives such as a `PhoneOtpForm`, provider connect buttons or hooks, success/failure/cancel callbacks, and helpers that report available, verified, and missing recommended credentials in one normalized shape.
 
 ### E02.3.1 Adapt the older web2, React, and wallet SDK prototypes into the new package model
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-04-29T19:27:57Z
+- Timestamp completed: 2026-04-29T19:39:33Z
+- Feature branch: codex/e02-2-core-identity-sync
+- Head: b7b6c36
+- Session-log reference(s): session: v114, session: v115, session: v116
 
 Review `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/web2`, `web2-react`, and `web3` as prototype material for the new `@cubid/react` and chain-package ecosystem. Preserve the useful boundaries: headless AllowPage URL builders and callback-state helpers, provider stamp normalization, verified-stamp persistence callbacks, simple phone/email completion forms, provider connect buttons, and wallet adapter interfaces that keep chain-specific dependencies outside React and core. Translate them into the new target package names instead of reviving `@cubid/web2`, `@cubid/web2-react`, or `@cubid/web3`. Avoid copying bare prototype UI as final design; use the callback and adapter contracts as the valuable part. This todo should produce package-ready primitives that support downstream profile-completion flows without leaking OAuth, wallet, or chain complexity into application code.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -561,12 +561,12 @@ Make `@cubid/core` easier to adopt by exposing a small, typed, high-level server
 
 ### E02.2.1 Port the best runtime-agnostic SDK ergonomics from `cubid-sdk-v2`
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-04-29T17:27:43Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/e02-2-core-identity-sync
+- Head: b78ae9e
+- Session-log reference(s): session: v102
 
 Use the older `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/api` implementation as a comparison source when expanding `@cubid/core`, but do not copy it blindly. Cherry-pick the stronger developer ergonomics: normalized camelCase response models, malformed-response detection, endpoint-aware error metadata, optional custom headers if still safe, and broader low-level wrappers for `addStamp`, location, user-data, search-location, and OTP routes where those routes remain part of the supported API story. Keep the newer `@cubid/core` security posture: no plaintext OTP exposure, no framework or Node-only assumptions, no broad legacy defaults that obscure the target origin, and no chain or React dependencies. The success condition is that `@cubid/core` becomes more pleasant and safer to consume without inheriting old package naming, insecure response shapes, or deprecated route assumptions.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -594,12 +594,12 @@ Review `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/web2`, `web2-react`, an
 
 ### E02.4 Add Deno validation, integration guides, examples, and stability notes
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-04-29T17:41:47Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/e02-2-core-identity-sync
+- Head: 5626b19
+- Session-log reference(s): session: v105
 
 Back the published packages with the DX and compatibility work needed for real external adoption. Add CI that proves `@cubid/core` is importable in Deno and usable in a Supabase-Edge-like environment, including a smoke import from the JSR form and a Deno-focused validation step in the normal package workflow. Write a dedicated integration guide for Next.js plus Supabase Edge that covers browser versus server usage, secret handling, phone OTP, provider handoff flows, and the post-return refresh pattern. Add copy-paste examples for resolving a Cubid user from an authenticated email, syncing an identity snapshot in an Edge Function, rendering linked or pending credential states in React, and collecting phone plus provider stamps after signup. Close with versioned API stability notes so downstream apps understand Cubid’s compatibility guarantees and deprecation posture.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -550,12 +550,12 @@ Package `@cubid/core` as the required public integration foundation that works c
 
 ### E02.2 Add a stable server-facing identity sync contract to `@cubid/core`
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-04-29T16:07:42Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-04-29T16:41:13Z
 - Feature branch: codex/e02-2-core-identity-sync
-- Head: 4cf2f89
-- Session-log reference(s): session: v99
+- Head: 2727a8e
+- Session-log reference(s): session: v99, session: v100, session: v101
 
 Make `@cubid/core` easier to adopt by exposing a small, typed, high-level server integration surface instead of forcing every app to compose low-level Cubid route calls by hand. The package should provide stable helpers such as `ensureUserByEmail`, `fetchIdentity`, `fetchScore`, and `fetchStamps`, plus an optional normalized identity snapshot result for systems that want one typed view of Cubid user state. As part of this, explicitly document the current “resolve or create by email” semantics so integrators know whether the operation is idempotent, what canonical user identifier is returned, what happens when the user already exists, and which failures are retry-safe. Add structured error modeling for auth/config failures, validation problems, transient upstream errors, rate limits, and identity-not-found versus not-yet-verified states.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -559,6 +559,17 @@ Package `@cubid/core` as the required public integration foundation that works c
 
 Make `@cubid/core` easier to adopt by exposing a small, typed, high-level server integration surface instead of forcing every app to compose low-level Cubid route calls by hand. The package should provide stable helpers such as `ensureUserByEmail`, `fetchIdentity`, `fetchScore`, and `fetchStamps`, plus an optional normalized identity snapshot result for systems that want one typed view of Cubid user state. As part of this, explicitly document the current “resolve or create by email” semantics so integrators know whether the operation is idempotent, what canonical user identifier is returned, what happens when the user already exists, and which failures are retry-safe. Add structured error modeling for auth/config failures, validation problems, transient upstream errors, rate limits, and identity-not-found versus not-yet-verified states.
 
+### E02.2.1 Port the best runtime-agnostic SDK ergonomics from `cubid-sdk-v2`
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Use the older `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/api` implementation as a comparison source when expanding `@cubid/core`, but do not copy it blindly. Cherry-pick the stronger developer ergonomics: normalized camelCase response models, malformed-response detection, endpoint-aware error metadata, optional custom headers if still safe, and broader low-level wrappers for `addStamp`, location, user-data, search-location, and OTP routes where those routes remain part of the supported API story. Keep the newer `@cubid/core` security posture: no plaintext OTP exposure, no framework or Node-only assumptions, no broad legacy defaults that obscure the target origin, and no chain or React dependencies. The success condition is that `@cubid/core` becomes more pleasant and safer to consume without inheriting old package naming, insecure response shapes, or deprecated route assumptions.
+
 ### E02.3 Publish `@cubid/react` and chain SDK packages with profile-completion primitives
 
 - Status: Not started
@@ -569,6 +580,17 @@ Make `@cubid/core` easier to adopt by exposing a small, typed, high-level server
 - Session-log reference(s): TBD
 
 Turn the browser-side and ecosystem-specific integration layers into publishable packages that downstream apps can consume without local tarballs or repo-coupled wrappers. `@cubid/react` should own React hooks, components, AllowPage integration helpers, and profile-completion primitives, while chain packages such as `@cubid/evm`, `@cubid/wagmi`, `@cubid/solana`, `@cubid/cardano`, `@cubid/sui`, and `@cubid/near` isolate wallet and signing dependencies. The React flow should make inline phone capture, provider/stamp connection, and post-return refresh patterns easy without each app owning Cubid OAuth and callback complexity. Provide primitives such as a `PhoneOtpForm`, provider connect buttons or hooks, success/failure/cancel callbacks, and helpers that report available, verified, and missing recommended credentials in one normalized shape.
+
+### E02.3.1 Adapt the older web2, React, and wallet SDK prototypes into the new package model
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Review `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/web2`, `web2-react`, and `web3` as prototype material for the new `@cubid/react` and chain-package ecosystem. Preserve the useful boundaries: headless AllowPage URL builders and callback-state helpers, provider stamp normalization, verified-stamp persistence callbacks, simple phone/email completion forms, provider connect buttons, and wallet adapter interfaces that keep chain-specific dependencies outside React and core. Translate them into the new target package names instead of reviving `@cubid/web2`, `@cubid/web2-react`, or `@cubid/web3`. Avoid copying bare prototype UI as final design; use the callback and adapter contracts as the valuable part. This todo should produce package-ready primitives that support downstream profile-completion flows without leaking OAuth, wallet, or chain complexity into application code.
 
 ### E02.4 Add Deno validation, integration guides, examples, and stability notes
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -550,12 +550,12 @@ Package `@cubid/core` as the required public integration foundation that works c
 
 ### E02.2 Add a stable server-facing identity sync contract to `@cubid/core`
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-04-29T16:07:42Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/e02-2-core-identity-sync
+- Head: 4cf2f89
+- Session-log reference(s): session: v99
 
 Make `@cubid/core` easier to adopt by exposing a small, typed, high-level server integration surface instead of forcing every app to compose low-level Cubid route calls by hand. The package should provide stable helpers such as `ensureUserByEmail`, `fetchIdentity`, `fetchScore`, and `fetchStamps`, plus an optional normalized identity snapshot result for systems that want one typed view of Cubid user state. As part of this, explicitly document the current “resolve or create by email” semantics so integrators know whether the operation is idempotent, what canonical user identifier is returned, what happens when the user already exists, and which failures are retry-safe. Add structured error modeling for auth/config failures, validation problems, transient upstream errors, rate limits, and identity-not-found versus not-yet-verified states.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -561,12 +561,12 @@ Make `@cubid/core` easier to adopt by exposing a small, typed, high-level server
 
 ### E02.2.1 Port the best runtime-agnostic SDK ergonomics from `cubid-sdk-v2`
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-04-29T17:27:43Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-04-29T17:31:33Z
 - Feature branch: codex/e02-2-core-identity-sync
-- Head: b78ae9e
-- Session-log reference(s): session: v102
+- Head: e995f0e
+- Session-log reference(s): session: v102, session: v103, session: v104
 
 Use the older `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/api` implementation as a comparison source when expanding `@cubid/core`, but do not copy it blindly. Cherry-pick the stronger developer ergonomics: normalized camelCase response models, malformed-response detection, endpoint-aware error metadata, optional custom headers if still safe, and broader low-level wrappers for `addStamp`, location, user-data, search-location, and OTP routes where those routes remain part of the supported API story. Keep the newer `@cubid/core` security posture: no plaintext OTP exposure, no framework or Node-only assumptions, no broad legacy defaults that obscure the target origin, and no chain or React dependencies. The success condition is that `@cubid/core` becomes more pleasant and safer to consume without inheriting old package naming, insecure response shapes, or deprecated route assumptions.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -594,12 +594,12 @@ Review `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/web2`, `web2-react`, an
 
 ### E02.4 Add Deno validation, integration guides, examples, and stability notes
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-04-29T17:41:47Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-04-29T17:45:07Z
 - Feature branch: codex/e02-2-core-identity-sync
-- Head: 5626b19
-- Session-log reference(s): session: v105
+- Head: 9fe5a52
+- Session-log reference(s): session: v105, session: v106, session: v107
 
 Back the published packages with the DX and compatibility work needed for real external adoption. Add CI that proves `@cubid/core` is importable in Deno and usable in a Supabase-Edge-like environment, including a smoke import from the JSR form and a Deno-focused validation step in the normal package workflow. Write a dedicated integration guide for Next.js plus Supabase Edge that covers browser versus server usage, secret handling, phone OTP, provider handoff flows, and the post-return refresh pattern. Add copy-paste examples for resolving a Cubid user from an authenticated email, syncing an identity snapshot in an Edge Function, rendering linked or pending credential states in React, and collecting phone plus provider stamps after signup. Close with versioned API stability notes so downstream apps understand Cubid’s compatibility guarantees and deprecation posture.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -572,12 +572,12 @@ Use the older `/Users/botmaster/src/cubid/cubid-sdk-v2/packages/api` implementat
 
 ### E02.3 Publish `@cubid/react` and chain SDK packages with profile-completion primitives
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-04-29T19:27:57Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/e02-2-core-identity-sync
+- Head: 36f121b
+- Session-log reference(s): session: v114
 
 Turn the browser-side and ecosystem-specific integration layers into publishable packages that downstream apps can consume without local tarballs or repo-coupled wrappers. `@cubid/react` should own React hooks, components, AllowPage integration helpers, and profile-completion primitives, while chain packages such as `@cubid/evm`, `@cubid/wagmi`, `@cubid/solana`, `@cubid/cardano`, `@cubid/sui`, and `@cubid/near` isolate wallet and signing dependencies. The React flow should make inline phone capture, provider/stamp connection, and post-return refresh patterns easy without each app owning Cubid OAuth and callback complexity. Provide primitives such as a `PhoneOtpForm`, provider connect buttons or hooks, success/failure/cancel callbacks, and helpers that report available, verified, and missing recommended credentials in one normalized shape.
 

--- a/docs/engineering/cubid-core-package.md
+++ b/docs/engineering/cubid-core-package.md
@@ -6,14 +6,23 @@ APIs, or browser-only helpers. The package uses standard `fetch` and plain JSON
 contracts so it can run in Node, Deno, Supabase Edge Functions, workers, and
 tests.
 
-## E02.1 Contract
+## Current Contract
 
 - Package name: `@cubid/core`
 - Initial version: `0.1.0`
 - Runtime target: ESM, standards-only
-- Initial surface: low-level wrappers for current Passport v2 routes
-- Deferred to E02.2: `ensureUserByEmail`, identity snapshot helpers, and
-  normalized high-level sync flows
+- Surface: normalized wrappers for current Passport v2 routes plus
+  server-facing identity sync helpers
+- Identity helpers: `ensureUserByEmail`, `fetchIdentity`, `fetchScore`,
+  `fetchStamps`, and `syncIdentitySnapshot`
+- Response model: SDK-friendly camelCase fields with the original server
+  payload retained in `raw` for migration and debugging
+- Error model: `CubidApiError` includes category, optional code, optional
+  endpoint, request ID, status, and parsed details
+
+Malformed successful responses must throw `CubidApiError` with
+`code: "MALFORMED_RESPONSE"` so integrators do not accidentally depend on
+partial or unsafe response shapes.
 
 ## Publishing
 

--- a/docs/engineering/cubid-core-package.md
+++ b/docs/engineering/cubid-core-package.md
@@ -51,3 +51,20 @@ JSR setup:
 The publish workflow is manual (`workflow_dispatch`) so maintainers choose when
 to release. Normal CI performs npm pack and JSR dry-runs to catch packaging
 regressions before release.
+
+## Deno And Edge Validation
+
+The package includes a Deno smoke check at
+`packages/core/deno/supabase-edge-smoke.ts`. It imports the TypeScript source
+directly and models a Supabase Edge Function using `Deno.env`, injected `fetch`,
+`ensureUserByEmail`, and `syncIdentitySnapshot`.
+
+Run:
+
+```sh
+pnpm --filter @cubid/core deno:check
+```
+
+This validates Deno/Supabase Edge importability before publication. The
+published JSR import path remains `jsr:@cubid/core` and is documented in
+`docs/engineering/next-supabase-edge-integration-guide.md`.

--- a/docs/engineering/cubid-core-package.md
+++ b/docs/engineering/cubid-core-package.md
@@ -15,6 +15,8 @@ tests.
   server-facing identity sync helpers
 - Identity helpers: `ensureUserByEmail`, `fetchIdentity`, `fetchScore`,
   `fetchStamps`, and `syncIdentitySnapshot`
+- Additional wrappers: `addStamp`, location fetches, user-data fetch, location
+  search, and email/phone OTP send/verify helpers
 - Response model: SDK-friendly camelCase fields with the original server
   payload retained in `raw` for migration and debugging
 - Error model: `CubidApiError` includes category, optional code, optional
@@ -23,6 +25,9 @@ tests.
 Malformed successful responses must throw `CubidApiError` with
 `code: "MALFORMED_RESPONSE"` so integrators do not accidentally depend on
 partial or unsafe response shapes.
+
+OTP helpers must not expose raw OTP values. They normalize only delivery and
+verification metadata even if a legacy server payload contains a code.
 
 ## Publishing
 

--- a/docs/engineering/next-supabase-edge-integration-guide.md
+++ b/docs/engineering/next-supabase-edge-integration-guide.md
@@ -1,0 +1,126 @@
+# Next.js And Supabase Edge Integration Guide
+
+This guide shows how downstream apps should consume `@cubid/core` from a
+Next.js server and from Supabase Edge Functions. `@cubid/core` is
+runtime-agnostic: keep it on the server, inject `fetch` when useful, and never
+ship Cubid dapp API keys to browser bundles.
+
+## Server-Side Next.js Usage
+
+Use `@cubid/core` from route handlers, server actions, or backend-only modules.
+Browser components should call your app server, not Cubid directly.
+
+```ts
+import { createCubidApiClient } from "@cubid/core"
+
+const cubid = createCubidApiClient({
+  apiKey: process.env.CUBID_API_KEY!,
+  baseUrl: process.env.CUBID_API_BASE_URL ?? "https://passport.cubid.me",
+  dappId: process.env.CUBID_DAPP_ID!,
+})
+
+export async function ensureCubidUser(email: string) {
+  return cubid.ensureUserByEmail({ email })
+}
+```
+
+## Supabase Edge Usage
+
+Use the JSR package after publication:
+
+```ts
+import { createCubidApiClient } from "jsr:@cubid/core"
+
+const cubid = createCubidApiClient({
+  apiKey: Deno.env.get("CUBID_API_KEY")!,
+  baseUrl: Deno.env.get("CUBID_API_BASE_URL") ?? "https://passport.cubid.me",
+  dappId: Deno.env.get("CUBID_DAPP_ID")!,
+  fetch,
+})
+
+Deno.serve(async (request) => {
+  const { email } = await request.json()
+  const user = await cubid.ensureUserByEmail({ email })
+  const snapshot = await cubid.syncIdentitySnapshot({ userId: user.userId })
+
+  return Response.json({
+    score: snapshot.score.cubidScore,
+    stamps: snapshot.stamps.allStamps.map((stamp) => stamp.stampType),
+    userId: user.userId,
+  })
+})
+```
+
+The repo validates Deno compatibility before publish with
+`pnpm --filter @cubid/core deno:check`. Live `jsr:@cubid/core` imports are
+available after the package is linked and published through trusted publishing.
+
+## Secrets
+
+Store these as server-side or Edge Function secrets only:
+
+- `CUBID_API_KEY`
+- `CUBID_DAPP_ID`
+- `CUBID_API_BASE_URL`, optional and usually `https://passport.cubid.me`
+
+Do not place Cubid dapp API keys in `NEXT_PUBLIC_*`, browser local storage, or
+client-rendered JavaScript.
+
+## Identity Snapshot Pattern
+
+For signup or login flows, resolve the Cubid user first and then fetch a
+snapshot for local app state.
+
+```ts
+const user = await cubid.ensureUserByEmail({ email: session.user.email })
+const snapshot = await cubid.syncIdentitySnapshot({ userId: user.userId })
+
+await saveLocalIdentitySnapshot({
+  cubidUserId: user.userId,
+  score: snapshot.score.cubidScore,
+  stampTypes: snapshot.stamps.allStamps.map((stamp) => stamp.stampType),
+  syncedAt: snapshot.syncedAt,
+})
+```
+
+Apps should store the app-scoped `userId` and a refresh timestamp, not raw Cubid
+credentials or unnecessary identity details.
+
+## Phone OTP And Provider Handoff
+
+`@cubid/core` exposes low-level OTP wrappers for server-controlled flows:
+
+```ts
+await cubid.sendPhoneOtp({ phone: "+15555550123" })
+const verified = await cubid.verifyPhoneOtp({
+  otp: form.otp,
+  phone: "+15555550123",
+})
+```
+
+The OTP helpers return delivery or verification metadata only; they never return
+raw OTP codes. React UI primitives, AllowPage helpers, and provider handoff
+flows belong in later `@cubid/react` work, not in `@cubid/core`.
+
+## Post-Return Refresh
+
+After a user returns from an AllowPage or provider-stamp flow, refresh Cubid
+state server-side and update the app's cached view.
+
+```ts
+const snapshot = await cubid.syncIdentitySnapshot({ userId: cubidUserId })
+
+return {
+  linked: snapshot.stamps.allStamps.map((stamp) => stamp.stampType),
+  score: snapshot.score.cubidScore,
+  syncedAt: snapshot.syncedAt,
+}
+```
+
+## Stability Notes
+
+`@cubid/core` `0.x` is the pre-1.0 SDK foundation. The package should preserve
+runtime-agnostic imports, structured `CubidApiError`, and the high-level helper
+names introduced in E02.2. Breaking changes before `1.0` must be documented in
+the package README and this guide before publication.
+

--- a/docs/engineering/sdk-package-target-state.md
+++ b/docs/engineering/sdk-package-target-state.md
@@ -60,7 +60,19 @@ but should not accumulate heavy crypto custody dependencies.
 
 ## Current E02 Direction
 
-E02 starts by publishing `@cubid/core` as the dual-target npm/JSR foundation.
-High-level identity sync helpers, React profile-completion primitives, chain SDK
-packages, Deno/Supabase Edge examples, and API stability notes build on that
-foundation in later E02 slices.
+E02 starts by publishing `@cubid/core` as the dual-target npm/JSR foundation,
+then layers in package-ready integration surfaces:
+
+- `@cubid/core` now owns the runtime-agnostic API client, identity sync helpers,
+  normalized responses, Deno validation, and Edge examples.
+- `@cubid/react` owns React-only profile completion primitives, including phone
+  OTP UI, provider connect buttons, AllowPage URL helpers, callback-state
+  helpers, and missing-recommended-credential summaries.
+- Chain package workspaces now exist as dependency-isolated homes for
+  chain-specific wallet/stamp contracts. The first slice keeps them lightweight
+  and does not yet add heavy SDKs or signing implementations.
+- `@cubid/wagmi` is the only package with a wagmi peer boundary. It can add
+  wagmi hooks/connectors later without leaking wagmi into core or React.
+
+Live npm/JSR publication still requires trusted-publisher setup and explicit
+release workflow execution.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "check:api-security": "bash ./scripts/check-api-security-regressions.sh",
-    "check:core-package": "pnpm --filter @cubid/core build && pnpm --filter @cubid/core pack:dry-run && pnpm --filter @cubid/core jsr:dry-run",
+    "check:core-package": "pnpm --filter @cubid/core deno:check && pnpm --filter @cubid/core build && pnpm --filter @cubid/core pack:dry-run && pnpm --filter @cubid/core jsr:dry-run",
     "check:secrets": "node ./scripts/check-operational-secrets.mjs",
     "format": "turbo run format",
     "format:write": "turbo run format:write"

--- a/packages/cardano/README.md
+++ b/packages/cardano/README.md
@@ -1,0 +1,4 @@
+# @cubid/cardano
+
+Cardano-specific Cubid wallet/stamp helper contracts.
+

--- a/packages/cardano/package.json
+++ b/packages/cardano/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@cubid/cardano",
+  "version": "0.1.0",
+  "description": "Cardano wallet and stamp helper contracts for Cubid integrations.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "publishConfig": { "access": "public" },
+  "devDependencies": { "typescript": "5.2.2" },
+  "scripts": {
+    "build": "pnpm exec tsc -p tsconfig.build.json",
+    "lint": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "typecheck": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "test": "echo \"No @cubid/cardano tests yet\"",
+    "format": "echo \"No format changes required for @cubid/cardano\"",
+    "format:write": "echo \"No format changes required for @cubid/cardano\""
+  }
+}

--- a/packages/cardano/src/index.ts
+++ b/packages/cardano/src/index.ts
@@ -1,0 +1,18 @@
+export type CubidCardanoConnection = {
+  address: string
+  networkId?: number | string
+  stakeAddress?: string
+}
+
+export function createCardanoStampData(connection: CubidCardanoConnection) {
+  const address = connection.address.trim()
+  return {
+    address,
+    chainType: "cardano" as const,
+    identity: address,
+    networkId: connection.networkId,
+    stakeAddress: connection.stakeAddress,
+    uniquevalue: address,
+    walletType: "cardano" as const,
+  }
+}

--- a/packages/cardano/tsconfig.build.json
+++ b/packages/cardano/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/cardano/tsconfig.json
+++ b/packages/cardano/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -34,7 +34,21 @@ const created = await cubid.createUser({
 })
 
 const score = await cubid.fetchScore({
-  userId: created.user_id!,
+  userId: created.userId!,
+})
+```
+
+For server-side "resolve or create by email" flows, prefer
+`ensureUserByEmail` so callers always receive a canonical app-scoped Cubid user
+identifier or a structured error.
+
+```ts
+const user = await cubid.ensureUserByEmail({
+  email: "person@example.com",
+})
+
+const snapshot = await cubid.syncIdentitySnapshot({
+  userId: user.userId,
 })
 ```
 
@@ -59,16 +73,23 @@ client bundles.
 
 ## Foundation Surface
 
-E02.1 provides low-level wrappers around current Passport v2 endpoints:
+The foundation client provides normalized wrappers around current Passport v2
+endpoints:
 
 - `createUser`
+- `ensureUserByEmail`
 - `fetchIdentity`
 - `fetchScore`
 - `fetchStamps`
+- `syncIdentitySnapshot`
 
-Higher-level helpers such as `ensureUserByEmail`, identity snapshots, and
-profile-completion flows are intentionally deferred to E02.2 and later SDK
-tasks.
+Responses use SDK-friendly camelCase fields while retaining the original
+server payload in `raw` for migration/debugging. Malformed successful responses
+throw `CubidApiError` with `code: "MALFORMED_RESPONSE"` instead of returning an
+unsafe partial shape.
+
+Profile-completion flows and React components are intentionally deferred to
+later SDK tasks.
 
 ## Errors
 
@@ -76,6 +97,9 @@ Failed requests throw `CubidApiError` with:
 
 - `category`: `config`, `auth`, `validation`, `rate_limit`, `not_found`,
   `upstream`, or `unknown`
+- `code`: machine-readable detail such as `NETWORK_ERROR` or
+  `MALFORMED_RESPONSE` when available
+- `endpoint`: Cubid endpoint associated with the failure when available
 - `status`: HTTP status when available
 - `requestId`: Cubid `X-Request-Id` when returned by the API
 - `details`: parsed error payload when available

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -104,6 +104,21 @@ never expose raw OTP values, even if a legacy server payload includes one.
 Profile-completion flows and React components are intentionally deferred to
 later SDK tasks.
 
+## Deno Validation
+
+The package includes a Supabase-Edge-style Deno smoke check that imports the
+TypeScript source directly before publish:
+
+```sh
+pnpm --filter @cubid/core deno:check
+```
+
+After trusted publishing is configured and the package is released, Edge
+Functions should import from `jsr:@cubid/core`.
+
+See `docs/engineering/next-supabase-edge-integration-guide.md` for Next.js and
+Supabase Edge examples.
+
 ## Errors
 
 Failed requests throw `CubidApiError` with:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -78,15 +78,28 @@ endpoints:
 
 - `createUser`
 - `ensureUserByEmail`
+- `addStamp`
 - `fetchIdentity`
 - `fetchScore`
 - `fetchStamps`
+- `fetchApproxLocation`
+- `fetchExactLocation`
+- `fetchRoughLocation`
+- `fetchUserData`
+- `searchLocation`
+- `sendEmailOtp`
+- `verifyEmailOtp`
+- `sendPhoneOtp`
+- `verifyPhoneOtp`
 - `syncIdentitySnapshot`
 
 Responses use SDK-friendly camelCase fields while retaining the original
 server payload in `raw` for migration/debugging. Malformed successful responses
 throw `CubidApiError` with `code: "MALFORMED_RESPONSE"` instead of returning an
 unsafe partial shape.
+
+OTP helpers intentionally return delivery or verification metadata only. They
+never expose raw OTP values, even if a legacy server payload includes one.
 
 Profile-completion flows and React components are intentionally deferred to
 later SDK tasks.

--- a/packages/core/deno/supabase-edge-smoke.ts
+++ b/packages/core/deno/supabase-edge-smoke.ts
@@ -1,0 +1,55 @@
+import { createCubidApiClient, CubidApiError } from "../src/index.ts"
+
+type EnvReader = {
+  get(name: string): string | undefined
+}
+
+const envOrThrow = (env: EnvReader, name: string): string => {
+  const value = env.get(name)
+  if (!value) {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+export const createCubidEdgeHandler = (env: EnvReader = Deno.env) => {
+  const cubid = createCubidApiClient({
+    apiKey: envOrThrow(env, "CUBID_API_KEY"),
+    baseUrl: env.get("CUBID_API_BASE_URL") ?? "https://passport.cubid.me",
+    dappId: envOrThrow(env, "CUBID_DAPP_ID"),
+    fetch,
+  })
+
+  return async (request: Request): Promise<Response> => {
+    const body = (await request.json()) as { email?: string }
+    if (!body.email) {
+      return Response.json({ error: "email is required" }, { status: 400 })
+    }
+
+    try {
+      const user = await cubid.ensureUserByEmail({ email: body.email })
+      const snapshot = await cubid.syncIdentitySnapshot({ userId: user.userId })
+
+      return Response.json({
+        score: snapshot.score.cubidScore,
+        stamps: snapshot.stamps.allStamps.map((stamp) => stamp.stampType),
+        userId: user.userId,
+      })
+    } catch (error) {
+      if (error instanceof CubidApiError) {
+        return Response.json(
+          {
+            category: error.category,
+            code: error.code,
+            error: error.message,
+            requestId: error.requestId,
+          },
+          { status: error.status ?? 502 }
+        )
+      }
+
+      throw error
+    }
+  }
+}
+

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "lint": "pnpm exec tsc --noEmit -p tsconfig.json",
     "typecheck": "pnpm exec tsc --noEmit -p tsconfig.json",
     "test": "pnpm exec tsx --test src/*.test.ts",
+    "deno:check": "deno check --no-lock deno/supabase-edge-smoke.ts",
     "pack:dry-run": "npm pack --dry-run",
     "jsr:dry-run": "pnpm dlx jsr publish --dry-run --allow-dirty",
     "format": "echo \"No format changes required for @cubid/core\"",

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -62,7 +62,7 @@ test("createCubidApiClient allows HTTP only for loopback development hosts", asy
     })
 
     const response = await client.fetchScore({ userId: "dapp_user_123" })
-    assert.deepEqual(response, { cubid_score: 1 })
+    assert.equal(response.cubidScore, 1)
   }
 
   assert.throws(
@@ -102,7 +102,10 @@ test("createUser posts legacy v2 payload with credentials", async () => {
   })
   const response = await client.createUser({ email: "user@example.com" })
 
-  assert.equal(response.user_id, "dapp_user_123")
+  assert.equal(response.userId, "dapp_user_123")
+  assert.equal(response.isNewAppUser, true)
+  assert.equal(response.isSybilAttack, false)
+  assert.equal(response.isBlacklisted, false)
   assert.equal(
     String(calls[0]?.input),
     "https://passport.cubid.me/api/v2/create_user"
@@ -120,7 +123,16 @@ test("low-level wrappers use injected fetch for identity, score, and stamps", as
     const path = new URL(String(input)).pathname
     paths.push(path)
     if (path.endsWith("/fetch_identity")) {
-      return createJsonResponse({ error: null, stamp_details: [] })
+      return createJsonResponse({
+        error: null,
+        stamp_details: [
+          {
+            stamp_type: "email",
+            status: "Verified",
+            value: "user@example.com",
+          },
+        ],
+      })
     }
     if (path.endsWith("/fetch_score")) {
       return createJsonResponse({
@@ -138,9 +150,26 @@ test("low-level wrappers use injected fetch for identity, score, and stamps", as
     fetch: fetchImpl,
   })
 
-  await client.fetchIdentity({ userId: "dapp_user_123" })
-  await client.fetchScore({ userId: "dapp_user_123" })
-  await client.fetchStamps({ userId: "dapp_user_123" })
+  const identity = await client.fetchIdentity({ userId: "dapp_user_123" })
+  const score = await client.fetchScore({ userId: "dapp_user_123" })
+  const stamps = await client.fetchStamps({ userId: "dapp_user_123" })
+
+  assert.deepEqual(identity.stampDetails, [
+    {
+      raw: {
+        stamp_type: "email",
+        status: "Verified",
+        value: "user@example.com",
+      },
+      stampType: "email",
+      status: "Verified",
+      value: "user@example.com",
+    },
+  ])
+  assert.equal(score.cubidScore, 10)
+  assert.equal(score.scoringSchema, 1)
+  assert.deepEqual(stamps.allStamps, [])
+  assert.equal(stamps.email, "user@example.com")
 
   assert.deepEqual(paths, [
     "/api/v2/identity/fetch_identity",
@@ -219,4 +248,108 @@ test("createUser requires a dapp id without leaking the API key", async () => {
       error.category === "config" &&
       !error.message.includes("very-secret-api-key")
   )
+})
+
+test("ensureUserByEmail resolves the canonical user id through create_user", async () => {
+  const calls: Array<{ body: unknown; input: string | URL | Request }> = []
+  const client = createCubidApiClient({
+    apiKey: "api_key",
+    baseUrl: "https://passport.cubid.me",
+    dappId: "dapp_123",
+    fetch: async (input, init) => {
+      calls.push({
+        body: JSON.parse(String(init?.body)),
+        input,
+      })
+      return createJsonResponse({
+        error: null,
+        is_blacklisted: false,
+        is_new_app_user: false,
+        is_sybil_attack: false,
+        user_id: "dapp_user_123",
+      })
+    },
+  })
+
+  const response = await client.ensureUserByEmail({
+    email: " user@example.com ",
+  })
+
+  assert.equal(response.email, "user@example.com")
+  assert.equal(response.userId, "dapp_user_123")
+  assert.equal(response.isNewAppUser, false)
+  assert.deepEqual(calls[0]?.body, {
+    apikey: "api_key",
+    dapp_id: "dapp_123",
+    email: "user@example.com",
+  })
+})
+
+test("malformed success responses map to structured CubidApiError values", async () => {
+  const client = createCubidApiClient({
+    apiKey: "api_key",
+    baseUrl: "https://passport.cubid.me",
+    fetch: async () => createJsonResponse(["not", "an", "object"]),
+  })
+
+  await assert.rejects(
+    () => client.fetchIdentity({ userId: "dapp_user_123" }),
+    (error) => {
+      assert.ok(error instanceof CubidApiError)
+      assert.equal(error.category, "upstream")
+      assert.equal(error.code, "MALFORMED_RESPONSE")
+      assert.equal(error.endpoint, "identity/fetch_identity")
+      assert.equal(error.requestId, "request_123")
+      return true
+    }
+  )
+})
+
+test("syncIdentitySnapshot combines identity, score, and stamp responses", async () => {
+  const paths: string[] = []
+  const client = createCubidApiClient({
+    apiKey: "api_key",
+    baseUrl: "https://passport.cubid.me",
+    fetch: async (input) => {
+      const path = new URL(String(input)).pathname
+      paths.push(path)
+
+      if (path.endsWith("/fetch_identity")) {
+        return createJsonResponse({ error: null, stamp_details: [] })
+      }
+      if (path.endsWith("/fetch_score")) {
+        return createJsonResponse({
+          cubid_score: 99,
+          error: null,
+          scoring_schema: "v2",
+        })
+      }
+      return createJsonResponse({
+        all_stamps: [
+          {
+            id: 1,
+            is_valid: true,
+            stamptype: 13,
+            stamptype_string: "email",
+            uniquevalue: "user@example.com",
+          },
+        ],
+        email: "user@example.com",
+      })
+    },
+  })
+
+  const snapshot = await client.syncIdentitySnapshot({
+    userId: "dapp_user_123",
+  })
+
+  assert.equal(snapshot.userId, "dapp_user_123")
+  assert.equal(snapshot.score.cubidScore, 99)
+  assert.equal(snapshot.stamps.allStamps[0]?.stampType, "email")
+  assert.match(snapshot.syncedAt, /^\d{4}-\d{2}-\d{2}T/)
+  assert.deepEqual(paths.sort(), [
+    "/api/v2/identity/fetch_identity",
+    "/api/v2/identity/fetch_stamps",
+    "/api/v2/score/fetch_score",
+  ])
 })

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -353,3 +353,178 @@ test("syncIdentitySnapshot combines identity, score, and stamp responses", async
     "/api/v2/score/fetch_score",
   ])
 })
+
+test("additional runtime-agnostic wrappers normalize legacy v2 responses", async () => {
+  const calls: Array<{ body: unknown; path: string }> = []
+  const client = createCubidApiClient({
+    apiKey: "api_key",
+    baseUrl: "https://passport.cubid.me",
+    fetch: async (input, init) => {
+      const path = new URL(String(input)).pathname
+      calls.push({
+        body: JSON.parse(String(init?.body)),
+        path,
+      })
+
+      if (path.endsWith("/identity/add_stamp")) {
+        return createJsonResponse({ success: true })
+      }
+      if (path.endsWith("/fetch_approx_location")) {
+        return createJsonResponse({
+          coordinates: { lat: 43.65, lng: -79.38 },
+          country: "Canada",
+          error: null,
+          placename: "Toronto",
+          pluscode: "87M2",
+          postalcode: "M5H",
+        })
+      }
+      if (path.endsWith("/fetch_exact_location")) {
+        return createJsonResponse({
+          coordinates: { lat: 43.6501, lng: -79.3802 },
+          country: "Canada",
+          error: null,
+          place: { city: "Toronto" },
+        })
+      }
+      if (path.endsWith("/fetch_rough_location")) {
+        return createJsonResponse({
+          coordinates: { lat: 43.6, lng: -79.4 },
+          cubid_country: "Canada",
+          error: null,
+          pluscode: "87M2",
+        })
+      }
+      if (path.endsWith("/fetch_user_data")) {
+        return createJsonResponse({
+          coordinates: { lat: 43.65, lng: -79.38 },
+          country: "Canada",
+          error: null,
+          name: "Cubid User",
+          placename: "Toronto",
+        })
+      }
+      if (path.endsWith("/search-location")) {
+        return createJsonResponse([{ name: "Toronto" }, "fallback"])
+      }
+
+      throw new Error(`Unexpected path ${path}`)
+    },
+  })
+
+  await assert.doesNotReject(() =>
+    client.addStamp({
+      pageId: "7",
+      stampData: { identity: "user@example.com" },
+      stampType: "email",
+      userId: "dapp_user_123",
+    })
+  )
+  const approx = await client.fetchApproxLocation({ userId: "dapp_user_123" })
+  const exact = await client.fetchExactLocation({ userId: "dapp_user_123" })
+  const rough = await client.fetchRoughLocation({ userId: "dapp_user_123" })
+  const userData = await client.fetchUserData({ userId: "dapp_user_123" })
+  const results = await client.searchLocation({ locationInput: "Toronto" })
+
+  assert.equal(approx.placeName, "Toronto")
+  assert.equal(approx.postalCode, "M5H")
+  assert.deepEqual(exact.place, { city: "Toronto" })
+  assert.equal(rough.country, "Canada")
+  assert.equal(userData.name, "Cubid User")
+  assert.deepEqual(results, [{ name: "Toronto" }, { value: "fallback" }])
+  assert.deepEqual(calls.map((call) => call.path), [
+    "/api/v2/identity/add_stamp",
+    "/api/v2/identity/fetch_approx_location",
+    "/api/v2/identity/fetch_exact_location",
+    "/api/v2/identity/fetch_rough_location",
+    "/api/v2/identity/fetch_user_data",
+    "/api/v2/search-location",
+  ])
+  assert.deepEqual(calls[0]?.body, {
+    page_id: 7,
+    stampData: { identity: "user@example.com" },
+    stamp_type: "email",
+    user_data: { uuid: "dapp_user_123" },
+  })
+})
+
+test("OTP wrappers normalize safe response metadata without returning OTP codes", async () => {
+  const paths: string[] = []
+  const client = createCubidApiClient({
+    apiKey: "api_key",
+    baseUrl: "https://passport.cubid.me",
+    fetch: async (input) => {
+      const path = new URL(String(input)).pathname
+      paths.push(path)
+
+      if (path.endsWith("/email/send_otp")) {
+        return createJsonResponse({
+          data: {
+            dappId: 42,
+            email: "user@example.com",
+            otp: 1234,
+            sent: true,
+          },
+        })
+      }
+      if (path.endsWith("/email/verify_otp")) {
+        return createJsonResponse({
+          data: {
+            dappId: 42,
+            email: "user@example.com",
+            is_verified: true,
+          },
+        })
+      }
+      if (path.endsWith("/twillio/send-otp")) {
+        return createJsonResponse({ data: { status: "sent" } })
+      }
+      if (path.endsWith("/twillio/verify-otp")) {
+        return createJsonResponse({ data: { status: "approved" } })
+      }
+
+      throw new Error(`Unexpected path ${path}`)
+    },
+  })
+
+  const emailSent = await client.sendEmailOtp({ email: "user@example.com" })
+  const emailVerified = await client.verifyEmailOtp({
+    email: "user@example.com",
+    otp: 1234,
+  })
+  const phoneSent = await client.sendPhoneOtp({ phone: "+15555550123" })
+  const phoneVerified = await client.verifyPhoneOtp({
+    otp: "654321",
+    phone: "+15555550123",
+  })
+
+  assert.equal(emailSent.sent, true)
+  assert.equal("otp" in emailSent, false)
+  assert.equal(emailVerified.isVerified, true)
+  assert.equal(phoneSent.status, "sent")
+  assert.equal(phoneVerified.isVerified, true)
+  assert.deepEqual(paths, [
+    "/api/v2/email/send_otp",
+    "/api/v2/email/verify_otp",
+    "/api/v2/twillio/send-otp",
+    "/api/v2/twillio/verify-otp",
+  ])
+})
+
+test("searchLocation rejects malformed successful payloads", async () => {
+  const client = createCubidApiClient({
+    apiKey: "api_key",
+    baseUrl: "https://passport.cubid.me",
+    fetch: async () => createJsonResponse({ results: [] }),
+  })
+
+  await assert.rejects(
+    () => client.searchLocation({ locationInput: "Toronto" }),
+    (error) => {
+      assert.ok(error instanceof CubidApiError)
+      assert.equal(error.code, "MALFORMED_RESPONSE")
+      assert.equal(error.endpoint, "search-location")
+      return true
+    }
+  )
+})

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -271,7 +271,8 @@ test("ensureUserByEmail resolves the canonical user id through create_user", asy
     },
   })
 
-  const response = await client.ensureUserByEmail({
+  const { ensureUserByEmail } = client
+  const response = await ensureUserByEmail({
     email: " user@example.com ",
   })
 
@@ -339,7 +340,8 @@ test("syncIdentitySnapshot combines identity, score, and stamp responses", async
     },
   })
 
-  const snapshot = await client.syncIdentitySnapshot({
+  const { syncIdentitySnapshot } = client
+  const snapshot = await syncIdentitySnapshot({
     userId: "dapp_user_123",
   })
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -894,7 +894,7 @@ export const createCubidApiClient = (
     }
   }
 
-  return {
+  const client: CubidApiClient = {
     addStamp(input) {
       const userId = assertNonEmptyString(
         input.userId,
@@ -961,7 +961,7 @@ export const createCubidApiClient = (
         "email",
         "ensure_user_by_email"
       )
-      const created = await this.createUser({
+      const created = await client.createUser({
         dappId: input.dappId,
         email,
       })
@@ -1169,9 +1169,9 @@ export const createCubidApiClient = (
         "sync_identity_snapshot"
       )
       const [identity, score, stamps] = await Promise.all([
-        this.fetchIdentity({ userId }),
-        this.fetchScore({ userId }),
-        this.fetchStamps({ userId }),
+        client.fetchIdentity({ userId }),
+        client.fetchScore({ userId }),
+        client.fetchStamps({ userId }),
       ])
 
       return {
@@ -1237,4 +1237,6 @@ export const createCubidApiClient = (
       )
     },
   }
+
+  return client
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,9 @@ export type CubidApiErrorCategory =
 
 export type CubidApiErrorInput = {
   category: CubidApiErrorCategory
+  code?: string
   details?: unknown
+  endpoint?: string
   message: string
   requestId?: string | null
   status?: number
@@ -29,7 +31,9 @@ export type CubidApiErrorInput = {
 
 export class CubidApiError extends Error {
   readonly category: CubidApiErrorCategory
+  readonly code?: string
   readonly details?: unknown
+  readonly endpoint?: string
   readonly requestId?: string | null
   readonly status?: number
 
@@ -37,7 +41,9 @@ export class CubidApiError extends Error {
     super(input.message)
     this.name = "CubidApiError"
     this.category = input.category
+    this.code = input.code
     this.details = input.details
+    this.endpoint = input.endpoint
     this.requestId = input.requestId
     this.status = input.status
   }
@@ -61,6 +67,11 @@ export type CubidApiClientOptions = {
    * instrumentation. Defaults to globalThis.fetch.
    */
   fetch?: CubidFetch
+  /**
+   * Optional headers for tracing or caller-owned instrumentation. Do not pass
+   * browser-visible secrets here.
+   */
+  headers?: HeadersInit
 }
 
 export type CubidCreateUserInput = {
@@ -75,11 +86,22 @@ export type CubidCreateUserInput = {
 }
 
 export type CubidCreateUserResponse = {
-  error: null | string
-  is_blacklisted: boolean
-  is_new_app_user: boolean
-  is_sybil_attack: boolean
-  user_id?: string | null
+  error: unknown
+  isBlacklisted: boolean
+  isNewAppUser: boolean
+  isSybilAttack: boolean
+  raw: Record<string, unknown>
+  userId: string | null
+}
+
+export type CubidEnsureUserByEmailInput = {
+  dappId?: number | string
+  email: string
+}
+
+export type CubidEnsureUserByEmailResponse = CubidCreateUserResponse & {
+  email: string
+  userId: string
 }
 
 export type CubidFetchIdentityInput = {
@@ -87,14 +109,16 @@ export type CubidFetchIdentityInput = {
 }
 
 export type CubidStampDetail = {
-  stamp_type: string
-  status: "Verified" | "Unverified" | string
+  raw: Record<string, unknown>
+  stampType: string
+  status: "Verified" | "Unverified" | string | null
   value: unknown
 }
 
 export type CubidFetchIdentityResponse = {
-  error: null | string
-  stamp_details: CubidStampDetail[]
+  error: unknown
+  raw: Record<string, unknown>
+  stampDetails: CubidStampDetail[]
 }
 
 export type CubidFetchScoreInput = {
@@ -102,9 +126,10 @@ export type CubidFetchScoreInput = {
 }
 
 export type CubidFetchScoreResponse = {
-  cubid_score: number
-  error: null | string
-  scoring_schema: number | string | null
+  cubidScore: number
+  error: unknown
+  raw: Record<string, unknown>
+  scoringSchema: number | string | null
 }
 
 export type CubidFetchStampsInput = {
@@ -117,19 +142,50 @@ export type CubidRawStamp = Record<string, unknown> & {
   stamptype_string?: string
 }
 
+export type CubidStampRecord = {
+  emailForVerification?: string | null
+  id?: number
+  identity?: string | null
+  isValid?: boolean | null
+  permAvailable?: boolean
+  raw: Record<string, unknown>
+  stampType?: string | null
+  stampTypeId?: number
+  uniqueValue?: string | null
+}
+
 export type CubidFetchStampsResponse = {
-  all_stamps: CubidRawStamp[]
+  allStamps: CubidStampRecord[]
   email?: string | null
-  error?: string | null
+  error?: unknown
+  raw: Record<string, unknown>
+}
+
+export type CubidIdentitySnapshotInput = {
+  userId: string
+}
+
+export type CubidIdentitySnapshot = {
+  identity: CubidFetchIdentityResponse
+  score: CubidFetchScoreResponse
+  stamps: CubidFetchStampsResponse
+  syncedAt: string
+  userId: string
 }
 
 export type CubidApiClient = {
   createUser(input: CubidCreateUserInput): Promise<CubidCreateUserResponse>
+  ensureUserByEmail(
+    input: CubidEnsureUserByEmailInput
+  ): Promise<CubidEnsureUserByEmailResponse>
   fetchIdentity(
     input: CubidFetchIdentityInput
   ): Promise<CubidFetchIdentityResponse>
   fetchScore(input: CubidFetchScoreInput): Promise<CubidFetchScoreResponse>
   fetchStamps(input: CubidFetchStampsInput): Promise<CubidFetchStampsResponse>
+  syncIdentitySnapshot(
+    input: CubidIdentitySnapshotInput
+  ): Promise<CubidIdentitySnapshot>
 }
 
 type CubidRequestBody = Record<string, unknown>
@@ -201,6 +257,23 @@ const assertApiKey = (apiKey: string): string => {
   return normalized
 }
 
+const assertNonEmptyString = (
+  value: string,
+  field: string,
+  endpoint: string
+): string => {
+  const normalized = value.trim()
+  if (!normalized) {
+    throw new CubidApiError({
+      category: "validation",
+      code: "INVALID_INPUT",
+      endpoint,
+      message: `${field} is required.`,
+    })
+  }
+  return normalized
+}
+
 const categoryForStatus = (status: number): CubidApiErrorCategory => {
   if (status === 401 || status === 403) {
     return "auth"
@@ -218,6 +291,39 @@ const categoryForStatus = (status: number): CubidApiErrorCategory => {
     return "upstream"
   }
   return "unknown"
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | null =>
+  typeof value === "string" ? value : null
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === "number" ? value : undefined
+
+const asBoolean = (value: unknown): boolean | undefined =>
+  typeof value === "boolean" ? value : undefined
+
+const assertRecord = (
+  value: unknown,
+  endpoint: string,
+  requestId?: string | null,
+  status?: number
+): Record<string, unknown> => {
+  if (isRecord(value)) {
+    return value
+  }
+
+  throw new CubidApiError({
+    category: "upstream",
+    code: "MALFORMED_RESPONSE",
+    details: value,
+    endpoint,
+    message: `Malformed response from ${endpoint}.`,
+    requestId,
+    status,
+  })
 }
 
 const messageFromPayload = (payload: unknown, fallback: string): string => {
@@ -266,21 +372,33 @@ const makeRequest = async <Result>(
   fetchImpl: CubidFetch,
   baseUrl: string,
   path: string,
-  body: CubidRequestBody
+  body: CubidRequestBody,
+  endpoint: string,
+  normalize: (
+    payload: unknown,
+    requestId?: string | null,
+    status?: number
+  ) => Result,
+  headers?: HeadersInit
 ): Promise<Result> => {
   let response: Response
   try {
+    const requestHeaders = new Headers(headers)
+    if (!requestHeaders.has("content-type")) {
+      requestHeaders.set("content-type", "application/json")
+    }
+
     response = await fetchImpl(`${baseUrl}${path}`, {
       body: JSON.stringify(body),
-      headers: {
-        "content-type": "application/json",
-      },
+      headers: requestHeaders,
       method: "POST",
     })
   } catch (error) {
     throw new CubidApiError({
       category: "upstream",
+      code: "NETWORK_ERROR",
       details: error,
+      endpoint,
       message: "Cubid API request failed before receiving a response.",
     })
   }
@@ -292,6 +410,7 @@ const makeRequest = async <Result>(
     throw new CubidApiError({
       category: categoryForStatus(response.status),
       details: payload,
+      endpoint,
       message: messageFromPayload(
         payload,
         `Cubid API request failed with status ${response.status}.`
@@ -301,7 +420,117 @@ const makeRequest = async <Result>(
     })
   }
 
-  return payload as Result
+  return normalize(payload, requestId, response.status)
+}
+
+const normalizeCreateUser = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidCreateUserResponse => {
+  const record = assertRecord(payload, "create_user", requestId, status)
+
+  return {
+    error: record.error ?? null,
+    isBlacklisted: Boolean(record.is_blacklisted),
+    isNewAppUser: Boolean(record.is_new_app_user),
+    isSybilAttack: Boolean(record.is_sybil_attack),
+    raw: record,
+    userId: asString(record.user_id),
+  }
+}
+
+const normalizeIdentity = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidFetchIdentityResponse => {
+  const record = assertRecord(payload, "identity/fetch_identity", requestId, status)
+  const stampDetails = Array.isArray(record.stamp_details)
+    ? record.stamp_details
+    : []
+
+  return {
+    error: record.error ?? null,
+    raw: record,
+    stampDetails: stampDetails.map((item) => {
+      const detail = assertRecord(
+        item,
+        "identity/fetch_identity.stamp_details",
+        requestId,
+        status
+      )
+
+      return {
+        raw: detail,
+        stampType: asString(detail.stamp_type) ?? "unknown",
+        status: asString(detail.status),
+        value: detail.value,
+      }
+    }),
+  }
+}
+
+const normalizeScore = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidFetchScoreResponse => {
+  const record = assertRecord(payload, "score/fetch_score", requestId, status)
+
+  return {
+    cubidScore: typeof record.cubid_score === "number" ? record.cubid_score : 0,
+    error: record.error ?? null,
+    raw: record,
+    scoringSchema:
+      typeof record.scoring_schema === "number" ||
+      typeof record.scoring_schema === "string"
+        ? record.scoring_schema
+        : null,
+  }
+}
+
+const normalizeStampRecord = (
+  raw: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidStampRecord => {
+  const record = assertRecord(
+    raw,
+    "identity/fetch_stamps.all_stamps",
+    requestId,
+    status
+  )
+
+  return {
+    emailForVerification: asString(record.emailForVerification),
+    id: asNumber(record.id),
+    identity: asString(record.identity),
+    isValid: asBoolean(record.is_valid),
+    permAvailable: asBoolean(record.permAvailable),
+    raw: record,
+    stampType: asString(record.stamptype_string),
+    stampTypeId: asNumber(record.stamptype),
+    uniqueValue: asString(record.uniquevalue),
+  }
+}
+
+const normalizeStamps = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidFetchStampsResponse => {
+  const record = assertRecord(payload, "identity/fetch_stamps", requestId, status)
+  const allStamps = Array.isArray(record.all_stamps) ? record.all_stamps : []
+
+  return {
+    allStamps: allStamps.map((stamp) =>
+      normalizeStampRecord(stamp, requestId, status)
+    ),
+    email: asString(record.email),
+    error: record.error ?? null,
+    raw: record,
+  }
 }
 
 export const createCubidApiClient = (
@@ -310,6 +539,7 @@ export const createCubidApiClient = (
   const baseUrl = normalizeBaseUrl(options.baseUrl)
   const apiKey = assertApiKey(options.apiKey)
   const fetchImpl = resolveFetch(options.fetch)
+  const headers = options.headers
 
   const withCredentials = (body: CubidRequestBody): CubidRequestBody => {
     const withApiKey = {
@@ -350,41 +580,121 @@ export const createCubidApiClient = (
           linkedin_sub: input.linkedinSub,
           phone: input.phone,
           twitter_sub: input.twitterSub,
-        })
+        }),
+        "create_user",
+        normalizeCreateUser,
+        headers
       )
     },
 
+    async ensureUserByEmail(input) {
+      const email = assertNonEmptyString(
+        input.email,
+        "email",
+        "ensure_user_by_email"
+      )
+      const created = await this.createUser({
+        dappId: input.dappId,
+        email,
+      })
+
+      if (!created.userId) {
+        throw new CubidApiError({
+          category: "upstream",
+          code: "MALFORMED_RESPONSE",
+          details: created.raw,
+          endpoint: "create_user",
+          message:
+            "Cubid create_user did not return a canonical user identifier.",
+        })
+      }
+
+      return {
+        ...created,
+        email,
+        userId: created.userId,
+      }
+    },
+
     fetchIdentity(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "identity/fetch_identity"
+      )
+
       return makeRequest<CubidFetchIdentityResponse>(
         fetchImpl,
         baseUrl,
         "/api/v2/identity/fetch_identity",
         withCredentials({
-          user_id: input.userId,
-        })
+          user_id: userId,
+        }),
+        "identity/fetch_identity",
+        normalizeIdentity,
+        headers
       )
     },
 
     fetchScore(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "score/fetch_score"
+      )
+
       return makeRequest<CubidFetchScoreResponse>(
         fetchImpl,
         baseUrl,
         "/api/v2/score/fetch_score",
         withCredentials({
-          user_id: input.userId,
-        })
+          user_id: userId,
+        }),
+        "score/fetch_score",
+        normalizeScore,
+        headers
       )
     },
 
     fetchStamps(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "identity/fetch_stamps"
+      )
+
       return makeRequest<CubidFetchStampsResponse>(
         fetchImpl,
         baseUrl,
         "/api/v2/identity/fetch_stamps",
         withCredentials({
-          user_id: input.userId,
-        })
+          user_id: userId,
+        }),
+        "identity/fetch_stamps",
+        normalizeStamps,
+        headers
       )
+    },
+
+    async syncIdentitySnapshot(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "sync_identity_snapshot"
+      )
+      const [identity, score, stamps] = await Promise.all([
+        this.fetchIdentity({ userId }),
+        this.fetchScore({ userId }),
+        this.fetchStamps({ userId }),
+      ])
+
+      return {
+        identity,
+        score,
+        stamps,
+        syncedAt: new Date().toISOString(),
+        userId,
+      }
     },
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,6 +161,107 @@ export type CubidFetchStampsResponse = {
   raw: Record<string, unknown>
 }
 
+export type CubidCoordinates = {
+  lat: number
+  lng: number
+}
+
+export type CubidFetchApproxLocationResponse = {
+  coordinates?: CubidCoordinates
+  country?: string | null
+  error: unknown
+  placeName?: string | null
+  plusCode?: string | null
+  postalCode?: string | null
+  raw: Record<string, unknown>
+}
+
+export type CubidFetchExactLocationResponse = {
+  coordinates?: CubidCoordinates
+  country?: string | null
+  error: unknown
+  place?: unknown
+  raw: Record<string, unknown>
+}
+
+export type CubidFetchRoughLocationResponse = {
+  coordinates?: CubidCoordinates
+  country?: unknown
+  error: unknown
+  plusCode?: string | null
+  raw: Record<string, unknown>
+}
+
+export type CubidFetchUserDataResponse = {
+  coordinates?: CubidCoordinates
+  country?: string | null
+  error: unknown
+  name?: string | null
+  placeName?: string | null
+  raw: Record<string, unknown>
+}
+
+export type CubidSearchLocationInput = {
+  locationInput: string
+}
+
+export type CubidSearchLocationResponse = Array<Record<string, unknown>>
+
+export type CubidAddStampInput = {
+  pageId: number | string
+  stampData: Record<string, unknown>
+  stampType: string
+  userId: string
+}
+
+export type CubidAddStampResponse = {
+  raw: Record<string, unknown>
+  success: boolean
+}
+
+export type CubidSendEmailOtpInput = {
+  email: string
+}
+
+export type CubidSendEmailOtpResponse = {
+  dappId?: number | string
+  email?: string | null
+  raw: Record<string, unknown>
+  sent: boolean
+}
+
+export type CubidVerifyEmailOtpInput = {
+  email: string
+  otp: number | string
+}
+
+export type CubidVerifyEmailOtpResponse = {
+  dappId?: number | string
+  email?: string | null
+  isVerified: boolean
+  raw: Record<string, unknown>
+}
+
+export type CubidSendPhoneOtpInput = {
+  phone: string
+}
+
+export type CubidSendPhoneOtpResponse = {
+  raw: Record<string, unknown>
+  status?: string | null
+}
+
+export type CubidVerifyPhoneOtpInput = {
+  otp: number | string
+  phone: string
+}
+
+export type CubidVerifyPhoneOtpResponse = {
+  isVerified: boolean
+  raw: Record<string, unknown>
+  status?: string | null
+}
+
 export type CubidIdentitySnapshotInput = {
   userId: string
 }
@@ -174,18 +275,46 @@ export type CubidIdentitySnapshot = {
 }
 
 export type CubidApiClient = {
+  addStamp(input: CubidAddStampInput): Promise<CubidAddStampResponse>
   createUser(input: CubidCreateUserInput): Promise<CubidCreateUserResponse>
   ensureUserByEmail(
     input: CubidEnsureUserByEmailInput
   ): Promise<CubidEnsureUserByEmailResponse>
+  fetchApproxLocation(
+    input: CubidFetchIdentityInput
+  ): Promise<CubidFetchApproxLocationResponse>
+  fetchExactLocation(
+    input: CubidFetchIdentityInput
+  ): Promise<CubidFetchExactLocationResponse>
   fetchIdentity(
     input: CubidFetchIdentityInput
   ): Promise<CubidFetchIdentityResponse>
+  fetchRoughLocation(
+    input: CubidFetchIdentityInput
+  ): Promise<CubidFetchRoughLocationResponse>
   fetchScore(input: CubidFetchScoreInput): Promise<CubidFetchScoreResponse>
   fetchStamps(input: CubidFetchStampsInput): Promise<CubidFetchStampsResponse>
+  fetchUserData(
+    input: CubidFetchIdentityInput
+  ): Promise<CubidFetchUserDataResponse>
+  searchLocation(
+    input: CubidSearchLocationInput
+  ): Promise<CubidSearchLocationResponse>
+  sendEmailOtp(
+    input: CubidSendEmailOtpInput
+  ): Promise<CubidSendEmailOtpResponse>
+  sendPhoneOtp(
+    input: CubidSendPhoneOtpInput
+  ): Promise<CubidSendPhoneOtpResponse>
   syncIdentitySnapshot(
     input: CubidIdentitySnapshotInput
   ): Promise<CubidIdentitySnapshot>
+  verifyEmailOtp(
+    input: CubidVerifyEmailOtpInput
+  ): Promise<CubidVerifyEmailOtpResponse>
+  verifyPhoneOtp(
+    input: CubidVerifyPhoneOtpInput
+  ): Promise<CubidVerifyPhoneOtpResponse>
 }
 
 type CubidRequestBody = Record<string, unknown>
@@ -304,6 +433,21 @@ const asNumber = (value: unknown): number | undefined =>
 
 const asBoolean = (value: unknown): boolean | undefined =>
   typeof value === "boolean" ? value : undefined
+
+const asCoordinates = (value: unknown): CubidCoordinates | undefined => {
+  if (!isRecord(value)) {
+    return undefined
+  }
+
+  const lat = value.lat
+  const lng = value.lng
+
+  if (typeof lat !== "number" || typeof lng !== "number") {
+    return undefined
+  }
+
+  return { lat, lng }
+}
 
 const assertRecord = (
   value: unknown,
@@ -533,6 +677,199 @@ const normalizeStamps = (
   }
 }
 
+const normalizeApproxLocation = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidFetchApproxLocationResponse => {
+  const record = assertRecord(
+    payload,
+    "identity/fetch_approx_location",
+    requestId,
+    status
+  )
+
+  return {
+    coordinates: asCoordinates(record.coordinates),
+    country: asString(record.country),
+    error: record.error ?? null,
+    placeName: asString(record.placename),
+    plusCode: asString(record.pluscode),
+    postalCode: asString(record.postalcode),
+    raw: record,
+  }
+}
+
+const normalizeExactLocation = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidFetchExactLocationResponse => {
+  const record = assertRecord(
+    payload,
+    "identity/fetch_exact_location",
+    requestId,
+    status
+  )
+
+  return {
+    coordinates: asCoordinates(record.coordinates),
+    country: asString(record.country),
+    error: record.error ?? null,
+    place: record.place,
+    raw: record,
+  }
+}
+
+const normalizeRoughLocation = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidFetchRoughLocationResponse => {
+  const record = assertRecord(
+    payload,
+    "identity/fetch_rough_location",
+    requestId,
+    status
+  )
+
+  return {
+    coordinates: asCoordinates(record.coordinates),
+    country: record.country ?? record.cubid_country ?? null,
+    error: record.error ?? null,
+    plusCode: asString(record.pluscode),
+    raw: record,
+  }
+}
+
+const normalizeUserData = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidFetchUserDataResponse => {
+  const record = assertRecord(payload, "identity/fetch_user_data", requestId, status)
+
+  return {
+    coordinates: asCoordinates(record.coordinates),
+    country: asString(record.country),
+    error: record.error ?? null,
+    name: asString(record.name),
+    placeName: asString(record.placename),
+    raw: record,
+  }
+}
+
+const normalizeSearchLocation = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidSearchLocationResponse => {
+  if (!Array.isArray(payload)) {
+    throw new CubidApiError({
+      category: "upstream",
+      code: "MALFORMED_RESPONSE",
+      details: payload,
+      endpoint: "search-location",
+      message: "Malformed response from search-location.",
+      requestId,
+      status,
+    })
+  }
+
+  return payload.map((item) => (isRecord(item) ? item : { value: item }))
+}
+
+const normalizeAddStamp = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidAddStampResponse => {
+  const record = assertRecord(payload, "identity/add_stamp", requestId, status)
+
+  return {
+    raw: record,
+    success: Boolean(record.success),
+  }
+}
+
+const normalizeEmailOtpSent = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidSendEmailOtpResponse => {
+  const record = assertRecord(payload, "email/send_otp", requestId, status)
+  const data = isRecord(record.data) ? record.data : record
+
+  return {
+    dappId:
+      typeof data.dappId === "number" || typeof data.dappId === "string"
+        ? data.dappId
+        : undefined,
+    email: asString(data.email),
+    raw: record,
+    sent: data.sent === undefined ? true : Boolean(data.sent),
+  }
+}
+
+const normalizeEmailOtpVerified = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidVerifyEmailOtpResponse => {
+  const record = assertRecord(payload, "email/verify_otp", requestId, status)
+  const data = isRecord(record.data) ? record.data : record
+
+  return {
+    dappId:
+      typeof data.dappId === "number" || typeof data.dappId === "string"
+        ? data.dappId
+        : undefined,
+    email: asString(data.email),
+    isVerified: Boolean(data.is_verified),
+    raw: record,
+  }
+}
+
+const normalizePhoneOtpSent = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidSendPhoneOtpResponse => {
+  if (typeof payload === "string") {
+    return {
+      raw: { message: payload },
+      status: payload,
+    }
+  }
+
+  const record = assertRecord(payload, "twillio/send-otp", requestId, status)
+  const data = isRecord(record.data) ? record.data : record
+
+  return {
+    raw: record,
+    status: asString(data.status) ?? asString(data.message),
+  }
+}
+
+const normalizePhoneOtpVerified = (
+  payload: unknown,
+  requestId?: string | null,
+  status?: number
+): CubidVerifyPhoneOtpResponse => {
+  const record = assertRecord(payload, "twillio/verify-otp", requestId, status)
+  const data = isRecord(record.data) ? record.data : record
+  const verificationStatus = asString(data.status)
+
+  return {
+    isVerified:
+      Boolean(data.is_verified) ||
+      verificationStatus === "approved" ||
+      verificationStatus === "verified",
+    raw: record,
+    status: verificationStatus,
+  }
+}
+
 export const createCubidApiClient = (
   options: CubidApiClientOptions
 ): CubidApiClient => {
@@ -558,6 +895,37 @@ export const createCubidApiClient = (
   }
 
   return {
+    addStamp(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "identity/add_stamp"
+      )
+      const stampType = assertNonEmptyString(
+        input.stampType,
+        "stampType",
+        "identity/add_stamp"
+      )
+
+      return makeRequest<CubidAddStampResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/identity/add_stamp",
+        {
+          page_id:
+            typeof input.pageId === "string"
+              ? Number(input.pageId) || input.pageId
+              : input.pageId,
+          stamp_type: stampType,
+          stampData: input.stampData,
+          user_data: { uuid: userId },
+        },
+        "identity/add_stamp",
+        normalizeAddStamp,
+        headers
+      )
+    },
+
     createUser(input) {
       const dappId = input.dappId ?? options.dappId
       if (dappId === undefined) {
@@ -616,6 +984,42 @@ export const createCubidApiClient = (
       }
     },
 
+    fetchApproxLocation(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "identity/fetch_approx_location"
+      )
+
+      return makeRequest<CubidFetchApproxLocationResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/identity/fetch_approx_location",
+        withCredentials({ user_id: userId }),
+        "identity/fetch_approx_location",
+        normalizeApproxLocation,
+        headers
+      )
+    },
+
+    fetchExactLocation(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "identity/fetch_exact_location"
+      )
+
+      return makeRequest<CubidFetchExactLocationResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/identity/fetch_exact_location",
+        withCredentials({ user_id: userId }),
+        "identity/fetch_exact_location",
+        normalizeExactLocation,
+        headers
+      )
+    },
+
     fetchIdentity(input) {
       const userId = assertNonEmptyString(
         input.userId,
@@ -632,6 +1036,24 @@ export const createCubidApiClient = (
         }),
         "identity/fetch_identity",
         normalizeIdentity,
+        headers
+      )
+    },
+
+    fetchRoughLocation(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "identity/fetch_rough_location"
+      )
+
+      return makeRequest<CubidFetchRoughLocationResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/identity/fetch_rough_location",
+        withCredentials({ user_id: userId }),
+        "identity/fetch_rough_location",
+        normalizeRoughLocation,
         headers
       )
     },
@@ -676,6 +1098,70 @@ export const createCubidApiClient = (
       )
     },
 
+    fetchUserData(input) {
+      const userId = assertNonEmptyString(
+        input.userId,
+        "userId",
+        "identity/fetch_user_data"
+      )
+
+      return makeRequest<CubidFetchUserDataResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/identity/fetch_user_data",
+        withCredentials({ user_id: userId }),
+        "identity/fetch_user_data",
+        normalizeUserData,
+        headers
+      )
+    },
+
+    searchLocation(input) {
+      const locationInput = assertNonEmptyString(
+        input.locationInput,
+        "locationInput",
+        "search-location"
+      )
+
+      return makeRequest<CubidSearchLocationResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/search-location",
+        withCredentials({ location_input: locationInput }),
+        "search-location",
+        normalizeSearchLocation,
+        headers
+      )
+    },
+
+    sendEmailOtp(input) {
+      const email = assertNonEmptyString(input.email, "email", "email/send_otp")
+
+      return makeRequest<CubidSendEmailOtpResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/email/send_otp",
+        withCredentials({ email }),
+        "email/send_otp",
+        normalizeEmailOtpSent,
+        headers
+      )
+    },
+
+    sendPhoneOtp(input) {
+      const phone = assertNonEmptyString(input.phone, "phone", "twillio/send-otp")
+
+      return makeRequest<CubidSendPhoneOtpResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/twillio/send-otp",
+        withCredentials({ phone }),
+        "twillio/send-otp",
+        normalizePhoneOtpSent,
+        headers
+      )
+    },
+
     async syncIdentitySnapshot(input) {
       const userId = assertNonEmptyString(
         input.userId,
@@ -695,6 +1181,60 @@ export const createCubidApiClient = (
         syncedAt: new Date().toISOString(),
         userId,
       }
+    },
+
+    verifyEmailOtp(input) {
+      const email = assertNonEmptyString(
+        input.email,
+        "email",
+        "email/verify_otp"
+      )
+      const otp = String(input.otp).trim()
+      if (!otp) {
+        throw new CubidApiError({
+          category: "validation",
+          code: "INVALID_INPUT",
+          endpoint: "email/verify_otp",
+          message: "otp is required.",
+        })
+      }
+
+      return makeRequest<CubidVerifyEmailOtpResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/email/verify_otp",
+        withCredentials({ email, otp }),
+        "email/verify_otp",
+        normalizeEmailOtpVerified,
+        headers
+      )
+    },
+
+    verifyPhoneOtp(input) {
+      const phone = assertNonEmptyString(
+        input.phone,
+        "phone",
+        "twillio/verify-otp"
+      )
+      const otpCode = String(input.otp).trim()
+      if (!otpCode) {
+        throw new CubidApiError({
+          category: "validation",
+          code: "INVALID_INPUT",
+          endpoint: "twillio/verify-otp",
+          message: "otp is required.",
+        })
+      }
+
+      return makeRequest<CubidVerifyPhoneOtpResponse>(
+        fetchImpl,
+        baseUrl,
+        "/api/v2/twillio/verify-otp",
+        withCredentials({ otpCode, phone }),
+        "twillio/verify-otp",
+        normalizePhoneOtpVerified,
+        headers
+      )
     },
   }
 }

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -1,0 +1,6 @@
+# @cubid/evm
+
+EVM-specific Cubid wallet/stamp helper contracts. This package is intentionally
+separate from `@cubid/core` so EVM dependencies can evolve without affecting the
+runtime-agnostic API client.
+

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@cubid/evm",
+  "version": "0.1.0",
+  "description": "EVM wallet and stamp helper contracts for Cubid integrations.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "publishConfig": { "access": "public" },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.20.6",
+    "typescript": "5.2.2"
+  },
+  "scripts": {
+    "build": "pnpm exec tsc -p tsconfig.build.json",
+    "lint": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "typecheck": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "test": "pnpm exec tsx --test src/*.test.ts",
+    "format": "echo \"No format changes required for @cubid/evm\"",
+    "format:write": "echo \"No format changes required for @cubid/evm\""
+  }
+}

--- a/packages/evm/src/index.test.ts
+++ b/packages/evm/src/index.test.ts
@@ -14,4 +14,12 @@ test("@cubid/evm normalizes EVM wallet stamp data", () => {
     uniquevalue: "0xAbC",
     walletType: "evm",
   })
+  assert.deepEqual(
+    createEvmStampData({
+      address: "0xAbC",
+      chainId: 1,
+      metadata: { connectorId: "injected" },
+    }).metadata,
+    { connectorId: "injected" }
+  )
 })

--- a/packages/evm/src/index.test.ts
+++ b/packages/evm/src/index.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { createEvmStampData, normalizeEvmAddress } from "./index"
+
+test("@cubid/evm normalizes EVM wallet stamp data", () => {
+  assert.equal(normalizeEvmAddress(" 0xAbC "), "0xabc")
+  assert.deepEqual(createEvmStampData({ address: "0xAbC", chainId: 1 }), {
+    address: "0xAbC",
+    chainId: 1,
+    chainType: "evm",
+    identity: "0xAbC",
+    normalizedAddress: "0xabc",
+    uniquevalue: "0xAbC",
+    walletType: "evm",
+  })
+})

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -9,6 +9,7 @@ export type CubidEvmStampData = {
   chainId?: number | string
   chainType: "evm"
   identity: string
+  metadata?: Record<string, unknown>
   normalizedAddress: string
   uniquevalue: string
   walletType: "evm"
@@ -29,6 +30,7 @@ export function createEvmStampData(
     chainId: connection.chainId,
     chainType: "evm",
     identity: address,
+    ...(connection.metadata === undefined ? {} : { metadata: connection.metadata }),
     normalizedAddress,
     uniquevalue: address,
     walletType: "evm",

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -1,0 +1,36 @@
+export type CubidEvmConnection = {
+  address: string
+  chainId?: number | string
+  metadata?: Record<string, unknown>
+}
+
+export type CubidEvmStampData = {
+  address: string
+  chainId?: number | string
+  chainType: "evm"
+  identity: string
+  normalizedAddress: string
+  uniquevalue: string
+  walletType: "evm"
+}
+
+export function normalizeEvmAddress(address: string): string {
+  return address.trim().toLowerCase()
+}
+
+export function createEvmStampData(
+  connection: CubidEvmConnection
+): CubidEvmStampData {
+  const address = connection.address.trim()
+  const normalizedAddress = normalizeEvmAddress(address)
+
+  return {
+    address,
+    chainId: connection.chainId,
+    chainType: "evm",
+    identity: address,
+    normalizedAddress,
+    uniquevalue: address,
+    walletType: "evm",
+  }
+}

--- a/packages/evm/tsconfig.build.json
+++ b/packages/evm/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/evm/tsconfig.json
+++ b/packages/evm/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/near/README.md
+++ b/packages/near/README.md
@@ -1,0 +1,4 @@
+# @cubid/near
+
+NEAR-specific Cubid wallet/stamp helper contracts.
+

--- a/packages/near/package.json
+++ b/packages/near/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@cubid/near",
+  "version": "0.1.0",
+  "description": "NEAR wallet and stamp helper contracts for Cubid integrations.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "publishConfig": { "access": "public" },
+  "devDependencies": { "typescript": "5.2.2" },
+  "scripts": {
+    "build": "pnpm exec tsc -p tsconfig.build.json",
+    "lint": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "typecheck": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "test": "echo \"No @cubid/near tests yet\"",
+    "format": "echo \"No format changes required for @cubid/near\"",
+    "format:write": "echo \"No format changes required for @cubid/near\""
+  }
+}

--- a/packages/near/src/index.ts
+++ b/packages/near/src/index.ts
@@ -1,0 +1,18 @@
+export type CubidNearConnection = {
+  accountId: string
+  publicKey?: string
+  transactionSignature?: string
+}
+
+export function createNearStampData(connection: CubidNearConnection) {
+  const accountId = connection.accountId.trim()
+  return {
+    accountId,
+    chainType: "near" as const,
+    identity: accountId,
+    publicKey: connection.publicKey,
+    transactionSignature: connection.transactionSignature,
+    uniquevalue: accountId,
+    walletType: "near" as const,
+  }
+}

--- a/packages/near/tsconfig.build.json
+++ b/packages/near/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/near/tsconfig.json
+++ b/packages/near/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,31 @@
+# @cubid/react
+
+React primitives for Cubid profile-completion flows. This package depends on
+`@cubid/core` and React only; wallet, chain, and wagmi integrations live in
+chain-specific packages.
+
+```tsx
+import { CubidProvider, PhoneOtpForm, createCubidApiClient } from "@cubid/react"
+
+const client = createCubidApiClient({
+  apiKey: process.env.CUBID_DAPP_API_KEY!,
+  baseUrl: "https://passport.cubid.me",
+})
+
+export function ProfileCompletion() {
+  return (
+    <CubidProvider client={client}>
+      <PhoneOtpForm onVerified={(result) => console.log(result.isVerified)} />
+    </CubidProvider>
+  )
+}
+```
+
+The package exports:
+
+- `CubidProvider`, `useCubidClient`, and `useOptionalCubidClient`
+- `PhoneOtpForm` for inline phone collection and verification
+- `ProviderConnectButton` for provider/stamp handoff buttons
+- `ProfileCompletionPanel` for small composed profile-completion flows
+- `createAllowPageUrl`, callback-state helpers, and credential-summary helpers
+

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@cubid/react",
+  "version": "0.1.0",
+  "description": "React primitives for Cubid profile completion, AllowPage handoff, and credential collection flows.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@cubid/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18.2.0",
+    "react-dom": ">=18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "tsx": "^4.20.6",
+    "typescript": "5.2.2"
+  },
+  "scripts": {
+    "build": "pnpm --filter @cubid/core build && node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\" && pnpm exec tsc -p tsconfig.build.json",
+    "lint": "pnpm --filter @cubid/core build && pnpm exec tsc --noEmit -p tsconfig.json",
+    "typecheck": "pnpm --filter @cubid/core build && pnpm exec tsc --noEmit -p tsconfig.json",
+    "test": "pnpm exec tsx --test src/*.test.ts",
+    "format": "echo \"No format changes required for @cubid/react\"",
+    "format:write": "echo \"No format changes required for @cubid/react\""
+  }
+}

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -64,3 +64,21 @@ test("@cubid/react builds AllowPage and provider callback URLs", () => {
   assert.equal(authUrl.includes("client_id=client_123"), true)
   assert.equal(authUrl.includes("scope=read%3Auser+user%3Aemail"), true)
 })
+
+test("@cubid/react rejects callback state with unsupported providers", () => {
+  const state = createCubidCallbackState({
+    provider: "github",
+    userId: "user_123",
+  })
+  const payload = JSON.parse(
+    Buffer.from(state, "base64url").toString("utf8")
+  ) as Record<string, unknown>
+  const invalidState = Buffer.from(
+    JSON.stringify({ ...payload, provider: "not-a-provider" })
+  ).toString("base64url")
+
+  assert.throws(
+    () => parseCubidCallbackState(invalidState),
+    /unsupported provider/
+  )
+})

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildCubidAuthorizationUrl,
+  createAllowPageUrl,
+  createCubidCallbackState,
+  parseCubidCallbackState,
+  summarizeCredentials,
+} from "./index"
+
+test("@cubid/react summarizes missing recommended credentials", () => {
+  assert.deepEqual(
+    summarizeCredentials({
+      availableStampTypes: ["phone", "email", "phone"],
+      recommendedStampTypes: ["email", "phone", "github"],
+      verifiedStampTypes: ["email"],
+    }),
+    {
+      availableStampTypes: ["email", "phone"],
+      missingRecommendedStampTypes: ["github", "phone"],
+      recommendedStampTypes: ["email", "github", "phone"],
+      verifiedStampTypes: ["email"],
+    }
+  )
+})
+
+test("@cubid/react builds AllowPage and provider callback URLs", () => {
+  const allowUrl = createAllowPageUrl({
+    colorMode: "dark",
+    extras: { source: "signup" },
+    pageId: 42,
+    passportOrigin: "https://passport.cubid.me",
+    path: "/widget-allow",
+    socialProvider: "github",
+    userId: "user_123",
+  })
+  assert.equal(
+    allowUrl,
+    "https://passport.cubid.me/widget-allow?uid=user_123&page_id=42&colormode=dark&social_provider=github&source=signup"
+  )
+
+  const state = createCubidCallbackState({
+    metadata: { flow: "signup" },
+    provider: "github",
+    userId: "user_123",
+  })
+  assert.deepEqual(parseCubidCallbackState(state), {
+    metadata: { flow: "signup" },
+    nonce: undefined,
+    pageId: undefined,
+    provider: "github",
+    returnTo: undefined,
+    userId: "user_123",
+  })
+
+  const authUrl = buildCubidAuthorizationUrl({
+    authorizationUrl: "https://github.com/login/oauth/authorize",
+    clientId: "client_123",
+    redirectUri: "https://app.example/callback",
+    scope: ["read:user", "user:email"],
+    state,
+  })
+  assert.equal(authUrl.includes("client_id=client_123"), true)
+  assert.equal(authUrl.includes("scope=read%3Auser+user%3Aemail"), true)
+})

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -174,6 +174,10 @@ export function createCubidCallbackState(state: CubidCallbackState): string {
   return encodeBase64Url(JSON.stringify(state))
 }
 
+function isCubidProfileProvider(value: string): value is CubidProfileProvider {
+  return (CUBID_PROFILE_PROVIDERS as readonly string[]).includes(value)
+}
+
 export function parseCubidCallbackState(encodedState: string): CubidCallbackState {
   const parsed = JSON.parse(decodeBase64Url(encodedState)) as unknown
 
@@ -184,6 +188,9 @@ export function parseCubidCallbackState(encodedState: string): CubidCallbackStat
   const state = parsed as Record<string, unknown>
   if (typeof state.provider !== "string") {
     throw new Error("Cubid callback state is missing the provider.")
+  }
+  if (!isCubidProfileProvider(state.provider)) {
+    throw new Error("Cubid callback state has an unsupported provider.")
   }
 
   return {
@@ -199,7 +206,7 @@ export function parseCubidCallbackState(encodedState: string): CubidCallbackStat
         : undefined,
     nonce: typeof state.nonce === "string" ? state.nonce : undefined,
     pageId: typeof state.pageId === "string" ? state.pageId : undefined,
-    provider: state.provider as CubidProfileProvider,
+    provider: state.provider,
     returnTo: typeof state.returnTo === "string" ? state.returnTo : undefined,
     userId: typeof state.userId === "string" ? state.userId : undefined,
   }
@@ -265,6 +272,9 @@ export function PhoneOtpForm({
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
+    if (step === "verified") {
+      return
+    }
     setIsBusy(true)
 
     try {
@@ -319,7 +329,7 @@ export function PhoneOtpForm({
           />
         </>
       ) : null}
-      <button disabled={isBusy} type="submit">
+      <button disabled={isBusy || step === "verified"} type="submit">
         {step === "collect"
           ? "Send phone code"
           : step === "verify"
@@ -339,6 +349,7 @@ export type ProviderConnectButtonProps = Omit<
   authorizationUrl?: string
   navigate?: boolean
   onConnect?: (details: CubidProviderConnectDetails) => Promise<void> | void
+  onError?: (error: unknown) => void
   provider: CubidProfileProvider
 }
 
@@ -348,25 +359,34 @@ export function ProviderConnectButton({
   children,
   navigate = false,
   onConnect,
+  onError,
   provider,
   type = "button",
   ...buttonProps
 }: ProviderConnectButtonProps) {
   async function handleClick() {
-    const url =
-      authorizationUrl ??
-      (authorizationRequest
-        ? buildCubidAuthorizationUrl(authorizationRequest)
-        : undefined)
+    try {
+      const url =
+        authorizationUrl ??
+        (authorizationRequest
+          ? buildCubidAuthorizationUrl(authorizationRequest)
+          : undefined)
 
-    await onConnect?.({
-      provider,
-      state: authorizationRequest?.state,
-      url,
-    })
+      await onConnect?.({
+        provider,
+        state: authorizationRequest?.state,
+        url,
+      })
 
-    if (navigate && url && typeof window !== "undefined") {
-      window.location.assign(url)
+      if (navigate && url && typeof window !== "undefined") {
+        window.location.assign(url)
+      }
+    } catch (error) {
+      if (onError) {
+        onError(error)
+        return
+      }
+      console.error(error)
     }
   }
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,0 +1,415 @@
+import {
+  createContext,
+  startTransition,
+  useContext,
+  useId,
+  useState,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react"
+
+export { createCubidApiClient, CubidApiError } from "@cubid/core"
+export type {
+  CubidApiClient,
+  CubidSendPhoneOtpResponse,
+  CubidVerifyPhoneOtpResponse,
+} from "@cubid/core"
+
+import type {
+  CubidApiClient,
+  CubidSendPhoneOtpResponse,
+  CubidVerifyPhoneOtpResponse,
+} from "@cubid/core"
+
+export const CUBID_PROFILE_PROVIDERS = [
+  "discord",
+  "github",
+  "google",
+  "instagram",
+  "linkedin",
+  "twitter",
+  "worldcoin",
+] as const
+
+export type CubidProfileProvider = (typeof CUBID_PROFILE_PROVIDERS)[number]
+export type CubidCredentialType = CubidProfileProvider | "email" | "phone"
+
+export type CubidCredentialSummaryInput = {
+  availableStampTypes?: readonly string[]
+  recommendedStampTypes?: readonly string[]
+  verifiedStampTypes?: readonly string[]
+}
+
+export type CubidCredentialSummary = {
+  availableStampTypes: string[]
+  missingRecommendedStampTypes: string[]
+  recommendedStampTypes: string[]
+  verifiedStampTypes: string[]
+}
+
+export type CubidAllowPageUrlInput = {
+  colorMode?: string
+  extras?: Record<string, boolean | number | string | undefined>
+  pageId?: number | string
+  passportOrigin: string
+  path?: "/allow" | "/widget-allow"
+  socialProvider?: CubidProfileProvider
+  success?: boolean
+  userId?: string
+}
+
+export type CubidCallbackState = {
+  metadata?: Record<string, string>
+  nonce?: string
+  pageId?: string
+  provider: CubidProfileProvider
+  returnTo?: string
+  userId?: string
+}
+
+export type CubidProviderConnectDetails = {
+  provider: CubidProfileProvider
+  state?: CubidCallbackState | string
+  url?: string
+}
+
+export type CubidAuthorizationRequest = {
+  authorizationUrl: string
+  clientId: string
+  extraParams?: Record<string, boolean | number | string | undefined>
+  redirectUri: string
+  responseType?: string
+  scope?: string | string[]
+  state?: CubidCallbackState | string
+}
+
+const CubidContext = createContext<CubidApiClient | null>(null)
+
+export type CubidProviderProps = {
+  children: ReactNode
+  client: CubidApiClient
+}
+
+export function CubidProvider({ children, client }: CubidProviderProps) {
+  return <CubidContext.Provider value={client}>{children}</CubidContext.Provider>
+}
+
+export function useOptionalCubidClient() {
+  return useContext(CubidContext)
+}
+
+export function useCubidClient() {
+  const client = useOptionalCubidClient()
+
+  if (!client) {
+    throw new Error("A Cubid API client was not found in context.")
+  }
+
+  return client
+}
+
+export function summarizeCredentials(
+  input: CubidCredentialSummaryInput
+): CubidCredentialSummary {
+  const availableStampTypes = [...new Set(input.availableStampTypes ?? [])].sort()
+  const recommendedStampTypes = [
+    ...new Set(input.recommendedStampTypes ?? []),
+  ].sort()
+  const verifiedStampTypes = [...new Set(input.verifiedStampTypes ?? [])].sort()
+  const verified = new Set(verifiedStampTypes)
+
+  return {
+    availableStampTypes,
+    missingRecommendedStampTypes: recommendedStampTypes.filter(
+      (stampType) => !verified.has(stampType)
+    ),
+    recommendedStampTypes,
+    verifiedStampTypes,
+  }
+}
+
+export function createAllowPageUrl(input: CubidAllowPageUrlInput): string {
+  const url = new URL(input.path ?? "/allow", input.passportOrigin)
+  if (input.userId) {
+    url.searchParams.set("uid", input.userId)
+  }
+  if (input.pageId !== undefined) {
+    url.searchParams.set("page_id", String(input.pageId))
+  }
+  if (input.colorMode) {
+    url.searchParams.set("colormode", input.colorMode)
+  }
+  if (input.socialProvider) {
+    url.searchParams.set("social_provider", input.socialProvider)
+  }
+  if (input.success !== undefined) {
+    url.searchParams.set("success", String(input.success))
+  }
+  for (const [key, value] of Object.entries(input.extras ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url.toString()
+}
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ""
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "")
+}
+
+function decodeBase64Url(value: string): string {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/")
+  const padded = `${base64}${"=".repeat((4 - (base64.length % 4 || 4)) % 4)}`
+  const binary = atob(padded)
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}
+
+export function createCubidCallbackState(state: CubidCallbackState): string {
+  return encodeBase64Url(JSON.stringify(state))
+}
+
+export function parseCubidCallbackState(encodedState: string): CubidCallbackState {
+  const parsed = JSON.parse(decodeBase64Url(encodedState)) as unknown
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Malformed Cubid callback state.")
+  }
+
+  const state = parsed as Record<string, unknown>
+  if (typeof state.provider !== "string") {
+    throw new Error("Cubid callback state is missing the provider.")
+  }
+
+  return {
+    metadata:
+      typeof state.metadata === "object" &&
+      state.metadata !== null &&
+      !Array.isArray(state.metadata)
+        ? Object.fromEntries(
+            Object.entries(state.metadata).filter(
+              (entry): entry is [string, string] => typeof entry[1] === "string"
+            )
+          )
+        : undefined,
+    nonce: typeof state.nonce === "string" ? state.nonce : undefined,
+    pageId: typeof state.pageId === "string" ? state.pageId : undefined,
+    provider: state.provider as CubidProfileProvider,
+    returnTo: typeof state.returnTo === "string" ? state.returnTo : undefined,
+    userId: typeof state.userId === "string" ? state.userId : undefined,
+  }
+}
+
+export function buildCubidAuthorizationUrl(
+  request: CubidAuthorizationRequest
+): string {
+  const url = new URL(request.authorizationUrl)
+  url.searchParams.set("client_id", request.clientId)
+  url.searchParams.set("redirect_uri", request.redirectUri)
+  url.searchParams.set("response_type", request.responseType ?? "code")
+  if (request.scope) {
+    url.searchParams.set(
+      "scope",
+      Array.isArray(request.scope) ? request.scope.join(" ") : request.scope
+    )
+  }
+  if (request.state) {
+    url.searchParams.set(
+      "state",
+      typeof request.state === "string"
+        ? request.state
+        : createCubidCallbackState(request.state)
+    )
+  }
+  for (const [key, value] of Object.entries(request.extraParams ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url.toString()
+}
+
+export type PhoneOtpFormProps = Omit<
+  ComponentPropsWithoutRef<"form">,
+  "onSubmit"
+> & {
+  client?: CubidApiClient
+  defaultPhone?: string
+  onError?: (error: unknown) => void
+  onStarted?: (result: CubidSendPhoneOtpResponse) => Promise<void> | void
+  onVerified?: (result: CubidVerifyPhoneOtpResponse) => Promise<void> | void
+}
+
+export function PhoneOtpForm({
+  client,
+  defaultPhone = "",
+  onError,
+  onStarted,
+  onVerified,
+  ...formProps
+}: PhoneOtpFormProps) {
+  const contextualClient = useOptionalCubidClient()
+  const resolvedClient = client ?? contextualClient ?? undefined
+  const phoneId = useId()
+  const otpId = useId()
+  const [phone, setPhone] = useState(defaultPhone)
+  const [otp, setOtp] = useState("")
+  const [step, setStep] = useState<"collect" | "verified" | "verify">("collect")
+  const [isBusy, setIsBusy] = useState(false)
+  const [status, setStatus] = useState<string>()
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsBusy(true)
+
+    try {
+      if (!resolvedClient) {
+        throw new Error("PhoneOtpForm requires a Cubid API client.")
+      }
+
+      if (step === "collect") {
+        const result = await resolvedClient.sendPhoneOtp({ phone })
+        await onStarted?.(result)
+        startTransition(() => {
+          setStatus(result.status ?? "Code sent.")
+          setStep("verify")
+        })
+      } else if (step === "verify") {
+        const result = await resolvedClient.verifyPhoneOtp({ otp, phone })
+        await onVerified?.(result)
+        startTransition(() => {
+          setStatus(result.isVerified ? "Phone verified." : "Verification failed.")
+          setStep(result.isVerified ? "verified" : "verify")
+        })
+      }
+    } catch (error) {
+      startTransition(() => setStatus("Unable to complete phone verification."))
+      onError?.(error)
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  return (
+    <form {...formProps} onSubmit={handleSubmit}>
+      <label htmlFor={phoneId}>Phone</label>
+      <input
+        autoComplete="tel"
+        disabled={isBusy || step === "verified"}
+        id={phoneId}
+        onChange={(event) => setPhone(event.target.value)}
+        type="tel"
+        value={phone}
+      />
+      {step !== "collect" ? (
+        <>
+          <label htmlFor={otpId}>Code</label>
+          <input
+            autoComplete="one-time-code"
+            disabled={isBusy || step === "verified"}
+            id={otpId}
+            inputMode="numeric"
+            onChange={(event) => setOtp(event.target.value)}
+            value={otp}
+          />
+        </>
+      ) : null}
+      <button disabled={isBusy} type="submit">
+        {step === "collect"
+          ? "Send phone code"
+          : step === "verify"
+            ? "Verify phone code"
+            : "Phone verified"}
+      </button>
+      <p aria-live="polite">{status}</p>
+    </form>
+  )
+}
+
+export type ProviderConnectButtonProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "onClick"
+> & {
+  authorizationRequest?: CubidAuthorizationRequest
+  authorizationUrl?: string
+  navigate?: boolean
+  onConnect?: (details: CubidProviderConnectDetails) => Promise<void> | void
+  provider: CubidProfileProvider
+}
+
+export function ProviderConnectButton({
+  authorizationRequest,
+  authorizationUrl,
+  children,
+  navigate = false,
+  onConnect,
+  provider,
+  type = "button",
+  ...buttonProps
+}: ProviderConnectButtonProps) {
+  async function handleClick() {
+    const url =
+      authorizationUrl ??
+      (authorizationRequest
+        ? buildCubidAuthorizationUrl(authorizationRequest)
+        : undefined)
+
+    await onConnect?.({
+      provider,
+      state: authorizationRequest?.state,
+      url,
+    })
+
+    if (navigate && url && typeof window !== "undefined") {
+      window.location.assign(url)
+    }
+  }
+
+  return (
+    <button {...buttonProps} onClick={handleClick} type={type}>
+      {children ?? `Connect ${provider}`}
+    </button>
+  )
+}
+
+export type ProfileCompletionPanelProps = ComponentPropsWithoutRef<"section"> & {
+  client?: CubidApiClient
+  phone?: false | { defaultPhone?: string }
+  providers?: Array<{
+    authorizationRequest?: CubidAuthorizationRequest
+    authorizationUrl?: string
+    provider: CubidProfileProvider
+  }>
+}
+
+export function ProfileCompletionPanel({
+  client,
+  phone = {},
+  providers = [],
+  ...sectionProps
+}: ProfileCompletionPanelProps) {
+  return (
+    <section {...sectionProps}>
+      {phone !== false ? (
+        <PhoneOtpForm client={client} defaultPhone={phone.defaultPhone} />
+      ) : null}
+      {providers.length > 0 ? (
+        <div>
+          {providers.map((providerConfig) => (
+            <ProviderConnectButton
+              authorizationRequest={providerConfig.authorizationRequest}
+              authorizationUrl={providerConfig.authorizationUrl}
+              key={providerConfig.provider}
+              provider={providerConfig.provider}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/solana/README.md
+++ b/packages/solana/README.md
@@ -1,0 +1,5 @@
+# @cubid/solana
+
+Solana-specific Cubid wallet/stamp helper contracts. The first package slice
+keeps SDK dependencies out until signing and adapter support land.
+

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@cubid/solana",
+  "version": "0.1.0",
+  "description": "Solana wallet and stamp helper contracts for Cubid integrations.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "publishConfig": { "access": "public" },
+  "devDependencies": { "typescript": "5.2.2" },
+  "scripts": {
+    "build": "pnpm exec tsc -p tsconfig.build.json",
+    "lint": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "typecheck": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "test": "echo \"No @cubid/solana tests yet\"",
+    "format": "echo \"No format changes required for @cubid/solana\"",
+    "format:write": "echo \"No format changes required for @cubid/solana\""
+  }
+}

--- a/packages/solana/src/index.ts
+++ b/packages/solana/src/index.ts
@@ -9,6 +9,7 @@ export function createSolanaStampData(connection: CubidSolanaConnection) {
     address,
     chainType: "solana" as const,
     identity: address,
+    ...(connection.metadata === undefined ? {} : { metadata: connection.metadata }),
     uniquevalue: address,
     walletType: "solana" as const,
   }

--- a/packages/solana/src/index.ts
+++ b/packages/solana/src/index.ts
@@ -1,0 +1,15 @@
+export type CubidSolanaConnection = {
+  address: string
+  metadata?: Record<string, unknown>
+}
+
+export function createSolanaStampData(connection: CubidSolanaConnection) {
+  const address = connection.address.trim()
+  return {
+    address,
+    chainType: "solana" as const,
+    identity: address,
+    uniquevalue: address,
+    walletType: "solana" as const,
+  }
+}

--- a/packages/solana/tsconfig.build.json
+++ b/packages/solana/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/solana/tsconfig.json
+++ b/packages/solana/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/sui/README.md
+++ b/packages/sui/README.md
@@ -1,0 +1,5 @@
+# @cubid/sui
+
+Sui-specific Cubid wallet/stamp helper contracts. Full Sui SDK support remains
+deferred until the chain package takes an explicit SDK dependency.
+

--- a/packages/sui/package.json
+++ b/packages/sui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@cubid/sui",
+  "version": "0.1.0",
+  "description": "Sui wallet and stamp helper contracts for Cubid integrations.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "publishConfig": { "access": "public" },
+  "devDependencies": { "typescript": "5.2.2" },
+  "scripts": {
+    "build": "pnpm exec tsc -p tsconfig.build.json",
+    "lint": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "typecheck": "pnpm exec tsc --noEmit -p tsconfig.json",
+    "test": "echo \"No @cubid/sui tests yet\"",
+    "format": "echo \"No format changes required for @cubid/sui\"",
+    "format:write": "echo \"No format changes required for @cubid/sui\""
+  }
+}

--- a/packages/sui/src/index.ts
+++ b/packages/sui/src/index.ts
@@ -1,0 +1,16 @@
+export type CubidSuiConnection = {
+  address: string
+  network?: string
+}
+
+export function createSuiStampData(connection: CubidSuiConnection) {
+  const address = connection.address.trim()
+  return {
+    address,
+    chainType: "sui" as const,
+    identity: address,
+    network: connection.network,
+    uniquevalue: address,
+    walletType: "sui" as const,
+  }
+}

--- a/packages/sui/tsconfig.build.json
+++ b/packages/sui/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/sui/tsconfig.json
+++ b/packages/sui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/wagmi/README.md
+++ b/packages/wagmi/README.md
@@ -1,0 +1,6 @@
+# @cubid/wagmi
+
+wagmi-facing Cubid integration contracts. This is the only official Cubid
+package that may depend on `wagmi`; the first slice keeps wagmi as a peer so the
+package can define safe boundaries before adding hooks.
+

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@cubid/wagmi",
+  "version": "0.1.0",
+  "description": "wagmi-facing Cubid integration contracts for EVM React apps.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "publishConfig": { "access": "public" },
+  "dependencies": {
+    "@cubid/evm": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18.2.0",
+    "wagmi": ">=2.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "typescript": "5.2.2"
+  },
+  "scripts": {
+    "build": "pnpm --filter @cubid/evm build && node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\" && pnpm exec tsc -p tsconfig.build.json",
+    "lint": "pnpm --filter @cubid/evm build && pnpm exec tsc --noEmit -p tsconfig.json",
+    "typecheck": "pnpm --filter @cubid/evm build && pnpm exec tsc --noEmit -p tsconfig.json",
+    "test": "echo \"No @cubid/wagmi tests yet\"",
+    "format": "echo \"No format changes required for @cubid/wagmi\"",
+    "format:write": "echo \"No format changes required for @cubid/wagmi\""
+  }
+}

--- a/packages/wagmi/src/index.ts
+++ b/packages/wagmi/src/index.ts
@@ -1,0 +1,19 @@
+import { createEvmStampData, type CubidEvmConnection } from "@cubid/evm"
+
+export type CubidWagmiAccount = {
+  address: string
+  chainId?: number
+  connectorId?: string
+}
+
+export function createWagmiEvmStampData(account: CubidWagmiAccount) {
+  const connection: CubidEvmConnection = {
+    address: account.address,
+    chainId: account.chainId,
+    metadata: { connectorId: account.connectorId },
+  }
+  return {
+    ...createEvmStampData(connection),
+    connectorId: account.connectorId,
+  }
+}

--- a/packages/wagmi/src/index.ts
+++ b/packages/wagmi/src/index.ts
@@ -10,7 +10,10 @@ export function createWagmiEvmStampData(account: CubidWagmiAccount) {
   const connection: CubidEvmConnection = {
     address: account.address,
     chainId: account.chainId,
-    metadata: { connectorId: account.connectorId },
+    metadata:
+      account.connectorId === undefined
+        ? undefined
+        : { connectorId: account.connectorId },
   }
   return {
     ...createEvmStampData(connection),

--- a/packages/wagmi/tsconfig.build.json
+++ b/packages/wagmi/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/wagmi/tsconfig.json
+++ b/packages/wagmi/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,12 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/cardano:
+    devDependencies:
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
   packages/claims:
     devDependencies:
       '@types/node':
@@ -594,6 +600,18 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/evm:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.2
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
   packages/identity:
     devDependencies:
       '@types/node':
@@ -606,8 +624,73 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/near:
+    devDependencies:
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
+  packages/react:
+    dependencies:
+      '@cubid/core':
+        specifier: workspace:*
+        version: link:../core
+      react:
+        specifier: '>=18.2.0'
+        version: 18.3.1
+      react-dom:
+        specifier: '>=18.2.0'
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.2
+      '@types/react':
+        specifier: ^18.2.14
+        version: 18.2.48
+      '@types/react-dom':
+        specifier: ^18.2.6
+        version: 18.2.18
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
+  packages/solana:
+    devDependencies:
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
+  packages/sui:
+    devDependencies:
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
   packages/types:
     devDependencies:
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
+  packages/wagmi:
+    dependencies:
+      '@cubid/evm':
+        specifier: workspace:*
+        version: link:../evm
+      react:
+        specifier: '>=18.2.0'
+        version: 18.3.1
+      wagmi:
+        specifier: '>=2.0.0'
+        version: 2.12.17(@react-native-async-storage/async-storage@1.21.0(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.59.13)(@tanstack/react-query@5.59.13(react@18.3.1))(@types/react@18.2.48)(bufferutil@4.0.8)(encoding@0.1.13)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.2.2)(utf-8-validate@5.0.10)(viem@2.21.25(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.2.14
+        version: 18.2.48
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -1507,9 +1590,6 @@ packages:
 
   '@chainsafe/ssz@0.9.4':
     resolution: {integrity: sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==}
-
-  '@coinbase/wallet-sdk@3.9.1':
-    resolution: {integrity: sha512-cGUE8wm1/cMI8irRMVOqbFWYcnNugqCtuy2lnnHfgloBg+GRLs9RsrkOUDMdv/StfUeeKhCDyYudsXXvcL1xIA==}
 
   '@coinbase/wallet-sdk@3.9.3':
     resolution: {integrity: sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==}
@@ -13997,11 +14077,11 @@ packages:
 
   uuid@2.0.1:
     resolution: {integrity: sha512-nWg9+Oa3qD2CQzHIP4qKUqwNfzKn8P0LtFhotaCTFchsV7ZfDhAybeip/HZVeMIpZi9JgY1E3nUlwaCmZT1sEg==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
 
   uuid@3.3.2:
     resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@3.4.0:
@@ -14011,6 +14091,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
@@ -14019,6 +14100,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuidv4@6.2.13:
@@ -16107,20 +16189,6 @@ snapshots:
       '@chainsafe/persistent-merkle-tree': 0.4.2
       case: 1.6.3
 
-  '@coinbase/wallet-sdk@3.9.1':
-    dependencies:
-      bn.js: 5.2.1
-      buffer: 6.0.3
-      clsx: 1.2.1
-      eth-block-tracker: 7.1.0
-      eth-json-rpc-filters: 6.0.1
-      eventemitter3: 5.0.1
-      keccak: 3.0.4
-      preact: 10.24.3
-      sha.js: 2.4.11
-    transitivePeerDependencies:
-      - supports-color
-
   '@coinbase/wallet-sdk@3.9.3':
     dependencies:
       bn.js: 5.2.1
@@ -17210,7 +17278,7 @@ snapshots:
       '@firebase/app-compat': 0.2.42
       '@firebase/component': 0.6.9
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
 
@@ -17245,7 +17313,7 @@ snapshots:
       '@firebase/installations': 0.6.9(@firebase/app@0.10.12)
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/app-check-compat@0.3.15(@firebase/app-compat@0.2.42)(@firebase/app@0.10.12)':
     dependencies:
@@ -17255,7 +17323,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
 
@@ -17295,7 +17363,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/app-compat@0.2.22':
     dependencies:
@@ -17311,7 +17379,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/app-types@0.9.0': {}
 
@@ -17359,7 +17427,7 @@ snapshots:
       '@firebase/auth-types': 0.12.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)
       '@firebase/component': 0.6.9
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
       undici: 6.19.7
     transitivePeerDependencies:
       - '@firebase/app'
@@ -17401,7 +17469,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
       undici: 6.19.7
     optionalDependencies:
       '@react-native-async-storage/async-storage': 1.21.0(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))
@@ -17428,7 +17496,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/database-compat@1.0.1':
     dependencies:
@@ -17446,7 +17514,7 @@ snapshots:
       '@firebase/database-types': 1.0.5
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/database-compat@2.1.3':
     dependencies:
@@ -17489,7 +17557,7 @@ snapshots:
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
       faye-websocket: 0.11.4
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/database@1.1.2':
     dependencies:
@@ -17521,7 +17589,7 @@ snapshots:
       '@firebase/firestore': 4.7.3(@firebase/app@0.10.12)
       '@firebase/firestore-types': 3.0.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
       - '@firebase/app-types'
@@ -17559,7 +17627,7 @@ snapshots:
       '@firebase/webchannel-wrapper': 1.0.1
       '@grpc/grpc-js': 1.9.15
       '@grpc/proto-loader': 0.7.13
-      tslib: 2.7.0
+      tslib: 2.8.1
       undici: 6.19.7
 
   '@firebase/functions-compat@0.3.14(@firebase/app-compat@0.2.42)(@firebase/app@0.10.12)':
@@ -17569,7 +17637,7 @@ snapshots:
       '@firebase/functions': 0.11.8(@firebase/app@0.10.12)
       '@firebase/functions-types': 0.6.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
 
@@ -17610,7 +17678,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/messaging-interop-types': 0.2.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
       undici: 6.19.7
 
   '@firebase/installations-compat@0.2.4(@firebase/app-compat@0.2.22)(@firebase/app-types@0.9.0)(@firebase/app@0.9.22)':
@@ -17632,7 +17700,7 @@ snapshots:
       '@firebase/installations': 0.6.9(@firebase/app@0.10.12)
       '@firebase/installations-types': 0.5.2(@firebase/app-types@0.9.2)
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
       - '@firebase/app-types'
@@ -17659,7 +17727,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/util': 1.10.0
       idb: 7.1.1
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/logger@0.4.0':
     dependencies:
@@ -17679,7 +17747,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/messaging': 0.12.11(@firebase/app@0.10.12)
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
 
@@ -17705,7 +17773,7 @@ snapshots:
       '@firebase/messaging-interop-types': 0.2.2
       '@firebase/util': 1.10.0
       idb: 7.1.1
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/messaging@0.12.4(@firebase/app@0.9.22)':
     dependencies:
@@ -17737,7 +17805,7 @@ snapshots:
       '@firebase/performance': 0.6.9(@firebase/app@0.10.12)
       '@firebase/performance-types': 0.2.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
 
@@ -17761,7 +17829,7 @@ snapshots:
       '@firebase/installations': 0.6.9(@firebase/app@0.10.12)
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/remote-config-compat@0.2.4(@firebase/app-compat@0.2.22)(@firebase/app@0.9.22)':
     dependencies:
@@ -17783,7 +17851,7 @@ snapshots:
       '@firebase/remote-config': 0.4.9(@firebase/app@0.10.12)
       '@firebase/remote-config-types': 0.3.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
 
@@ -17807,7 +17875,7 @@ snapshots:
       '@firebase/installations': 0.6.9(@firebase/app@0.10.12)
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/storage-compat@0.3.12(@firebase/app-compat@0.2.42)(@firebase/app-types@0.9.2)(@firebase/app@0.10.12)':
     dependencies:
@@ -17816,7 +17884,7 @@ snapshots:
       '@firebase/storage': 0.13.2(@firebase/app@0.10.12)
       '@firebase/storage-types': 0.8.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@firebase/app'
       - '@firebase/app-types'
@@ -17859,7 +17927,7 @@ snapshots:
       '@firebase/app': 0.10.12
       '@firebase/component': 0.6.9
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
       undici: 6.19.7
 
   '@firebase/util@1.10.0':
@@ -17882,7 +17950,7 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@firebase/webchannel-wrapper@0.10.3': {}
 
@@ -18858,7 +18926,7 @@ snapshots:
 
   '@metamask/safe-event-emitter@3.1.1': {}
 
-  '@metamask/sdk-communication-layer@0.28.2(cross-fetch@4.0.0(encoding@0.1.13))(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@metamask/sdk-communication-layer@0.28.2(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       bufferutil: 4.0.8
       cross-fetch: 4.0.0(encoding@0.1.13)
@@ -18886,7 +18954,7 @@ snapshots:
     dependencies:
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 16.1.0
-      '@metamask/sdk-communication-layer': 0.28.2(cross-fetch@4.0.0(encoding@0.1.13))(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@metamask/sdk-communication-layer': 0.28.2(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@metamask/sdk-install-modal-web': 0.28.1(i18next@23.11.5)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)
       '@types/dom-screen-wake-lock': 1.0.3
       '@types/uuid': 10.0.0
@@ -18934,8 +19002,8 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.1.0
-      '@noble/hashes': 1.5.0
-      '@scure/base': 1.1.9
+      '@noble/hashes': 1.7.2
+      '@scure/base': 1.2.6
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@8.1.1)
       pony-cause: 2.1.10
@@ -18948,8 +19016,8 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.1.0
-      '@noble/hashes': 1.5.0
-      '@scure/base': 1.1.9
+      '@noble/hashes': 1.7.2
+      '@scure/base': 1.2.6
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@8.1.1)
       pony-cause: 2.1.10
@@ -22725,7 +22793,7 @@ snapshots:
 
   '@wagmi/connectors@3.1.11(@react-native-async-storage/async-storage@1.21.0(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.2.48)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(typescript@5.2.2)(utf-8-validate@5.0.10)(viem@1.21.4(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)':
     dependencies:
-      '@coinbase/wallet-sdk': 3.9.1
+      '@coinbase/wallet-sdk': 3.9.3
       '@safe-global/safe-apps-provider': 0.18.3(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@safe-global/safe-apps-sdk': 8.1.0(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@walletconnect/ethereum-provider': 2.11.0(@react-native-async-storage/async-storage@1.21.0(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.2.48)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)
@@ -23568,7 +23636,7 @@ snapshots:
 
   '@web3-onboard/coinbase@2.2.6(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@coinbase/wallet-sdk': 3.9.1
+      '@coinbase/wallet-sdk': 3.9.3
       '@web3-onboard/common': 2.3.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -30265,7 +30333,7 @@ snapshots:
 
   mlly@1.5.0:
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.16.0
       pathe: 1.1.2
       pkg-types: 1.0.3
       ufo: 1.3.2


### PR DESCRIPTION
## Summary
- Adds the high-level `@cubid/core` server-facing identity sync helpers for downstream apps.
- Ports useful runtime-agnostic SDK ergonomics from the old SDK into the new `@cubid/core` model.
- Adds Deno/Supabase Edge validation and integration docs before publication.
- Adds package foundations for `@cubid/react` and chain-specific SDK packages.

## Objective
Make Cubid easier to consume as external infrastructure by providing a coherent public SDK surface instead of requiring downstream apps to compose legacy Passport routes or local SDK mirrors by hand.

## Changes
- Added `ensureUserByEmail`, normalized `fetchIdentity`, `fetchScore`, `fetchStamps`, and `syncIdentitySnapshot` helpers in `@cubid/core`.
- Added additional runtime-agnostic wrappers for stamps, location, user data, search location, and OTP flows while preserving safe OTP response handling.
- Added Deno validation for `@cubid/core`, CI/publish workflow wiring, and a Next.js plus Supabase Edge integration guide.
- Added `@cubid/react` with profile-completion primitives: phone OTP form, provider connect button, AllowPage URL helpers, callback-state helpers, and credential summary helpers.
- Added publishable package foundations for `@cubid/evm`, `@cubid/solana`, `@cubid/cardano`, `@cubid/sui`, `@cubid/near`, and `@cubid/wagmi`.

## Validation
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck'`
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/react test && pnpm --filter @cubid/react typecheck && pnpm --filter @cubid/react build'`
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/evm test && pnpm --filter @cubid/evm typecheck && pnpm --filter @cubid/evm build'`
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/solana typecheck && pnpm --filter @cubid/solana build && pnpm --filter @cubid/cardano typecheck && pnpm --filter @cubid/cardano build && pnpm --filter @cubid/sui typecheck && pnpm --filter @cubid/sui build'`
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/near typecheck && pnpm --filter @cubid/near build && pnpm --filter @cubid/wagmi typecheck && pnpm --filter @cubid/wagmi build'`
- `npx -p node@24 -c 'node --version && pnpm test'`
- `npx -p node@24 -c 'node --version && pnpm typecheck'`
- `npx -p node@24 -c 'node --version && pnpm build'`

## Reviewer Notes
- Review `@cubid/core` helpers first, then `@cubid/react`, then the chain package shells.
- The chain packages intentionally start lightweight; heavy SDK/signing dependencies are deferred to avoid polluting `@cubid/core` or `@cubid/react`.
- Root build still emits pre-existing Admin/Passport lint warnings and the known Celo contractkit browser `fs` warning.

## Follow-ups
- Configure npm/JSR trusted publishing before any live package release.
- Add richer chain signing hooks/connectors in follow-up package slices.
- Publish the separate E03/E04 actor branch after this E02 SDK branch is reviewed.
