### PR TITLE
[codex] Add @cubid/core publishing setup runbook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify release branch
+        if: ${{ inputs.publish_npm || inputs.publish_jsr }}
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/dev" ]; then
+            echo "Package releases must be dispatched from the dev branch. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
+      - name: Print publish tool versions
+        run: |
+          node --version
+          npm --version
+          pnpm --version
+          deno --version
+
       - name: Validate @cubid/core
         run: |
           pnpm --filter @cubid/core test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verify release branch
+        if: ${{ inputs.publish_npm || inputs.publish_jsr }}
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/dev" ]; then
+            echo "Package releases must be dispatched from the dev branch. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -44,14 +52,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Verify release branch
-        if: ${{ inputs.publish_npm || inputs.publish_jsr }}
-        run: |
-          if [ "$GITHUB_REF" != "refs/heads/dev" ]; then
-            echo "Package releases must be dispatched from the dev branch. Current ref: $GITHUB_REF"
-            exit 1
-          fi
 
       - name: Print publish tool versions
         run: |

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3263,6 +3263,33 @@ Resolve the actionable Copilot and Codex review comments on PR #152 before conti
 
 - commit and push the PR review fixes, reply to and resolve review threads, then re-check PR state
 
+### session: v121
+
+- timestamp: 2026-04-30T12:18:51Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-1-core-publishing-setup**
+- head: **`b6b0606`**
+- session name: **Address PR 153 publishing runbook review**
+
+#### Objective
+
+Resolve Copilot review comments on PR #153 by making the publishing runbook less time-bound and moving the release-branch guard earlier in the workflow.
+
+#### Actions Taken
+
+- replaced point-in-time npm/auth status bullets with repeatable verification commands
+- rewrote the agent-first-person runbook section as an impersonal repo-side task checklist
+- moved the publish branch guard directly after checkout so mistaken release dispatches fail before setup and install work
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck && pnpm --filter @cubid/core deno:check && pnpm --filter @cubid/core build && pnpm --filter @cubid/core pack:dry-run && pnpm --filter @cubid/core jsr:dry-run'`
+- `git diff --check`
+
+#### Follow-up
+
+- commit, push, reply to the three review threads, and resolve them
+
 ### session: v120
 
 - timestamp: 2026-04-30T09:05:06Z

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3263,6 +3263,33 @@ Resolve the actionable Copilot and Codex review comments on PR #152 before conti
 
 - commit and push the PR review fixes, reply to and resolve review threads, then re-check PR state
 
+### session: v120
+
+- timestamp: 2026-04-30T09:05:06Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-1-core-publishing-setup**
+- head: **`339dcf3`**
+- session name: **Close E02.1 repo-side core publishing setup**
+
+#### Objective
+
+Close the repo-side E02.1 package setup while keeping the npm/JSR account-owner first release as an explicit follow-up.
+
+#### Actions Taken
+
+- marked E02.1 completed against the repo-side publishing setup commit
+- added `E02.1.1` for the registry-side first release and trusted-publisher activation steps that require human npm/JSR ownership
+- kept live package publication out of this commit because `@cubid/core` is not yet published and registry setup requires account-owner action
+
+#### Verification
+
+- confirmed E02.1 now points at setup commit `339dcf3`
+- confirmed E02.1.1 captures the remaining npm/JSR release work as a separate todo
+
+#### Follow-up
+
+- open a PR for the publishing setup, merge to `dev`, then have a Cubid npm/JSR owner complete E02.1.1 using the runbook
+
 ### session: v119
 
 - timestamp: 2026-04-30T09:03:20Z

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3263,6 +3263,37 @@ Resolve the actionable Copilot and Codex review comments on PR #152 before conti
 
 - commit and push the PR review fixes, reply to and resolve review threads, then re-check PR state
 
+### session: v119
+
+- timestamp: 2026-04-30T09:03:20Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-1-core-publishing-setup**
+- head: **`5ac2004`**
+- session name: **Harden core package publishing setup**
+
+#### Objective
+
+Prune stale feature branches and tighten the `@cubid/core` npm/JSR publishing path so registry setup can proceed through official Cubid-owned accounts and GitHub Actions trusted publishing.
+
+#### Actions Taken
+
+- pruned stale local branches from the earlier A/B/C rollout stacks
+- deleted stale remote feature branches for closed/superseded PRs
+- verified `@cubid/core` is not yet published on npm and that the local machine is not authenticated to npm
+- added a release-branch guard and tool-version logging to the manual publish workflow
+- added an operator runbook for npm organization setup, trusted publishing, JSR linking, and the first-version bootstrap decision
+
+#### Verification
+
+- `npm view @cubid/core --json` returned npm 404, confirming the package is not yet published
+- `npm whoami` returned `ENEEDAUTH`, confirming no local npm publish identity is active
+- `pnpm --filter @cubid/core pack:dry-run`
+- `pnpm --filter @cubid/core jsr:dry-run`
+
+#### Follow-up
+
+- merge the publishing setup changes, then have a Cubid npm/JSR owner complete the registry-side setup before running the manual publish workflow from `dev`
+
 ### session: v109
 
 - timestamp: 2026-04-29T18:00:37Z

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -542,9 +542,9 @@ Turn the current mixed bag of legacy routes into a coherent developer platform. 
 - Status: Started
 - Timestamp started: 2026-04-28T08:28:44Z
 - Timestamp completed: TBD
-- Feature branch: codex/e02-1-cubid-api-package
+- Feature branch: codex/e02-1-cubid-api-package; codex/e02-1-core-publishing-setup
 - Head: 452874b
-- Session-log reference(s): session: v94, session: v95
+- Session-log reference(s): session: v94, session: v95, session: v119
 
 Package `@cubid/core` as the required public integration foundation that works cleanly from both npm and JSR, so downstream apps can import `@cubid/core` in Next.js and `jsr:@cubid/core` in Supabase Edge or other Deno runtimes without mirrors, tarballs, or path hacks. Keep the package strictly runtime-agnostic: no React, no browser-only helpers, no Node-only assumptions, no chain SDKs, and no wagmi. All request logic should rely on `fetch`, `RequestInit`, `Headers`, and plain JSON contracts, with callers able to inject `fetch` and server-held credentials explicitly. The output of this todo is a package layout, export map, build/publish setup, and usage contract that makes Cubid’s core API client feel native in both Node and Deno environments.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -539,14 +539,25 @@ Turn the current mixed bag of legacy routes into a coherent developer platform. 
 
 ### E02.1 Publish `@cubid/core` as a dual-target runtime-agnostic package
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-04-28T08:28:44Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-04-30T09:05:06Z
 - Feature branch: codex/e02-1-cubid-api-package; codex/e02-1-core-publishing-setup
-- Head: 452874b
-- Session-log reference(s): session: v94, session: v95, session: v119
+- Head: 339dcf3
+- Session-log reference(s): session: v94, session: v95, session: v119, session: v120
 
 Package `@cubid/core` as the required public integration foundation that works cleanly from both npm and JSR, so downstream apps can import `@cubid/core` in Next.js and `jsr:@cubid/core` in Supabase Edge or other Deno runtimes without mirrors, tarballs, or path hacks. Keep the package strictly runtime-agnostic: no React, no browser-only helpers, no Node-only assumptions, no chain SDKs, and no wagmi. All request logic should rely on `fetch`, `RequestInit`, `Headers`, and plain JSON contracts, with callers able to inject `fetch` and server-held credentials explicitly. The output of this todo is a package layout, export map, build/publish setup, and usage contract that makes Cubid’s core API client feel native in both Node and Deno environments.
+
+### E02.1.1 Complete `@cubid/core` registry-side first release
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Complete the human-owned registry setup and first official `@cubid/core` release after the repo-side package and trusted-publishing workflow have merged to `dev`. Confirm the npm `cubid` organization exists, that the right maintainers belong to the `developers` team, and that `@cubid/core` is owned by the org rather than a personal account. If npm allows trusted-publisher setup before first publication, configure GitHub Actions trusted publishing directly; if not, perform the one-time owner-controlled bootstrap publish from a clean `dev` release commit, then immediately configure trusted publishing and restrict token access. Also create/link the JSR `@cubid/core` package to `Cubid-Me/cubid-passport`, run the manual publish workflow from `dev`, verify npm/JSR installs, and record package URLs plus version metadata.
 
 ### E02.2 Add a stable server-facing identity sync contract to `@cubid/core`
 

--- a/docs/engineering/core-publishing-runbook.md
+++ b/docs/engineering/core-publishing-runbook.md
@@ -4,7 +4,7 @@ This runbook is the operator checklist for publishing `@cubid/core` to npm and
 JSR. The repo is already wired for tokenless publishing from GitHub Actions; the
 remaining setup happens in the npm and JSR account UIs.
 
-## Current State
+## Release Contract
 
 - npm package: `@cubid/core`
 - JSR package: `@cubid/core`
@@ -12,20 +12,30 @@ remaining setup happens in the npm and JSR account UIs.
 - Workflow: `.github/workflows/publish.yml`
 - Release branch: `dev`
 - Release workflow trigger: manual `workflow_dispatch`
-- npm status checked on 2026-04-30: `@cubid/core` is not yet published
-- Local npm status checked on 2026-04-30: this machine is not authenticated
+
+Before a release, verify the current registry and local-auth state instead of
+relying on old notes:
+
+```sh
+npm view @cubid/core version
+npm whoami
+```
+
+If `npm view` returns a 404, the package has not been published yet. If
+`npm whoami` fails, the local machine is not authenticated to npm.
 
 Do not publish from a personal npm account as a routine release path. Official
 Cubid packages should be owned by the npm `cubid` organization and released
 through trusted publishing from GitHub Actions.
 
-## What I Can Do In Repo
+## Repo-Side Tasks
 
-- keep the package runtime-agnostic and publishable
-- run npm pack and JSR dry-runs
-- keep the GitHub Actions workflow ready for trusted publishing
-- open the PR that updates package code, docs, and release automation
-- run the publish workflow after registry setup is complete, if you ask me to
+- Keep the package runtime-agnostic and publishable.
+- Run npm pack and JSR dry-runs to validate release artifacts.
+- Keep the GitHub Actions workflow ready for trusted publishing.
+- Open PRs that update package code, docs, and release automation.
+- After registry setup is complete, run the publish workflow from GitHub
+  Actions.
 
 ## What Needs A Human Account Owner
 

--- a/docs/engineering/core-publishing-runbook.md
+++ b/docs/engineering/core-publishing-runbook.md
@@ -1,0 +1,133 @@
+# `@cubid/core` Publishing Runbook
+
+This runbook is the operator checklist for publishing `@cubid/core` to npm and
+JSR. The repo is already wired for tokenless publishing from GitHub Actions; the
+remaining setup happens in the npm and JSR account UIs.
+
+## Current State
+
+- npm package: `@cubid/core`
+- JSR package: `@cubid/core`
+- GitHub repository: `Cubid-Me/cubid-passport`
+- Workflow: `.github/workflows/publish.yml`
+- Release branch: `dev`
+- Release workflow trigger: manual `workflow_dispatch`
+- npm status checked on 2026-04-30: `@cubid/core` is not yet published
+- Local npm status checked on 2026-04-30: this machine is not authenticated
+
+Do not publish from a personal npm account as a routine release path. Official
+Cubid packages should be owned by the npm `cubid` organization and released
+through trusted publishing from GitHub Actions.
+
+## What I Can Do In Repo
+
+- keep the package runtime-agnostic and publishable
+- run npm pack and JSR dry-runs
+- keep the GitHub Actions workflow ready for trusted publishing
+- open the PR that updates package code, docs, and release automation
+- run the publish workflow after registry setup is complete, if you ask me to
+
+## What Needs A Human Account Owner
+
+You or another npm/JSR owner must do the first registry setup because it depends
+on account permissions and package ownership. This should be done with the
+official Cubid org accounts, not an agent-owned or personal workaround.
+
+## npm Setup
+
+1. Sign in at `https://www.npmjs.com/`.
+2. Confirm the npm organization `cubid` exists.
+3. Confirm your account is a member of the `cubid` organization.
+4. Confirm the `developers` team exists and has package publish/admin access for
+   Cubid SDK packages.
+5. Search for `@cubid/core`.
+6. If `@cubid/core` exists, open package settings and configure Trusted
+   Publishing:
+   - Provider: `GitHub Actions`
+   - Organization or user: `Cubid-Me`
+   - Repository: `cubid-passport`
+   - Workflow filename: `publish.yml`
+   - Environment name: leave blank
+7. In the package settings, set publishing access to require 2FA and disallow
+   tokens after trusted publishing is confirmed working.
+
+### If npm Says The Package Does Not Exist
+
+npm's trusted-publisher UI is package-settings based. If npm does not let you
+configure Trusted Publishing before the first package version exists, use this
+bootstrap path:
+
+1. Make sure this publishing setup PR has merged to `dev`.
+2. Use the official npm org owner account, not an agent or personal automation
+   token.
+3. Publish version `0.1.0` once from the clean `dev` release commit with:
+
+   ```sh
+   pnpm --filter @cubid/core build
+   cd packages/core
+   npm publish --access public
+   ```
+
+4. Immediately configure Trusted Publishing with the fields above.
+5. Immediately restrict publishing access to require 2FA and disallow tokens.
+6. Future releases must use the GitHub Actions workflow, not local publish.
+
+This one-time bootstrap is only acceptable if npm does not support creating the
+trusted-publisher binding for an unpublished package. Do not store a long-lived
+npm automation token in this repository.
+
+## JSR Setup
+
+1. Sign in at `https://jsr.io/` using the Cubid-maintained GitHub identity.
+2. Create or open scope `@cubid`.
+3. Create or open package `@cubid/core`.
+4. In the package settings, link the GitHub repository:
+   - Repository: `Cubid-Me/cubid-passport`
+   - Workflow: `.github/workflows/publish.yml`
+5. Keep tokenless GitHub Actions publishing as the release path.
+
+JSR supports tokenless publishing from GitHub Actions after the package is
+linked to the repository.
+
+## Release Steps After Setup
+
+1. Ensure the release commit is merged to `dev`.
+2. Open GitHub Actions for `Cubid-Me/cubid-passport`.
+3. Select workflow `Publish Packages`.
+4. Click `Run workflow`.
+5. Select branch `dev`.
+6. Set `publish_npm` and/or `publish_jsr` to `true`.
+7. Run the workflow.
+8. Confirm the workflow passes and the package pages show the new version.
+
+The workflow fails intentionally if a publish is dispatched from any branch
+other than `dev`.
+
+## Verification Commands
+
+Run these before a release PR:
+
+```sh
+pnpm --filter @cubid/core test
+pnpm --filter @cubid/core typecheck
+pnpm --filter @cubid/core deno:check
+pnpm --filter @cubid/core build
+pnpm --filter @cubid/core pack:dry-run
+pnpm --filter @cubid/core jsr:dry-run
+```
+
+After publication:
+
+```sh
+npm view @cubid/core
+```
+
+Also confirm JSR shows `@cubid/core` and that a Deno/Supabase Edge import can
+use `jsr:@cubid/core`.
+
+## Known Decision: License
+
+`@cubid/core` is currently marked `UNLICENSED`. That is technically
+publishable, but it is not friendly to external adoption. Before a broad
+developer launch, choose an explicit SDK license such as MIT or Apache-2.0 and
+apply it intentionally. Do not invent that license during routine maintenance.

--- a/docs/engineering/cubid-core-package.md
+++ b/docs/engineering/cubid-core-package.md
@@ -34,6 +34,11 @@ verification metadata even if a legacy server payload contains a code.
 Use trusted publishing only. Do not publish this package with a local npm user
 or a long-lived npm token.
 
+The operator checklist lives in
+`docs/engineering/core-publishing-runbook.md`. Use that runbook for the first
+registry setup, first-version bootstrap decision, and manual GitHub Actions
+release flow.
+
 npm Trusted Publisher setup:
 
 - Provider: GitHub Actions

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -153,3 +153,6 @@ The JSR package should be linked to:
 - Package: `@cubid/core`
 - Repository: `Cubid-Me/cubid-passport`
 - Workflow: `.github/workflows/publish.yml`
+
+See `docs/engineering/core-publishing-runbook.md` in the repository for the
+full npm/JSR setup checklist and first-version bootstrap notes.


### PR DESCRIPTION
## Summary
- Adds an operator runbook for publishing `@cubid/core` to npm and JSR through official Cubid-owned accounts.
- Guards the manual publish workflow so real publishes can only be dispatched from `dev`.
- Closes E02.1 as repo-side complete and splits registry-owner first release work into E02.1.1.

## Objective
Make the `@cubid/core` release path clear and safe before the first npm/JSR publication, especially for npm Trusted Publishing and JSR GitHub Actions linking.

## Changes
- Added `docs/engineering/core-publishing-runbook.md` with npm org, trusted-publisher, JSR linking, first-version bootstrap, and release steps.
- Updated the publish workflow with a release-branch guard and tool version logging.
- Linked the package docs to the runbook and updated E02.1/E02.1.1 roadmap metadata.

## Validation
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck && pnpm --filter @cubid/core deno:check && pnpm --filter @cubid/core build && pnpm --filter @cubid/core pack:dry-run && pnpm --filter @cubid/core jsr:dry-run'`
- `git diff --check`
- Confirmed `npm view @cubid/core --json` returns 404, so the package is not yet published.
- Confirmed `npm whoami` returns `ENEEDAUTH`, so no local npm identity is being used.

## Reviewer Notes
Review the workflow guard first, then the runbook. The runbook intentionally states that the first npm publish may require a human Cubid org owner if npm does not allow trusted-publisher setup for an unpublished package.

## Follow-ups
- Complete E02.1.1 after this lands: configure npm/JSR registry ownership, run the first release from `dev`, and verify package installs.
- Choose an explicit public SDK license before broad developer launch; the package is still marked `UNLICENSED`.