### PR TITLE
[codex] License @cubid/core as Apache 2.0

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3263,6 +3263,34 @@ Resolve the actionable Copilot and Codex review comments on PR #152 before conti
 
 - commit and push the PR review fixes, reply to and resolve review threads, then re-check PR state
 
+### session: v122
+
+- timestamp: 2026-04-30T12:33:37Z
+- agent: **OpenAI Codex**
+- branch: **codex/e02-1-core-apache-license**
+- head: **`a4201e6`**
+- session name: **Add Apache-2.0 license to core SDK**
+
+#### Objective
+
+Add an explicit Apache-2.0 license to the public `@cubid/core` SDK package without relicensing the private monorepo apps and services.
+
+#### Actions Taken
+
+- created a fresh feature branch from updated `dev`
+- changed `@cubid/core` npm and JSR metadata from `UNLICENSED` to `Apache-2.0`
+- added a package-local Apache-2.0 license file to the published SDK artifact set
+- updated SDK docs and publishing runbook copy to state the package-level license boundary
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck && pnpm --filter @cubid/core deno:check && pnpm --filter @cubid/core build && pnpm --filter @cubid/core pack:dry-run && pnpm --filter @cubid/core jsr:dry-run'`
+- `git diff --check`
+
+#### Follow-up
+
+- commit and publish the license change through a PR to `dev`
+
 ### session: v121
 
 - timestamp: 2026-04-30T12:18:51Z

--- a/docs/engineering/core-publishing-runbook.md
+++ b/docs/engineering/core-publishing-runbook.md
@@ -135,9 +135,8 @@ npm view @cubid/core
 Also confirm JSR shows `@cubid/core` and that a Deno/Supabase Edge import can
 use `jsr:@cubid/core`.
 
-## Known Decision: License
+## License
 
-`@cubid/core` is currently marked `UNLICENSED`. That is technically
-publishable, but it is not friendly to external adoption. Before a broad
-developer launch, choose an explicit SDK license such as MIT or Apache-2.0 and
-apply it intentionally. Do not invent that license during routine maintenance.
+`@cubid/core` is licensed as Apache-2.0. The license applies to the public SDK
+package in `packages/core`, not automatically to every app or service in this
+private monorepo.

--- a/docs/engineering/cubid-core-package.md
+++ b/docs/engineering/cubid-core-package.md
@@ -10,6 +10,7 @@ tests.
 
 - Package name: `@cubid/core`
 - Initial version: `0.1.0`
+- License: Apache-2.0
 - Runtime target: ESM, standards-only
 - Surface: normalized wrappers for current Passport v2 routes plus
   server-facing identity sync helpers

--- a/docs/engineering/sdk-package-target-state.md
+++ b/docs/engineering/sdk-package-target-state.md
@@ -11,6 +11,10 @@ Official packages are published under the npm org `@cubid/*`, owned by the
 uses trusted publishing from GitHub Actions; do not publish official packages
 from personal npm accounts or long-lived local tokens.
 
+Public SDK packages should use explicit package-level licenses. `@cubid/core`
+is Apache-2.0; app and service workspaces in this monorepo are not automatically
+covered by that SDK package license.
+
 Target packages:
 
 - `@cubid/core`: required runtime-agnostic foundation

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,6 +2,8 @@
 
 Runtime-agnostic Cubid foundation client for server-side integrations.
 
+Licensed under Apache-2.0.
+
 This package is intentionally small and standards-only. It does not import
 React, Next.js, Firebase, Supabase, Node built-ins, or browser-only helpers.
 All requests use `fetch`, `RequestInit`, `Headers`, and plain JSON so the same

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,12 +1,13 @@
 {
   "name": "@cubid/core",
   "version": "0.1.0",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts"
   },
   "publish": {
     "include": [
+      "LICENSE",
       "README.md",
       "src/**/*.ts",
       "jsr.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Runtime-agnostic Cubid core client for server-side integrations.",
   "type": "module",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,6 +15,7 @@
   },
   "files": [
     "dist",
+    "LICENSE",
     "README.md",
     "jsr.json"
   ],


### PR DESCRIPTION
## Summary
- Adds an Apache-2.0 license file scoped to the public `@cubid/core` package.
- Updates npm and JSR package metadata from `UNLICENSED` to `Apache-2.0`.
- Updates SDK/package docs to clarify this licenses the public SDK package, not the private monorepo apps and services.

## Objective
Make `@cubid/core` suitable for the first public npm/JSR release with an explicit SDK license.

## Changes
- Added `packages/core/LICENSE`.
- Included `LICENSE` in npm and JSR publish artifacts.
- Updated package docs, SDK target-state notes, and publishing runbook license guidance.

## Validation
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/core test && pnpm --filter @cubid/core typecheck && pnpm --filter @cubid/core deno:check && pnpm --filter @cubid/core build && pnpm --filter @cubid/core pack:dry-run && pnpm --filter @cubid/core jsr:dry-run'`
- `git diff --check`

## Reviewer Notes
The license is package-local by design. This PR does not add a root monorepo license.

## Follow-ups
- After merge, publish `@cubid/core@0.1.0` from clean `dev` as the one-time npm bootstrap if trusted publishing cannot be configured before first publish.