### PR TITLE
[codex] Add actor self-identification model and onboarding

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3286,3 +3286,29 @@ Mark E03 completed after the shared actor self-identification contracts, MCP tru
 #### Follow-up
 
 - publish the branch for review, then consider a later runtime slice for persistence and UI onboarding for agent and organization actors
+
+### session: v111
+
+- timestamp: 2026-04-29T19:10:46Z
+- agent: **OpenAI Codex**
+- branch: **codex/e03-actor-identity-model**
+- head: **`df7761f`**
+- session name: **Start E04 actor onboarding persistence**
+
+#### Objective
+
+Start E04 as the runtime persistence and onboarding slice for human, agent, and organization self-identification, building on the E03 shared actor identity contracts.
+
+#### Actions Taken
+
+- marked `E04` started in `agent-context/todo.md`
+- kept the work on the existing E03 feature branch because this slice is stacked directly on the actor identity model contracts
+- scoped E04 to authenticated Passport persistence, Profile onboarding, and documentation for self-identified actor types rather than full global onboarding redesign
+
+#### Verification
+
+- confirmed the repository was clean before E04 metadata changes
+
+#### Follow-up
+
+- add actor profile persistence, authenticated Passport APIs, Profile UI onboarding, tests, docs, and closeout metadata

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3260,3 +3260,29 @@ Implement shared human, agent, and organization identity contracts with MCP-comp
 #### Follow-up
 
 - commit the E03 implementation, then mark E03 completed with the implementation head
+
+### session: v110
+
+- timestamp: 2026-04-29T18:01:00Z
+- agent: **OpenAI Codex**
+- branch: **codex/e03-actor-identity-model**
+- head: **`7437c4c`**
+- session name: **Close E03 actor identity model**
+
+#### Objective
+
+Mark E03 completed after the shared actor self-identification contracts, MCP trust envelope, claims, docs, and tests landed.
+
+#### Actions Taken
+
+- updated `agent-context/todo.md` with the E03 completion timestamp
+- recorded the implementation commit as the E03 head
+- attached the start, implementation, and closeout session-log references to the todo
+
+#### Verification
+
+- confirmed E03 metadata points at implementation head `7437c4c`
+
+#### Follow-up
+
+- publish the branch for review, then consider a later runtime slice for persistence and UI onboarding for agent and organization actors

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3234,6 +3234,35 @@ Start E03 to add human, agent, and organization self-identification support with
 
 - implement the shared actor identity model, MCP trust response contracts, minimal OIDC claim definitions, docs, tests, and closeout metadata
 
+### session: v118
+
+- timestamp: 2026-04-30T08:45:06Z
+- agent: **OpenAI Codex**
+- branch: **codex/e03-actor-identity-model**
+- head: **`b5e1f0c`**
+- session name: **Address PR 152 actor identity review feedback**
+
+#### Objective
+
+Resolve the actionable Copilot and Codex review comments on PR #152 before continuing the E03/E04 merge flow.
+
+#### Actions Taken
+
+- defaulted agent self-identification to a standalone affiliation when callers omit affiliation metadata
+- renamed misleading actor normalization test wording and added coverage for the standalone default
+- tightened the actor profile migration grant from `all` to explicit service-role DML privileges
+- switched actor profile API route imports to the Passport path alias
+- fixed Profile actor-profile loading and form behavior so authenticated users without Redux email/phone can load profiles, current form selections drive policy copy, and hidden agent affiliation fields are not submitted after relationship switches
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/identity test && pnpm --filter @cubid/identity typecheck && pnpm --filter @cubid/passport test && pnpm --filter @cubid/passport typecheck'`
+- `npx -p node@24 -c 'node --version && pnpm test && pnpm typecheck'`
+
+#### Follow-up
+
+- commit and push the PR review fixes, reply to and resolve review threads, then re-check PR state
+
 ### session: v109
 
 - timestamp: 2026-04-29T18:00:37Z

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3206,3 +3206,30 @@ Resolve the actionable Copilot and Codex review comments on PR #151 before conti
 #### Follow-up
 
 - commit and push the review fixes, comment with the solutions, resolve the PR threads, and recheck CI
+
+### session: v108
+
+- timestamp: 2026-04-29T17:57:47Z
+- agent: **OpenAI Codex**
+- branch: **codex/e03-actor-identity-model**
+- head: **`397c376`**
+- session name: **Start E03 actor identity model**
+
+#### Objective
+
+Start E03 to add human, agent, and organization self-identification support with MCP-compatible trust interfaces while preserving human proof-of-personhood as the primary validation focus.
+
+#### Actions Taken
+
+- created a fresh E03 branch from `dev`
+- marked `E03` started in `agent-context/todo.md`
+- inspected `@cubid/identity`, `@cubid/claims`, OIDC contracts, and existing docs to place the actor model in shared domain packages rather than app-local code
+- locked the implementation direction: humans receive deep validation/scoring; agents and organizations are represented and can claim stamps, but receive limited generic validation by default
+
+#### Verification
+
+- confirmed the branch starts from current `dev` and the repository was clean before E03 metadata changes
+
+#### Follow-up
+
+- implement the shared actor identity model, MCP trust response contracts, minimal OIDC claim definitions, docs, tests, and closeout metadata

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3233,3 +3233,30 @@ Start E03 to add human, agent, and organization self-identification support with
 #### Follow-up
 
 - implement the shared actor identity model, MCP trust response contracts, minimal OIDC claim definitions, docs, tests, and closeout metadata
+
+### session: v109
+
+- timestamp: 2026-04-29T18:00:37Z
+- agent: **OpenAI Codex**
+- branch: **codex/e03-actor-identity-model**
+- head: **`7e305fc`**
+- session name: **Implement E03 actor identity contracts**
+
+#### Objective
+
+Implement shared human, agent, and organization identity contracts with MCP-compatible trust envelopes while keeping deep validation and humanity scoring focused on humans.
+
+#### Actions Taken
+
+- added `@cubid/identity` actor self-identification types, normalization helpers, validation-policy defaults, score/stamp eligibility helpers, and `cubid-mcp-trust:v1` response contracts
+- added tests proving organizations and agents are self-identified, non-human actors are not personhood-score eligible, and MCP trust responses suppress non-human score contribution
+- added actor self-identification claims to `@cubid/claims` under `cubid:claims`
+- documented the actor identity model and aligned the OIDC architecture doc with the E03 shared-contract boundary
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/identity test && pnpm --filter @cubid/identity typecheck && pnpm --filter @cubid/claims test && pnpm --filter @cubid/claims typecheck && pnpm --filter @cubid/identity build && pnpm --filter @cubid/claims build'`
+
+#### Follow-up
+
+- commit the E03 implementation, then mark E03 completed with the implementation head

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3312,3 +3312,35 @@ Start E04 as the runtime persistence and onboarding slice for human, agent, and 
 #### Follow-up
 
 - add actor profile persistence, authenticated Passport APIs, Profile UI onboarding, tests, docs, and closeout metadata
+
+### session: v112
+
+- timestamp: 2026-04-29T19:18:11Z
+- agent: **OpenAI Codex**
+- branch: **codex/e03-actor-identity-model**
+- head: **`26b17c4`**
+- session name: **Implement E04 actor profile persistence and onboarding**
+
+#### Objective
+
+Add the first runtime persistence and Passport onboarding surface for self-identified human, agent, and organization actors.
+
+#### Actions Taken
+
+- added a locked `public.actor_profiles` migration with one service-role-owned profile per Firebase user
+- added authenticated Passport actor profile get/upsert APIs using the shared Passport API baseline
+- added Passport Profile UI for choosing human, agent, or organization identity type with visible trust-policy copy
+- wired Passport to `@cubid/identity` so runtime responses use the E03 validation-policy contracts
+- added Passport route tests for default human profiles, organization persistence, agent affiliation persistence, and contradictory metadata rejection
+- updated the actor identity engineering doc with E04 persistence, API, and onboarding boundaries
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport typecheck'`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/identity test && pnpm --filter @cubid/identity typecheck'`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport build'`
+
+#### Follow-up
+
+- mark E04 completed after the implementation commit lands

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3344,3 +3344,29 @@ Add the first runtime persistence and Passport onboarding surface for self-ident
 #### Follow-up
 
 - mark E04 completed after the implementation commit lands
+
+### session: v113
+
+- timestamp: 2026-04-29T19:18:41Z
+- agent: **OpenAI Codex**
+- branch: **codex/e03-actor-identity-model**
+- head: **`4b42692`**
+- session name: **Close E04 actor onboarding persistence**
+
+#### Objective
+
+Close E04 after actor profile persistence, authenticated Passport APIs, Profile onboarding UI, docs, and tests landed.
+
+#### Actions Taken
+
+- marked `E04` completed in `agent-context/todo.md`
+- recorded implementation head `4b42692`
+- attached the E04 start, implementation, and closeout session-log references
+
+#### Verification
+
+- confirmed the E04 implementation commit exists at `4b42692`
+
+#### Follow-up
+
+- publish the stacked E03/E04 branch for review, or continue with the next identity runtime slice if desired

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -616,11 +616,11 @@ Expand the platform beyond human passports in a way that matches the backgrounde
 
 ### E04. Improve global onboarding, accessibility, and low-friction trust progression
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-04-29T19:10:46Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-04-29T19:18:41Z
 - Feature branch: codex/e03-actor-identity-model
-- Head: df7761f
-- Session-log reference(s): session: v111
+- Head: 4b42692
+- Session-log reference(s): session: v111, session: v112, session: v113
 
 Translate the backgrounder’s product constraints into concrete engineering work. Redesign onboarding and verification journeys so they remain accessible, globally usable, and low-friction for users with limited documentation, limited bandwidth, or limited digital literacy. Establish an accessibility bar of WCAG 2.1 AA across Passport and Admin, including keyboard support, semantic structure, announcement behavior, color contrast, and readable step flows. Replace hard assumptions about phone, email, or wallet availability with progressive trust accumulation so users can start with minimal identity signals and deepen later. This work should include telemetry that measures abandonment at each step without capturing unnecessary personal data. The outcome should be a trust platform that grows identity depth without turning into a heavy KYC product, which is central to the Cubid mission.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -605,12 +605,12 @@ Back the published packages with the DX and compatibility work needed for real e
 
 ### E03. Add agent and organization identity support, including MCP-compatible interfaces
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-04-29T17:57:47Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/e03-actor-identity-model
+- Head: 397c376
+- Session-log reference(s): session: v108
 
 Expand the platform beyond human passports in a way that matches the backgrounder without diluting the human proof-of-personhood core. Define how non-human actors such as agents and organizations are represented, authenticated, disclosed, and clearly labeled so they never masquerade as human identities. Build this into the shared identity domain model, the OIDC subject model where appropriate, and the developer API contracts. Add MCP-compatible integration surfaces so agent systems can query Cubid trust signals and identify themselves through supported protocols. The implementation should preserve app-scoped identity, consent boundaries, and data minimization, while making explicit which signals are human-only, agent-only, or organization-only. This todo gives Cubid a broader protocol footprint while staying honest about what personhood and trust mean in different actor classes.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -605,12 +605,12 @@ Back the published packages with the DX and compatibility work needed for real e
 
 ### E03. Add agent and organization identity support, including MCP-compatible interfaces
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-04-29T17:57:47Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-04-29T18:01:00Z
 - Feature branch: codex/e03-actor-identity-model
-- Head: 397c376
-- Session-log reference(s): session: v108
+- Head: 7437c4c
+- Session-log reference(s): session: v108, session: v109, session: v110
 
 Expand the platform beyond human passports in a way that matches the backgrounder without diluting the human proof-of-personhood core. Define how non-human actors such as agents and organizations are represented, authenticated, disclosed, and clearly labeled so they never masquerade as human identities. Build this into the shared identity domain model, the OIDC subject model where appropriate, and the developer API contracts. Add MCP-compatible integration surfaces so agent systems can query Cubid trust signals and identify themselves through supported protocols. The implementation should preserve app-scoped identity, consent boundaries, and data minimization, while making explicit which signals are human-only, agent-only, or organization-only. This todo gives Cubid a broader protocol footprint while staying honest about what personhood and trust mean in different actor classes.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -616,11 +616,11 @@ Expand the platform beyond human passports in a way that matches the backgrounde
 
 ### E04. Improve global onboarding, accessibility, and low-friction trust progression
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-04-29T19:10:46Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/e03-actor-identity-model
+- Head: df7761f
+- Session-log reference(s): session: v111
 
 Translate the backgrounder’s product constraints into concrete engineering work. Redesign onboarding and verification journeys so they remain accessible, globally usable, and low-friction for users with limited documentation, limited bandwidth, or limited digital literacy. Establish an accessibility bar of WCAG 2.1 AA across Passport and Admin, including keyboard support, semantic structure, announcement behavior, color contrast, and readable step flows. Replace hard assumptions about phone, email, or wallet availability with progressive trust accumulation so users can start with minimal identity signals and deepen later. This work should include telemetry that measures abandonment at each step without capturing unnecessary personal data. The outcome should be a trust platform that grows identity depth without turning into a heavy KYC product, which is central to the Cubid mission.

--- a/apps/passport/components/profile/index.tsx
+++ b/apps/passport/components/profile/index.tsx
@@ -125,6 +125,30 @@ const agentAffiliationLabels = {
   standalone: "Standalone agent",
 }
 
+const actorValidationPolicies = {
+  agent: {
+    description:
+      "Agents self-identify and may claim stamps, but do not receive bespoke personhood validation by default.",
+    personhoodScoreEligible: false,
+    stampClaimEligible: true,
+    validationIntensity: "limited_generic",
+  },
+  human: {
+    description:
+      "Humans are the primary proof-of-personhood subject and receive deep validation and scoring.",
+    personhoodScoreEligible: true,
+    stampClaimEligible: true,
+    validationIntensity: "deep_human",
+  },
+  organization: {
+    description:
+      "Organizations include teams, groups, networks, communities, collectives, and formal entities; validation is generic by default.",
+    personhoodScoreEligible: false,
+    stampClaimEligible: true,
+    validationIntensity: "limited_generic",
+  },
+}
+
 const formatList = (values: string[]) => {
   if (!values.length) {
     return "None"
@@ -301,8 +325,7 @@ export const Profile = () => {
   )
 
   const fetchActorProfile = useCallback(async () => {
-    if (!email && !phone) {
-      setActorProfile(null)
+    if (!firebase.auth().currentUser) {
       return
     }
 
@@ -321,7 +344,7 @@ export const Profile = () => {
     } finally {
       setActorProfileLoading(false)
     }
-  }, [applyActorProfileFormState, email, phone, getOidcAuthHeaders])
+  }, [applyActorProfileFormState, getOidcAuthHeaders])
 
   useEffect(() => {
     fetchActorProfile()
@@ -331,17 +354,24 @@ export const Profile = () => {
     setActorProfileSaving(true)
     try {
       const headers = await getOidcAuthHeaders()
+      const agentAffiliation =
+        actorType === "agent"
+          ? {
+              affiliationType: agentAffiliationType,
+              description: agentAffiliationDescription || null,
+              organizationSubjectKey:
+                agentAffiliationType === "organization_supported"
+                  ? agentOrganizationSubjectKey || null
+                  : null,
+              supportedHumanSubjectKey:
+                agentAffiliationType === "human_supported"
+                  ? agentSupportedHumanSubjectKey || null
+                  : null,
+            }
+          : null
       const payload = {
         actorType,
-        agentAffiliation:
-          actorType === "agent"
-            ? {
-                affiliationType: agentAffiliationType,
-                description: agentAffiliationDescription || null,
-                organizationSubjectKey: agentOrganizationSubjectKey || null,
-                supportedHumanSubjectKey: agentSupportedHumanSubjectKey || null,
-              }
-            : null,
+        agentAffiliation,
         displayName: actorDisplayName || null,
         organizationKind: actorType === "organization" ? organizationKind : null,
       }
@@ -543,6 +573,8 @@ export const Profile = () => {
     [fetchOidcConsents, getOidcAuthHeaders]
   )
 
+  const selectedActorPolicy = actorValidationPolicies[actorType]
+
   return (
     <div className="p-3">
       <h1 className="mb-2 text-3xl font-semibold">Profile</h1>
@@ -693,7 +725,11 @@ export const Profile = () => {
                     <p className="text-sm font-medium">Agent relationship</p>
                     <Select
                       value={agentAffiliationType}
-                      onValueChange={setAgentAffiliationType}
+                      onValueChange={(value) => {
+                        setAgentAffiliationType(value)
+                        setAgentSupportedHumanSubjectKey("")
+                        setAgentOrganizationSubjectKey("")
+                      }}
                     >
                       <SelectTrigger aria-label="Agent relationship">
                         <SelectValue placeholder="Choose relationship" />
@@ -766,27 +802,24 @@ export const Profile = () => {
             </div>
             <div className="mt-4 rounded-lg border bg-muted/30 p-3 text-sm">
               <p className="font-semibold">
-                {actorTypeLabels[actorProfile?.actorType ?? actorType]} policy
+                {actorTypeLabels[actorType]} policy
               </p>
               <p className="mt-1 text-muted-foreground">
-                {actorProfile?.validationPolicy?.description ??
-                  "Save your identity type to see its trust policy."}
+                {selectedActorPolicy.description}
               </p>
               <div className="mt-3 grid gap-2 md:grid-cols-3">
                 <span className="rounded-full bg-background px-3 py-2">
-                  Validation:{" "}
-                  {actorProfile?.validationPolicy?.validationIntensity ??
-                    "pending"}
+                  Validation: {selectedActorPolicy.validationIntensity}
                 </span>
                 <span className="rounded-full bg-background px-3 py-2">
                   Personhood score:{" "}
-                  {actorProfile?.validationPolicy?.personhoodScoreEligible
+                  {selectedActorPolicy.personhoodScoreEligible
                     ? "eligible"
                     : "not eligible"}
                 </span>
                 <span className="rounded-full bg-background px-3 py-2">
                   Stamp claims:{" "}
-                  {actorProfile?.validationPolicy?.stampClaimEligible
+                  {selectedActorPolicy.stampClaimEligible
                     ? "available"
                     : "not available"}
                 </span>

--- a/apps/passport/components/profile/index.tsx
+++ b/apps/passport/components/profile/index.tsx
@@ -74,6 +74,57 @@ type PasskeyDeviceSummary = {
   updatedAt: string
 }
 
+type ActorProfileSummary = {
+  actorType: "human" | "agent" | "organization"
+  agentAffiliation: {
+    affiliationType: "standalone" | "human_supported" | "organization_supported"
+    description?: string | null
+    organizationSubjectKey?: string | null
+    supportedHumanSubjectKey?: string | null
+  } | null
+  createdAt: string | null
+  displayName: string | null
+  organizationKind:
+    | "formal_organization"
+    | "team"
+    | "group"
+    | "network"
+    | "community"
+    | "collective"
+    | "other"
+    | null
+  updatedAt: string | null
+  validationPolicy: {
+    description: string
+    personhoodScoreEligible: boolean
+    socialStampConflictPrevention: boolean
+    stampClaimEligible: boolean
+    validationIntensity: "deep_human" | "limited_generic" | "none"
+  }
+}
+
+const actorTypeLabels = {
+  agent: "Agent",
+  human: "Human",
+  organization: "Organization",
+}
+
+const organizationKindLabels = {
+  collective: "Collective",
+  community: "Community",
+  formal_organization: "Formal organization",
+  group: "Group",
+  network: "Network",
+  other: "Other",
+  team: "Team",
+}
+
+const agentAffiliationLabels = {
+  human_supported: "Supports one human",
+  organization_supported: "Belongs to an organization",
+  standalone: "Standalone agent",
+}
+
 const formatList = (values: string[]) => {
   if (!values.length) {
     return "None"
@@ -110,6 +161,26 @@ export const Profile = () => {
   const [revokingConsentId, setRevokingConsentId] = useState<string | null>(
     null
   )
+  const [actorProfile, setActorProfile] = useState<ActorProfileSummary | null>(
+    null
+  )
+  const [actorProfileLoading, setActorProfileLoading] = useState(false)
+  const [actorProfileSaving, setActorProfileSaving] = useState(false)
+  const [actorType, setActorType] = useState<
+    "human" | "agent" | "organization"
+  >("human")
+  const [actorDisplayName, setActorDisplayName] = useState("")
+  const [organizationKind, setOrganizationKind] =
+    useState<NonNullable<ActorProfileSummary["organizationKind"]>>("other")
+  const [agentAffiliationType, setAgentAffiliationType] = useState<
+    NonNullable<ActorProfileSummary["agentAffiliation"]>["affiliationType"]
+  >("standalone")
+  const [agentSupportedHumanSubjectKey, setAgentSupportedHumanSubjectKey] =
+    useState("")
+  const [agentOrganizationSubjectKey, setAgentOrganizationSubjectKey] =
+    useState("")
+  const [agentAffiliationDescription, setAgentAffiliationDescription] =
+    useState("")
 
   const fetchStamps = useCallback(async () => {
     if (email) {
@@ -206,6 +277,100 @@ export const Profile = () => {
       Authorization: `Bearer ${token}`,
     }
   }, [])
+
+  const applyActorProfileFormState = useCallback(
+    (profile: ActorProfileSummary) => {
+      setActorProfile(profile)
+      setActorType(profile.actorType)
+      setActorDisplayName(profile.displayName ?? "")
+      setOrganizationKind(profile.organizationKind ?? "other")
+      setAgentAffiliationType(
+        profile.agentAffiliation?.affiliationType ?? "standalone"
+      )
+      setAgentSupportedHumanSubjectKey(
+        profile.agentAffiliation?.supportedHumanSubjectKey ?? ""
+      )
+      setAgentOrganizationSubjectKey(
+        profile.agentAffiliation?.organizationSubjectKey ?? ""
+      )
+      setAgentAffiliationDescription(
+        profile.agentAffiliation?.description ?? ""
+      )
+    },
+    []
+  )
+
+  const fetchActorProfile = useCallback(async () => {
+    if (!email && !phone) {
+      setActorProfile(null)
+      return
+    }
+
+    setActorProfileLoading(true)
+    try {
+      const headers = await getOidcAuthHeaders()
+      const { data } = await axios.post<{ data: ActorProfileSummary }>(
+        "/api/actors/profile/get",
+        {},
+        { headers }
+      )
+      applyActorProfileFormState(data.data)
+    } catch (error) {
+      console.error(error)
+      toast.error("Failed to load identity type")
+    } finally {
+      setActorProfileLoading(false)
+    }
+  }, [applyActorProfileFormState, email, phone, getOidcAuthHeaders])
+
+  useEffect(() => {
+    fetchActorProfile()
+  }, [fetchActorProfile])
+
+  const saveActorProfile = useCallback(async () => {
+    setActorProfileSaving(true)
+    try {
+      const headers = await getOidcAuthHeaders()
+      const payload = {
+        actorType,
+        agentAffiliation:
+          actorType === "agent"
+            ? {
+                affiliationType: agentAffiliationType,
+                description: agentAffiliationDescription || null,
+                organizationSubjectKey: agentOrganizationSubjectKey || null,
+                supportedHumanSubjectKey: agentSupportedHumanSubjectKey || null,
+              }
+            : null,
+        displayName: actorDisplayName || null,
+        organizationKind: actorType === "organization" ? organizationKind : null,
+      }
+      const { data } = await axios.post<{ data: ActorProfileSummary }>(
+        "/api/actors/profile/upsert",
+        payload,
+        { headers }
+      )
+      applyActorProfileFormState(data.data)
+      toast.success("Identity type saved")
+    } catch (error: any) {
+      console.error(error)
+      toast.error(
+        error?.response?.data?.error?.message ?? "Failed to save identity type"
+      )
+    } finally {
+      setActorProfileSaving(false)
+    }
+  }, [
+    actorDisplayName,
+    actorType,
+    agentAffiliationDescription,
+    agentAffiliationType,
+    agentOrganizationSubjectKey,
+    agentSupportedHumanSubjectKey,
+    applyActorProfileFormState,
+    getOidcAuthHeaders,
+    organizationKind,
+  ])
 
   const fetchPasskeyDevices = useCallback(async () => {
     if (!email && !phone) {
@@ -459,6 +624,196 @@ export const Profile = () => {
                 <SelectItem value="sp">Spanish</SelectItem>
               </SelectContent>
             </Select>
+          </CardContent>
+        </Card>
+
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>Identity type</CardTitle>
+            <CardDescription>
+              Tell Cubid whether this account represents a human, an agent, or
+              an organization. Humans receive the deepest proof-of-personhood
+              scoring; agents and organizations can still claim stamps so those
+              accounts are not double-counted for human scores.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label className="text-sm font-medium" htmlFor="actor-display-name">
+                  Display name
+                </label>
+                <Input
+                  id="actor-display-name"
+                  value={actorDisplayName}
+                  onChange={(event) => setActorDisplayName(event.target.value)}
+                  placeholder="Name shown in Cubid trust contexts"
+                />
+              </div>
+              <div>
+                <p className="text-sm font-medium">Account represents</p>
+                <Select value={actorType} onValueChange={setActorType}>
+                  <SelectTrigger aria-label="Account represents">
+                    <SelectValue placeholder="Choose identity type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(actorTypeLabels).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {actorType === "organization" && (
+                <div>
+                  <p className="text-sm font-medium">Organization kind</p>
+                  <Select
+                    value={organizationKind}
+                    onValueChange={setOrganizationKind}
+                  >
+                    <SelectTrigger aria-label="Organization kind">
+                      <SelectValue placeholder="Choose organization kind" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(organizationKindLabels).map(
+                        ([value, label]) => (
+                          <SelectItem key={value} value={value}>
+                            {label}
+                          </SelectItem>
+                        )
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+              {actorType === "agent" && (
+                <>
+                  <div>
+                    <p className="text-sm font-medium">Agent relationship</p>
+                    <Select
+                      value={agentAffiliationType}
+                      onValueChange={setAgentAffiliationType}
+                    >
+                      <SelectTrigger aria-label="Agent relationship">
+                        <SelectValue placeholder="Choose relationship" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(agentAffiliationLabels).map(
+                          ([value, label]) => (
+                            <SelectItem key={value} value={value}>
+                              {label}
+                            </SelectItem>
+                          )
+                        )}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  {agentAffiliationType === "human_supported" && (
+                    <div>
+                      <label
+                        className="text-sm font-medium"
+                        htmlFor="agent-human-subject"
+                      >
+                        Supported human reference
+                      </label>
+                      <Input
+                        id="agent-human-subject"
+                        value={agentSupportedHumanSubjectKey}
+                        onChange={(event) =>
+                          setAgentSupportedHumanSubjectKey(event.target.value)
+                        }
+                        placeholder="Optional human subject reference"
+                      />
+                    </div>
+                  )}
+                  {agentAffiliationType === "organization_supported" && (
+                    <div>
+                      <label
+                        className="text-sm font-medium"
+                        htmlFor="agent-organization-subject"
+                      >
+                        Organization reference
+                      </label>
+                      <Input
+                        id="agent-organization-subject"
+                        value={agentOrganizationSubjectKey}
+                        onChange={(event) =>
+                          setAgentOrganizationSubjectKey(event.target.value)
+                        }
+                        placeholder="Optional organization reference"
+                      />
+                    </div>
+                  )}
+                  <div className="md:col-span-2">
+                    <label
+                      className="text-sm font-medium"
+                      htmlFor="agent-affiliation-description"
+                    >
+                      Relationship note
+                    </label>
+                    <Input
+                      id="agent-affiliation-description"
+                      value={agentAffiliationDescription}
+                      onChange={(event) =>
+                        setAgentAffiliationDescription(event.target.value)
+                      }
+                      placeholder="Optional context for this agent"
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+            <div className="mt-4 rounded-lg border bg-muted/30 p-3 text-sm">
+              <p className="font-semibold">
+                {actorTypeLabels[actorProfile?.actorType ?? actorType]} policy
+              </p>
+              <p className="mt-1 text-muted-foreground">
+                {actorProfile?.validationPolicy?.description ??
+                  "Save your identity type to see its trust policy."}
+              </p>
+              <div className="mt-3 grid gap-2 md:grid-cols-3">
+                <span className="rounded-full bg-background px-3 py-2">
+                  Validation:{" "}
+                  {actorProfile?.validationPolicy?.validationIntensity ??
+                    "pending"}
+                </span>
+                <span className="rounded-full bg-background px-3 py-2">
+                  Personhood score:{" "}
+                  {actorProfile?.validationPolicy?.personhoodScoreEligible
+                    ? "eligible"
+                    : "not eligible"}
+                </span>
+                <span className="rounded-full bg-background px-3 py-2">
+                  Stamp claims:{" "}
+                  {actorProfile?.validationPolicy?.stampClaimEligible
+                    ? "available"
+                    : "not available"}
+                </span>
+              </div>
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <Button
+                disabled={actorProfileSaving || actorProfileLoading}
+                onClick={saveActorProfile}
+              >
+                {actorProfileSaving ? "Saving..." : "Save identity type"}
+              </Button>
+              <Button
+                disabled={actorProfileLoading}
+                onClick={fetchActorProfile}
+                variant="outline"
+              >
+                {actorProfileLoading ? "Refreshing..." : "Refresh"}
+              </Button>
+              <p className="text-xs text-muted-foreground" aria-live="polite">
+                {actorProfile?.updatedAt
+                  ? `Last updated ${dayjs(actorProfile.updatedAt).format(
+                      "YYYY-MM-DD HH:mm"
+                    )}`
+                  : "No saved identity type yet."}
+              </p>
+            </div>
           </CardContent>
         </Card>
 

--- a/apps/passport/lib/server/actorProfiles.ts
+++ b/apps/passport/lib/server/actorProfiles.ts
@@ -1,0 +1,161 @@
+import { ApiSecurityError } from "@cubid/auth/server"
+import {
+  getActorValidationPolicy,
+  normalizeActorSelfIdentification,
+  type CubidActorSelfIdentification,
+  type CubidActorSelfIdentificationInput,
+} from "@cubid/identity"
+
+import type { PassportUserContext } from "./passportApi"
+
+type ActorProfileRow = {
+  actor_type: string
+  affiliation_description?: string | null
+  created_at?: string | null
+  display_name?: string | null
+  organization_kind?: string | null
+  organization_subject_key?: string | null
+  supported_human_subject_key?: string | null
+  updated_at?: string | null
+  agent_affiliation_type?: string | null
+}
+
+export type PassportActorProfileResponse = {
+  actorType: CubidActorSelfIdentification["actorType"]
+  agentAffiliation: CubidActorSelfIdentification["agentAffiliation"]
+  createdAt: string | null
+  displayName: string | null
+  organizationKind: CubidActorSelfIdentification["organizationKind"]
+  updatedAt: string | null
+  validationPolicy: ReturnType<typeof getActorValidationPolicy>
+}
+
+const toApiSecurityError = (error: unknown) => {
+  if (error instanceof ApiSecurityError) {
+    return error
+  }
+
+  if (error instanceof Error) {
+    return new ApiSecurityError(400, "invalid_request", error.message)
+  }
+
+  return new ApiSecurityError(
+    400,
+    "invalid_request",
+    "Actor self-identification is invalid."
+  )
+}
+
+const toResponse = (
+  selfIdentification: CubidActorSelfIdentification,
+  row?: Pick<ActorProfileRow, "created_at" | "updated_at"> | null
+): PassportActorProfileResponse => ({
+  actorType: selfIdentification.actorType,
+  agentAffiliation: selfIdentification.agentAffiliation,
+  createdAt: row?.created_at ?? null,
+  displayName: selfIdentification.displayName,
+  organizationKind: selfIdentification.organizationKind,
+  updatedAt: row?.updated_at ?? null,
+  validationPolicy: getActorValidationPolicy(selfIdentification.actorType),
+})
+
+const rowToInput = (row: ActorProfileRow): CubidActorSelfIdentificationInput => ({
+  actorType: row.actor_type as CubidActorSelfIdentificationInput["actorType"],
+  agentAffiliation: row.agent_affiliation_type
+    ? {
+        affiliationType:
+          row.agent_affiliation_type as NonNullable<
+            CubidActorSelfIdentificationInput["agentAffiliation"]
+          >["affiliationType"],
+        description: row.affiliation_description ?? null,
+        organizationSubjectKey: row.organization_subject_key ?? null,
+        supportedHumanSubjectKey: row.supported_human_subject_key ?? null,
+      }
+    : null,
+  displayName: row.display_name ?? null,
+  organizationKind:
+    row.organization_kind as CubidActorSelfIdentificationInput["organizationKind"],
+})
+
+export const getPassportActorProfile = async (
+  context: PassportUserContext
+): Promise<PassportActorProfileResponse> => {
+  const { data, error } = await context.supabase
+    .from("actor_profiles")
+    .select("*")
+    .eq("firebase_uid", context.firebaseToken.uid)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!data) {
+    const fallback = normalizeActorSelfIdentification({
+      actorType: "human",
+      displayName:
+        (typeof context.firebaseToken.name === "string"
+          ? context.firebaseToken.name
+          : null) ??
+        (typeof context.firebaseToken.email === "string"
+          ? context.firebaseToken.email
+          : null),
+    })
+    return toResponse(fallback, null)
+  }
+
+  try {
+    return toResponse(
+      normalizeActorSelfIdentification(rowToInput(data as ActorProfileRow)),
+      data as ActorProfileRow
+    )
+  } catch (error) {
+    throw toApiSecurityError(error)
+  }
+}
+
+export const upsertPassportActorProfile = async (
+  context: PassportUserContext,
+  input: CubidActorSelfIdentificationInput
+): Promise<PassportActorProfileResponse> => {
+  let normalized: CubidActorSelfIdentification
+
+  try {
+    normalized = normalizeActorSelfIdentification(input)
+  } catch (error) {
+    throw toApiSecurityError(error)
+  }
+
+  const now = new Date().toISOString()
+  const row = {
+    actor_type: normalized.actorType,
+    affiliation_description:
+      normalized.agentAffiliation?.description?.trim() || null,
+    display_name: normalized.displayName,
+    firebase_uid: context.firebaseToken.uid,
+    organization_kind: normalized.organizationKind,
+    organization_subject_key:
+      normalized.agentAffiliation?.organizationSubjectKey?.trim() || null,
+    supported_human_subject_key:
+      normalized.agentAffiliation?.supportedHumanSubjectKey?.trim() || null,
+    agent_affiliation_type:
+      normalized.agentAffiliation?.affiliationType ?? null,
+    updated_at: now,
+  }
+
+  const { data, error } = await context.supabase
+    .from("actor_profiles")
+    .upsert(row, { onConflict: "firebase_uid" })
+    .select("*")
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return toResponse(normalized, (data as ActorProfileRow | null) ?? {
+    created_at: now,
+    updated_at: now,
+  })
+}
+

--- a/apps/passport/package.json
+++ b/apps/passport/package.json
@@ -20,6 +20,7 @@
     "@celo/contractkit": "^5.0.4",
     "@cubid/auth": "workspace:*",
     "@cubid/config": "workspace:*",
+    "@cubid/identity": "workspace:*",
     "@cubid/types": "workspace:*",
     "@ethersproject/bignumber": "^5.7.0",
     "@farcaster/auth-kit": "^0.6.0",

--- a/apps/passport/pages/api/actors/profile/get.ts
+++ b/apps/passport/pages/api/actors/profile/get.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import { getPassportActorProfile } from "../../../../lib/server/actorProfiles"
+import { handlePassportRoute } from "../../../../lib/server/passportApi"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  await handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      allowedMethods: ["POST"],
+      rateLimitGroup: "passport_user_read",
+      route: "passport.actors.profile.get",
+    },
+    async ({ context }) => {
+      const profile = await getPassportActorProfile(context)
+      res.status(200).json({ data: profile })
+    }
+  )
+}
+

--- a/apps/passport/pages/api/actors/profile/get.ts
+++ b/apps/passport/pages/api/actors/profile/get.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 
-import { getPassportActorProfile } from "../../../../lib/server/actorProfiles"
-import { handlePassportRoute } from "../../../../lib/server/passportApi"
+import { getPassportActorProfile } from "@/lib/server/actorProfiles"
+import { handlePassportRoute } from "@/lib/server/passportApi"
 
 export default async function handler(
   req: NextApiRequest,
@@ -22,4 +22,3 @@ export default async function handler(
     }
   )
 }
-

--- a/apps/passport/pages/api/actors/profile/upsert.ts
+++ b/apps/passport/pages/api/actors/profile/upsert.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import { upsertPassportActorProfile } from "../../../../lib/server/actorProfiles"
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "../../../../lib/server/passportApi"
+
+const actorProfileSchema = passportSchemas.z.object({
+  actorType: passportSchemas.z.enum(["human", "agent", "organization"]),
+  agentAffiliation: passportSchemas.z
+    .object({
+      affiliationType: passportSchemas.z.enum([
+        "standalone",
+        "human_supported",
+        "organization_supported",
+      ]),
+      description: passportSchemas.z.string().max(500).optional().nullable(),
+      organizationSubjectKey: passportSchemas.z.string().max(200).optional().nullable(),
+      supportedHumanSubjectKey: passportSchemas.z.string().max(200).optional().nullable(),
+    })
+    .optional()
+    .nullable(),
+  displayName: passportSchemas.z.string().max(160).optional().nullable(),
+  organizationKind: passportSchemas.z
+    .enum([
+      "formal_organization",
+      "team",
+      "group",
+      "network",
+      "community",
+      "collective",
+      "other",
+    ])
+    .optional()
+    .nullable(),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  await handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      allowedMethods: ["POST"],
+      bodySchema: actorProfileSchema,
+      rateLimitGroup: "passport_user_mutation",
+      route: "passport.actors.profile.upsert",
+    },
+    async ({ body, context }) => {
+      const profile = await upsertPassportActorProfile(context, body)
+      res.status(200).json({ data: profile })
+    }
+  )
+}
+

--- a/apps/passport/pages/api/actors/profile/upsert.ts
+++ b/apps/passport/pages/api/actors/profile/upsert.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 
-import { upsertPassportActorProfile } from "../../../../lib/server/actorProfiles"
+import { upsertPassportActorProfile } from "@/lib/server/actorProfiles"
 import {
   handlePassportRoute,
   passportSchemas,
-} from "../../../../lib/server/passportApi"
+} from "@/lib/server/passportApi"
 
 const actorProfileSchema = passportSchemas.z.object({
   actorType: passportSchemas.z.enum(["human", "agent", "organization"]),
@@ -56,4 +56,3 @@ export default async function handler(
     }
   )
 }
-

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -32,6 +32,7 @@ type DappUserRow = {
 }
 
 export class MockPassportSupabase {
+  readonly actorProfiles = new Map<string, Record<string, unknown>>()
   readonly buckets = new Map<string, BucketRow>()
   readonly dappApiKeys = new Map<string, DappApiKeyRow>()
   readonly dappUserAccounts: Array<Record<string, unknown>> = []
@@ -168,6 +169,44 @@ export class MockPassportSupabase {
         insert: async (row: Record<string, unknown>) => {
           this.eventInserts.push(row)
           return { error: null }
+        },
+      }
+    }
+
+    if (table === "actor_profiles") {
+      return {
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            maybeSingle: async () => {
+              const row =
+                this.actorProfiles.get(String(filters.firebase_uid)) ?? null
+              return { data: row, error: null }
+            },
+          }
+          return query
+        },
+        upsert: (row: Record<string, unknown>) => {
+          const now = new Date().toISOString()
+          const firebaseUid = String(row.firebase_uid)
+          const existing = this.actorProfiles.get(firebaseUid)
+          const stored = {
+            created_at: existing?.created_at ?? now,
+            id: existing?.id ?? `actor_profile_${this.actorProfiles.size + 1}`,
+            ...existing,
+            ...row,
+            updated_at: row.updated_at ?? now,
+          }
+          this.actorProfiles.set(firebaseUid, stored)
+          return {
+            select: () => ({
+              maybeSingle: async () => ({ data: stored, error: null }),
+            }),
+          }
         },
       }
     }

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -3,6 +3,8 @@ import test from "node:test"
 
 import { hashDappApiKey } from "@cubid/auth/server"
 
+import actorProfileGetHandler from "../pages/api/actors/profile/get"
+import actorProfileUpsertHandler from "../pages/api/actors/profile/upsert"
 import consentListHandler from "../pages/api/oidc/consents/list"
 import supabaseSelectHandler from "../pages/api/supabase/select"
 import sendOtpHandler from "../pages/api/twillio/send-otp"
@@ -60,6 +62,17 @@ const addDappAuth = (supabase: MockPassportSupabase) => {
   return apiKey
 }
 
+const addFirebaseUserAuth = () => {
+  setPassportFirebaseAdminAuthForTests({
+    verifyIdToken: async () =>
+      ({
+        email: "person@example.com",
+        name: "Test Person",
+        uid: "firebase_actor_123",
+      }) as never,
+  })
+}
+
 test("legacy Passport Supabase select endpoint is hard-disabled with a request id", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
@@ -110,6 +123,135 @@ test("Passport OIDC consent list uses the shared user baseline for missing beare
       requestId: res.headers["x-request-id"],
     },
   })
+})
+
+test("Passport actor profile get defaults signed-in users to human", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+
+  const req = createApiRequest({
+    body: {},
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/actors/profile/get",
+  })
+  const res = createApiResponse()
+
+  await actorProfileGetHandler(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.headers["x-request-id"]?.startsWith("passport_"), true)
+  const data = (res.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(data.actorType, "human")
+  assert.equal(data.displayName, "Test Person")
+  assert.equal(
+    (data.validationPolicy as Record<string, unknown>).personhoodScoreEligible,
+    true
+  )
+})
+
+test("Passport actor profile upsert persists organization self-identification", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+
+  const req = createApiRequest({
+    body: {
+      actorType: "organization",
+      displayName: "Garden Network",
+      organizationKind: "network",
+    },
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/actors/profile/upsert",
+  })
+  const res = createApiResponse()
+
+  await actorProfileUpsertHandler(req, res)
+
+  assert.equal(res.statusCode, 200)
+  const data = (res.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(data.actorType, "organization")
+  assert.equal(data.organizationKind, "network")
+  assert.equal(
+    (data.validationPolicy as Record<string, unknown>).personhoodScoreEligible,
+    false
+  )
+  const stored = supabase.actorProfiles.get("firebase_actor_123")
+  assert.equal(stored?.actor_type, "organization")
+  assert.equal(stored?.organization_kind, "network")
+  assert.equal(stored?.firebase_uid, "firebase_actor_123")
+})
+
+test("Passport actor profile upsert persists agent affiliation without score eligibility", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+
+  const req = createApiRequest({
+    body: {
+      actorType: "agent",
+      agentAffiliation: {
+        affiliationType: "human_supported",
+        description: "Scheduling assistant",
+        supportedHumanSubjectKey: "human_subject_reference",
+      },
+      displayName: "Scheduling Agent",
+    },
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/actors/profile/upsert",
+  })
+  const res = createApiResponse()
+
+  await actorProfileUpsertHandler(req, res)
+
+  assert.equal(res.statusCode, 200)
+  const data = (res.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(data.actorType, "agent")
+  assert.equal(
+    (data.agentAffiliation as Record<string, unknown>).affiliationType,
+    "human_supported"
+  )
+  assert.equal(
+    (data.validationPolicy as Record<string, unknown>).personhoodScoreEligible,
+    false
+  )
+  const stored = supabase.actorProfiles.get("firebase_actor_123")
+  assert.equal(stored?.agent_affiliation_type, "human_supported")
+  assert.equal(stored?.supported_human_subject_key, "human_subject_reference")
+})
+
+test("Passport actor profile rejects contradictory self-identification", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+
+  const req = createApiRequest({
+    body: {
+      actorType: "human",
+      organizationKind: "team",
+    },
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/actors/profile/upsert",
+  })
+  const res = createApiResponse()
+
+  await actorProfileUpsertHandler(req, res)
+
+  assert.equal(res.statusCode, 400)
+  assert.equal((res.body as { error: { code: string } }).error.code, "invalid_request")
+  assert.equal(supabase.actorProfiles.size, 0)
 })
 
 test("Passport OTP send rejects malformed payloads with the shared envelope", async () => {

--- a/apps/passport/tsconfig.json
+++ b/apps/passport/tsconfig.json
@@ -11,6 +11,9 @@
       ],
       "@cubid/config": [
         "../../packages/config/src/index.ts"
+      ],
+      "@cubid/identity": [
+        "../../packages/identity/src/index.ts"
       ]
     },
     "plugins": [

--- a/docs/engineering/actor-identity-model.md
+++ b/docs/engineering/actor-identity-model.md
@@ -63,11 +63,37 @@ it supports a human, but that does not make the agent human or grant the agent a
 human score. Applications should display actor type clearly whenever they
 surface Cubid trust results.
 
+## Runtime Persistence And Onboarding
+
+E04 adds the first runtime persistence layer for actor self-identification.
+Passport stores one authenticated actor profile per Firebase user in
+`public.actor_profiles`, written only through service-role-backed Passport API
+routes. The table is not directly accessible to `anon`, `authenticated`, or
+browser clients.
+
+The Profile page now includes an `Identity type` card where signed-in users can
+self-identify as a human, agent, or organization. The card explains the default
+validation posture inline:
+
+- humans are eligible for personhood scoring and deeper validation
+- agents can be standalone, human-supported, or organization-supported
+- organizations can represent formal organizations, teams, groups, networks,
+  communities, collectives, or other loosely organized actors
+- non-human actors may claim stamps to prevent double-counting, but those stamps
+  do not contribute to a human score by default
+
+The Passport API surface is:
+
+- `POST /api/actors/profile/get`
+- `POST /api/actors/profile/upsert`
+
+Both routes require a Firebase bearer token, use the shared Passport API
+baseline for request IDs, CORS, validation, rate limits, and error envelopes,
+and never return raw Firebase UIDs or database row IDs.
+
 ## Current Boundaries
 
-E03 defines the shared model and claim contracts. It does not add a full UI for
-agent or organization onboarding, database migrations for new actor tables, or
-new OIDC token issuance logic for non-human subjects. Existing OIDC login
-remains human-first until a later implementation slice adds runtime persistence
-and consent flows for non-human actors.
-
+E03 defines the shared model and claim contracts. E04 persists self-declared
+actor profiles and adds Passport onboarding, but existing OIDC login remains
+human-first. Token issuance, Admin review surfaces, stamp conflict resolution
+UI, and MCP-facing runtime endpoints for non-human actors remain later slices.

--- a/docs/engineering/actor-identity-model.md
+++ b/docs/engineering/actor-identity-model.md
@@ -1,0 +1,73 @@
+# Actor Identity Model
+
+Cubid supports three self-identified actor types:
+
+- `human`: an individual person and the primary proof-of-personhood subject.
+- `agent`: software or automated actor, either standalone, supporting one
+  human, or associated with an organization.
+- `organization`: a broad category that includes formal incorporated
+  organizations, teams, groups, networks, communities, collectives, and other
+  loosely organized people.
+
+## Validation Posture
+
+Cubid spends most validation effort on self-identified humans. Humans are
+eligible for personhood scoring, identity-depth policy, passkey-backed login,
+and stamp-derived humanity claims.
+
+Agents and organizations are intentionally lighter-weight. They may
+self-identify, claim social accounts as stamps, and participate in app-scoped
+identity flows, but they are not eligible for human personhood score
+contribution by default. Cubid does not perform bespoke validation for
+standalone agents, organization-owned agents, or organizations unless a future
+product slice explicitly adds that policy.
+
+This distinction lets agents and organizations reserve or claim social accounts
+without letting those same accounts boost a human score elsewhere. The stamp can
+exist in Cubid, but its contribution depends on the actor type and policy.
+
+## Shared Package Contract
+
+`@cubid/identity` owns the shared actor model:
+
+- `CubidActorType`: `human`, `agent`, or `organization`.
+- `CubidOrganizationKind`: formal organization, team, group, network,
+  community, collective, or other.
+- `CubidAgentAffiliationType`: standalone, human-supported, or
+  organization-supported.
+- `normalizeActorSelfIdentification`: validates and normalizes actor-declared
+  metadata.
+- `getActorValidationPolicy`: returns the default validation/scoring posture.
+- `createMcpTrustResponse`: produces the MCP-compatible trust envelope.
+
+`@cubid/claims` exposes actor claims under `cubid:claims`:
+
+- `cubid_actor_type`
+- `cubid_actor_self_identification`
+- `cubid_agent_supports_human`
+- `cubid_organization_kind`
+
+## MCP Trust Envelope
+
+MCP-compatible clients should consume `cubid-mcp-trust:v1` envelopes. The
+envelope is app-scoped, consent-aware, and never exposes raw cross-app
+identifiers. It includes:
+
+- subject actor type and self-identification metadata
+- validation intensity and personhood-score eligibility
+- optional score only when the actor is a human
+- stamp claims with explicit `contributesToHumanityScore`
+
+The envelope is intentionally descriptive rather than magical: an agent can say
+it supports a human, but that does not make the agent human or grant the agent a
+human score. Applications should display actor type clearly whenever they
+surface Cubid trust results.
+
+## Current Boundaries
+
+E03 defines the shared model and claim contracts. It does not add a full UI for
+agent or organization onboarding, database migrations for new actor tables, or
+new OIDC token issuance logic for non-human subjects. Existing OIDC login
+remains human-first until a later implementation slice adds runtime persistence
+and consent flows for non-human actors.
+

--- a/docs/engineering/login-with-cubid-oidc-architecture.md
+++ b/docs/engineering/login-with-cubid-oidc-architecture.md
@@ -176,7 +176,7 @@ The issuer URL stays stable even if the runtime location or deployment platform 
 
 - Human identities are the only first-class end-user subject type in v1.
 - Service clients may authenticate as software clients for Cubid APIs, but they are not end-user identities.
-- Agent and organization subjects are deferred to later roadmap work and are not encoded in B01 human token semantics.
+- Agent and organization runtime subjects are deferred from B01/B02 token issuance, but E03 defines their shared self-identification and claim contracts in `docs/engineering/actor-identity-model.md`.
 
 ## Pairwise Subject Policy
 
@@ -880,7 +880,7 @@ sequenceDiagram
 The following are intentionally not part of B01 or B02 scope:
 
 - passkeys and WebAuthn credential lifecycle
-- agent or organization subject support
+- runtime OIDC login/token issuance for agent or organization subjects
 - broad arbitrary data export to relying parties
 - partner-specific custom claim registry UI and workflows
 - sector identifier grouping across multiple clients under the same owner

--- a/packages/claims/src/index.test.ts
+++ b/packages/claims/src/index.test.ts
@@ -29,6 +29,15 @@ test("getClaimDefinition returns metadata for known claims", () => {
   assert.equal(definition?.tokenEligible, true);
 });
 
+test("actor self-identification claims are available through cubid:claims", () => {
+  const claims = getClaimsForScopes(["cubid:claims"]);
+
+  assert.equal(claims.includes("cubid_actor_type"), true);
+  assert.equal(claims.includes("cubid_actor_self_identification"), true);
+  assert.equal(getClaimDefinition("cubid_agent_supports_human")?.classification, "boolean");
+  assert.equal(getClaimDefinition("cubid_organization_kind")?.tokenEligible, true);
+});
+
 test("createSeededClaimRegistryRecord overlays seeded claim metadata", () => {
   const seeded = createSeededClaimRegistryRecord({
     name: "custom_claim",

--- a/packages/claims/src/index.ts
+++ b/packages/claims/src/index.ts
@@ -209,6 +209,38 @@ export const CLAIM_DEFINITIONS: readonly OidcClaimDefinition[] = [
     tokenEligible: false,
     userinfoEligible: true,
   },
+  {
+    name: "cubid_actor_type",
+    scopes: ["cubid:claims"],
+    classification: "identity",
+    description: "Self-identified Cubid actor type: human, agent, or organization.",
+    tokenEligible: true,
+    userinfoEligible: true,
+  },
+  {
+    name: "cubid_actor_self_identification",
+    scopes: ["cubid:claims"],
+    classification: "json",
+    description: "Structured self-identification details for agent and organization actors.",
+    tokenEligible: false,
+    userinfoEligible: true,
+  },
+  {
+    name: "cubid_agent_supports_human",
+    scopes: ["cubid:claims"],
+    classification: "boolean",
+    description: "Whether an agent self-identifies as supporting a single human actor.",
+    tokenEligible: true,
+    userinfoEligible: true,
+  },
+  {
+    name: "cubid_organization_kind",
+    scopes: ["cubid:claims"],
+    classification: "identity",
+    description: "Organization self-identification kind such as team, group, network, or formal organization.",
+    tokenEligible: true,
+    userinfoEligible: true,
+  },
 ] as const;
 
 function createDisplayName(claimName: string): string {

--- a/packages/identity/src/index.test.ts
+++ b/packages/identity/src/index.test.ts
@@ -53,7 +53,7 @@ test("computeConsentFingerprint ignores ordering", () => {
   assert.equal(first, second);
 });
 
-test("normalizeActorSelfIdentification defaults organization kind and strips invalid fields", () => {
+test("normalizeActorSelfIdentification defaults organization kind and trims display names", () => {
   const organization = normalizeActorSelfIdentification({
     actorType: "organization",
     declaredAt: "2026-04-29T00:00:00Z",
@@ -68,6 +68,18 @@ test("normalizeActorSelfIdentification defaults organization kind and strips inv
   assert.equal(organization.displayName, "Cubid Network");
   assert.equal(organization.organizationKind, "other");
   assert.equal(human.organizationKind, null);
+});
+
+test("normalizeActorSelfIdentification defaults agents to standalone affiliation", () => {
+  const agent = normalizeActorSelfIdentification({
+    actorType: "agent",
+    declaredAt: "2026-04-29T00:00:00Z",
+    displayName: "Helper",
+  });
+
+  assert.deepEqual(agent.agentAffiliation, {
+    affiliationType: "standalone",
+  });
 });
 
 test("normalizeActorSelfIdentification rejects contradictory actor metadata", () => {

--- a/packages/identity/src/index.test.ts
+++ b/packages/identity/src/index.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  canStampContributeToHumanityScore,
   computeConsentFingerprint,
+  createMcpTrustResponse,
   derivePairwiseSubject,
+  getActorValidationPolicy,
+  normalizeActorSelfIdentification,
 } from "./index";
 
 const secret = "cubid-identity-secret";
@@ -47,4 +51,79 @@ test("computeConsentFingerprint ignores ordering", () => {
   const second = computeConsentFingerprint(["email", "openid"], ["email", "sub"]);
 
   assert.equal(first, second);
+});
+
+test("normalizeActorSelfIdentification defaults organization kind and strips invalid fields", () => {
+  const organization = normalizeActorSelfIdentification({
+    actorType: "organization",
+    declaredAt: "2026-04-29T00:00:00Z",
+    displayName: "  Cubid Network  ",
+  });
+  const human = normalizeActorSelfIdentification({
+    actorType: "human",
+    declaredAt: "2026-04-29T00:00:00Z",
+    displayName: "Person",
+  });
+
+  assert.equal(organization.displayName, "Cubid Network");
+  assert.equal(organization.organizationKind, "other");
+  assert.equal(human.organizationKind, null);
+});
+
+test("normalizeActorSelfIdentification rejects contradictory actor metadata", () => {
+  assert.throws(() =>
+    normalizeActorSelfIdentification({
+      actorType: "human",
+      organizationKind: "team",
+    }),
+  );
+  assert.throws(() =>
+    normalizeActorSelfIdentification({
+      actorType: "organization",
+      agentAffiliation: {
+        affiliationType: "standalone",
+      },
+    }),
+  );
+});
+
+test("actor validation policy keeps deep validation focused on humans", () => {
+  assert.equal(getActorValidationPolicy("human").validationIntensity, "deep_human");
+  assert.equal(getActorValidationPolicy("human").personhoodScoreEligible, true);
+  assert.equal(getActorValidationPolicy("agent").personhoodScoreEligible, false);
+  assert.equal(getActorValidationPolicy("organization").customValidationRequired, false);
+  assert.equal(canStampContributeToHumanityScore("human"), true);
+  assert.equal(canStampContributeToHumanityScore("agent"), false);
+});
+
+test("createMcpTrustResponse redacts cross-app identifiers and suppresses non-human score contribution", () => {
+  const selfIdentification = normalizeActorSelfIdentification({
+    actorType: "agent",
+    agentAffiliation: {
+      affiliationType: "human_supported",
+      supportedHumanSubjectKey: "human_subject_123",
+    },
+    declaredAt: "2026-04-29T00:00:00Z",
+    displayName: "Research agent",
+  });
+  const response = createMcpTrustResponse({
+    generatedAt: "2026-04-29T00:01:00Z",
+    score: 90,
+    selfIdentification,
+    stampClaims: [
+      {
+        claimStatus: "verified",
+        contributesToHumanityScore: true,
+        stampType: "github",
+      },
+    ],
+    subjectId: "app_scoped_agent_123",
+  });
+
+  assert.equal(response.protocolVersion, "cubid-mcp-trust:v1");
+  assert.equal(response.subject.actorType, "agent");
+  assert.equal(response.trustSummary.personhoodScoreEligible, false);
+  assert.equal(response.trustSummary.score, null);
+  assert.equal(response.stampClaims[0]?.contributesToHumanityScore, false);
+  assert.equal(response.disclosure.rawCrossAppIdentifiersExposed, false);
 });

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -2,7 +2,95 @@ import { createHash, createHmac, randomBytes } from "node:crypto";
 
 const DERIVATION_CONTEXT = "cubid-sub:v1";
 
+export const CUBID_ACTOR_TYPES = ["human", "agent", "organization"] as const;
+
+export const CUBID_ORGANIZATION_KINDS = [
+  "formal_organization",
+  "team",
+  "group",
+  "network",
+  "community",
+  "collective",
+  "other",
+] as const;
+
+export const CUBID_AGENT_AFFILIATION_TYPES = [
+  "standalone",
+  "human_supported",
+  "organization_supported",
+] as const;
+
+export type CubidActorType = (typeof CUBID_ACTOR_TYPES)[number];
+export type CubidOrganizationKind = (typeof CUBID_ORGANIZATION_KINDS)[number];
+export type CubidAgentAffiliationType = (typeof CUBID_AGENT_AFFILIATION_TYPES)[number];
+
 export type ConsentClassification = "identity" | "hashed" | "boolean" | "score" | "json";
+
+export interface CubidAgentAffiliation {
+  affiliationType: CubidAgentAffiliationType;
+  supportedHumanSubjectKey?: string | null;
+  organizationSubjectKey?: string | null;
+  description?: string | null;
+}
+
+export interface CubidActorSelfIdentificationInput {
+  actorType: CubidActorType;
+  displayName?: string | null;
+  organizationKind?: CubidOrganizationKind | null;
+  agentAffiliation?: CubidAgentAffiliation | null;
+  declaredAt?: string;
+}
+
+export interface CubidActorSelfIdentification {
+  actorType: CubidActorType;
+  displayName: string | null;
+  organizationKind: CubidOrganizationKind | null;
+  agentAffiliation: CubidAgentAffiliation | null;
+  declaredAt: string;
+}
+
+export type CubidValidationIntensity = "deep_human" | "limited_generic" | "none";
+
+export interface CubidActorValidationPolicy {
+  actorType: CubidActorType;
+  validationIntensity: CubidValidationIntensity;
+  personhoodScoreEligible: boolean;
+  stampClaimEligible: boolean;
+  socialStampConflictPrevention: boolean;
+  customValidationRequired: boolean;
+  description: string;
+}
+
+export interface CubidMcpTrustSubject {
+  subjectId: string;
+  actorType: CubidActorType;
+  displayName: string | null;
+  organizationKind: CubidOrganizationKind | null;
+  agentAffiliation: CubidAgentAffiliation | null;
+}
+
+export interface CubidMcpTrustResponse {
+  protocolVersion: "cubid-mcp-trust:v1";
+  subject: CubidMcpTrustSubject;
+  trustSummary: {
+    personhoodScoreEligible: boolean;
+    humanValidationFocus: boolean;
+    validationIntensity: CubidValidationIntensity;
+    score?: number | null;
+    scoreUpdatedAt?: string | null;
+  };
+  stampClaims: Array<{
+    stampType: string;
+    claimStatus: "claimed" | "verified" | "revoked" | "conflict";
+    contributesToHumanityScore: boolean;
+  }>;
+  disclosure: {
+    appScoped: boolean;
+    consentRequired: boolean;
+    rawCrossAppIdentifiersExposed: false;
+  };
+  generatedAt: string;
+}
 
 export interface HumanSubjectSeed {
   humanSubjectKey: string;
@@ -54,6 +142,120 @@ function base64UrlEncode(buffer: Uint8Array): string {
 
 export function createHumanSubjectKey(): string {
   return base64UrlEncode(randomBytes(32));
+}
+
+export function normalizeActorSelfIdentification(
+  input: CubidActorSelfIdentificationInput,
+): CubidActorSelfIdentification {
+  if (!CUBID_ACTOR_TYPES.includes(input.actorType)) {
+    throw new Error("Unsupported Cubid actor type.");
+  }
+
+  if (input.actorType !== "organization" && input.organizationKind) {
+    throw new Error("organizationKind is only valid for organization actors.");
+  }
+
+  if (input.actorType !== "agent" && input.agentAffiliation) {
+    throw new Error("agentAffiliation is only valid for agent actors.");
+  }
+
+  if (input.organizationKind && !CUBID_ORGANIZATION_KINDS.includes(input.organizationKind)) {
+    throw new Error("Unsupported Cubid organization kind.");
+  }
+
+  if (
+    input.agentAffiliation
+    && !CUBID_AGENT_AFFILIATION_TYPES.includes(input.agentAffiliation.affiliationType)
+  ) {
+    throw new Error("Unsupported Cubid agent affiliation type.");
+  }
+
+  return {
+    actorType: input.actorType,
+    agentAffiliation: input.actorType === "agent" ? input.agentAffiliation ?? null : null,
+    declaredAt: input.declaredAt ?? new Date().toISOString(),
+    displayName: input.displayName?.trim() || null,
+    organizationKind: input.actorType === "organization" ? input.organizationKind ?? "other" : null,
+  };
+}
+
+export function getActorValidationPolicy(actorType: CubidActorType): CubidActorValidationPolicy {
+  switch (actorType) {
+    case "human":
+      return {
+        actorType,
+        customValidationRequired: true,
+        description: "Humans are the primary proof-of-personhood subject and receive deep validation and scoring.",
+        personhoodScoreEligible: true,
+        socialStampConflictPrevention: true,
+        stampClaimEligible: true,
+        validationIntensity: "deep_human",
+      };
+    case "agent":
+      return {
+        actorType,
+        customValidationRequired: false,
+        description: "Agents self-identify and may claim stamps, but do not receive bespoke personhood validation by default.",
+        personhoodScoreEligible: false,
+        socialStampConflictPrevention: true,
+        stampClaimEligible: true,
+        validationIntensity: "limited_generic",
+      };
+    case "organization":
+      return {
+        actorType,
+        customValidationRequired: false,
+        description: "Organizations include teams, groups, networks, communities, collectives, and formal entities; validation is generic by default.",
+        personhoodScoreEligible: false,
+        socialStampConflictPrevention: true,
+        stampClaimEligible: true,
+        validationIntensity: "limited_generic",
+      };
+  }
+}
+
+export function canStampContributeToHumanityScore(actorType: CubidActorType): boolean {
+  return getActorValidationPolicy(actorType).personhoodScoreEligible;
+}
+
+export function createMcpTrustResponse(input: {
+  subjectId: string;
+  selfIdentification: CubidActorSelfIdentification;
+  stampClaims?: CubidMcpTrustResponse["stampClaims"];
+  score?: number | null;
+  scoreUpdatedAt?: string | null;
+  generatedAt?: string;
+}): CubidMcpTrustResponse {
+  const policy = getActorValidationPolicy(input.selfIdentification.actorType);
+
+  return {
+    disclosure: {
+      appScoped: true,
+      consentRequired: true,
+      rawCrossAppIdentifiersExposed: false,
+    },
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    protocolVersion: "cubid-mcp-trust:v1",
+    stampClaims: (input.stampClaims ?? []).map((stamp) => ({
+      ...stamp,
+      contributesToHumanityScore:
+        stamp.contributesToHumanityScore && policy.personhoodScoreEligible,
+    })),
+    subject: {
+      actorType: input.selfIdentification.actorType,
+      agentAffiliation: input.selfIdentification.agentAffiliation,
+      displayName: input.selfIdentification.displayName,
+      organizationKind: input.selfIdentification.organizationKind,
+      subjectId: input.subjectId,
+    },
+    trustSummary: {
+      humanValidationFocus: input.selfIdentification.actorType === "human",
+      personhoodScoreEligible: policy.personhoodScoreEligible,
+      score: policy.personhoodScoreEligible ? input.score ?? null : null,
+      scoreUpdatedAt: policy.personhoodScoreEligible ? input.scoreUpdatedAt ?? null : null,
+      validationIntensity: policy.validationIntensity,
+    },
+  };
 }
 
 export function derivePairwiseSubject(

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -172,7 +172,10 @@ export function normalizeActorSelfIdentification(
 
   return {
     actorType: input.actorType,
-    agentAffiliation: input.actorType === "agent" ? input.agentAffiliation ?? null : null,
+    agentAffiliation:
+      input.actorType === "agent"
+        ? input.agentAffiliation ?? { affiliationType: "standalone" }
+        : null,
     declaredAt: input.declaredAt ?? new Date().toISOString(),
     displayName: input.displayName?.trim() || null,
     organizationKind: input.actorType === "organization" ? input.organizationKind ?? "other" : null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@cubid/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@cubid/identity':
+        specifier: workspace:*
+        version: link:../../packages/identity
       '@cubid/types':
         specifier: workspace:*
         version: link:../../packages/types

--- a/supabase/migrations/20260429191000_actor_profiles.sql
+++ b/supabase/migrations/20260429191000_actor_profiles.sql
@@ -58,5 +58,4 @@ alter table public.actor_profiles enable row level security;
 revoke all on table public.actor_profiles from anon;
 revoke all on table public.actor_profiles from authenticated;
 revoke all on table public.actor_profiles from public;
-grant all on table public.actor_profiles to service_role;
-
+grant select, insert, update, delete on table public.actor_profiles to service_role;

--- a/supabase/migrations/20260429191000_actor_profiles.sql
+++ b/supabase/migrations/20260429191000_actor_profiles.sql
@@ -1,0 +1,62 @@
+create table if not exists public.actor_profiles (
+  id uuid primary key default extensions.gen_random_uuid(),
+  firebase_uid text not null,
+  actor_type text not null check (actor_type in ('human', 'agent', 'organization')),
+  display_name text,
+  organization_kind text check (
+    organization_kind is null
+    or organization_kind in (
+      'formal_organization',
+      'team',
+      'group',
+      'network',
+      'community',
+      'collective',
+      'other'
+    )
+  ),
+  agent_affiliation_type text check (
+    agent_affiliation_type is null
+    or agent_affiliation_type in (
+      'standalone',
+      'human_supported',
+      'organization_supported'
+    )
+  ),
+  supported_human_subject_key text,
+  organization_subject_key text,
+  affiliation_description text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint actor_profiles_firebase_uid_key unique (firebase_uid),
+  constraint actor_profiles_organization_shape check (
+    (actor_type = 'organization' and organization_kind is not null)
+    or (actor_type <> 'organization' and organization_kind is null)
+  ),
+  constraint actor_profiles_agent_shape check (
+    (actor_type = 'agent' and agent_affiliation_type is not null)
+    or (
+      actor_type <> 'agent'
+      and agent_affiliation_type is null
+      and supported_human_subject_key is null
+      and organization_subject_key is null
+      and affiliation_description is null
+    )
+  )
+);
+
+create index if not exists actor_profiles_actor_type_idx
+  on public.actor_profiles (actor_type);
+
+create index if not exists actor_profiles_organization_kind_idx
+  on public.actor_profiles (organization_kind)
+  where organization_kind is not null;
+
+alter table public.actor_profiles enable row level security;
+
+revoke all on table public.actor_profiles from anon;
+revoke all on table public.actor_profiles from authenticated;
+revoke all on table public.actor_profiles from public;
+grant all on table public.actor_profiles to service_role;
+


### PR DESCRIPTION
## Summary
- Adds shared actor self-identification contracts for humans, agents, and organizations.
- Adds MCP-compatible trust response envelopes that keep human proof-of-personhood distinct from non-human self-identification.
- Adds Passport actor-profile persistence, authenticated profile APIs, and profile UI onboarding.
- Adds actor claim definitions and documentation for the new model.

## Objective
Broaden Cubid beyond human-only identity records while preserving the core trust distinction: humans receive deep validation/scoring, while agents and organizations can self-identify, claim stamps, and reserve social accounts without being treated as human proof-of-personhood.

## Changes
- Extends `@cubid/identity` with actor types, organization kinds, agent affiliation types, normalization helpers, validation policy, and MCP trust envelopes.
- Extends `@cubid/claims` with actor-related Cubid claims.
- Adds `public.actor_profiles` migration and Passport service helpers/routes for authenticated actor-profile get/upsert.
- Adds Profile UI controls for human, agent, and organization self-identification.
- Updates engineering docs and roadmap/session metadata for E03/E04.

## Validation
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/identity test && pnpm --filter @cubid/identity typecheck && pnpm --filter @cubid/claims test && pnpm --filter @cubid/claims typecheck && pnpm --filter @cubid/passport test && pnpm --filter @cubid/passport typecheck'`
- `npx -p node@24 -c 'node --version && pnpm test && pnpm typecheck'`
- `npx -p node@24 -c 'node --version && pnpm lint && pnpm build'`

## Reviewer Notes
- Review `packages/identity/src/index.ts` and `docs/engineering/actor-identity-model.md` first for the trust model.
- Then review the Passport API/service layer before the Profile UI.
- Existing lint/build warnings remain pre-existing Tailwind/import/Next warnings; this branch did not broaden that cleanup.

## Follow-ups
- Runtime OIDC token issuance for agent/organization subjects remains deferred.
- Admin actor-profile visibility and MCP-facing runtime endpoints remain later slices.
