### PR TITLE
[codex] App disclosure grants and API v3 hardening

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4228,3 +4228,31 @@ Address Copilot review comments on PR 156 before requesting Codex review.
 #### Follow-up
 
 - push the Copilot fixes, confirm CI is green again, reply to and resolve the review threads, then request Codex review if no Codex review exists yet
+
+### session: v148
+
+- timestamp: 2026-05-03T01:07:47Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`c0f9bf3`**
+- session name: **Tighten failed API v3 idempotency semantics**
+
+#### Objective
+
+Address the Codex review finding that failed idempotency records must not re-run writes after possible partial side effects.
+
+#### Actions Taken
+
+- changed non-expired failed API v3 idempotency records to return terminal `409 idempotency_failed` instead of retrying the handler
+- preserved conditional reclaim only for expired idempotency records, where the original retention contract has elapsed
+- updated Passport route tests so failed-key retries prove no additional secret row is written
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- push the terminal failed-idempotency fix, confirm CI is green, then reply to and resolve the Copilot and Codex review threads

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4137,3 +4137,35 @@ Complete E02.6 by tightening the active API v3 backend routes against the canoni
 #### Follow-up
 
 - implement E02.7 next to standardize API v3 webhook contracts and delivery semantics
+
+### session: v145
+
+- timestamp: 2026-05-03T00:40:34Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`7f8aa93`**
+- session name: **Standardize E02.7 API v3 webhook contracts**
+
+#### Objective
+
+Complete E02.7 by standardizing API v3 webhook payloads, signatures, replay-protection inputs, delivery metadata, disclosure filtering, and SDK coordination.
+
+#### Actions Taken
+
+- added shared API v3 webhook helpers for canonical event names, payload construction, v1 signatures, replay headers, and delivery error classification
+- updated internal webhook trigger paths to deliver v3 protocol payloads with `X-Cubid-Event-Id`, `X-Cubid-Timestamp`, `X-Cubid-Signature-Version`, and `X-Cubid-Signature`
+- added migration fields for webhook event ids, API/payload versions, request bodies, redacted request headers, and signature version metadata
+- preserved disclosure-gated delivery and expanded Passport tests for signed payloads, undisclosed-stamp skips, failure attempts, retry metadata, and redaction of internal identifiers
+- updated the API v3 engineering doc and wrote an SDK-agent handoff note for webhook verification/docs follow-up
+- marked E02.7 completed in the roadmap
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- implement E02.8 next to reconcile SDK-impact notes and close the API v3 developer-platform coordination loop

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4169,3 +4169,32 @@ Complete E02.7 by standardizing API v3 webhook payloads, signatures, replay-prot
 #### Follow-up
 
 - implement E02.8 next to reconcile SDK-impact notes and close the API v3 developer-platform coordination loop
+
+### session: v146
+
+- timestamp: 2026-05-03T00:43:54Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`5b0504b`**
+- session name: **Coordinate E02.8 public SDK impact for API v3**
+
+#### Objective
+
+Close E02.8 by confirming API v3 SDK-impact coordination is recorded without moving public SDK implementation back into `cubid-passport`.
+
+#### Actions Taken
+
+- checked `agent-context/messages-from-cubid-sdk/` and confirmed there were no incoming SDK-agent notes to address
+- confirmed the SDK workspace contains outbound handoff notes for E02.6 idempotency and E02.7 webhook contract changes
+- recorded the SDK coordination ledger in `docs/engineering/api-v3-developer-platform.md`
+- marked E02.8 completed and closed the E02 backend API v3 review/hardening track in the roadmap
+
+#### Verification
+
+- `find agent-context/messages-from-cubid-sdk -type f -maxdepth 2 -print`
+- `git -C /Users/botmaster/src/cubid/cubid-sdk-v2 status --short -- agent-context/messages-from-cubid-passport`
+- `git diff --check`
+
+#### Follow-up
+
+- either yeet this feature branch for review or continue with the next backend-owned developer-platform track after E02

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4018,3 +4018,33 @@ Continue E01 by making profile and non-stamp location claims explicit in the sel
 #### Follow-up
 
 - add user-facing non-OIDC app disclosure history and revocation views so users can inspect and revoke Allow Page grants outside the OIDC consent panel
+
+### session: v141
+
+- timestamp: 2026-05-01T08:55:58Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`3123f99`**
+- session name: **Add non-OIDC app disclosure grant history and revocation**
+
+#### Objective
+
+Continue E01 by adding user-facing visibility and revocation for Allow Page disclosure grants outside the OIDC consent panel.
+
+#### Actions Taken
+
+- added Passport user APIs for listing and revoking non-OIDC Allow Page disclosure grants
+- added a Profile “App disclosure grants” card showing app, scopes, claims, policy/version metadata, data classifications, and revoked state
+- made Allow Page grant revocation update `selective_disclosure_grants`, emit `selective_disclosure_events`, and remove matching legacy stamp permissions
+- added Passport route coverage for list/revoke behavior and extended the test Supabase mock for disclosure grants
+- updated E01 engineering docs and sent an SDK-impact handoff note to the canonical SDK repo
+
+#### Verification
+
+- `pnpm --filter @cubid/passport typecheck`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- yeet the E01 branch for review when ready, or close E01 metadata after the PR merges if this is the final E01 implementation slice

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4198,3 +4198,33 @@ Close E02.8 by confirming API v3 SDK-impact coordination is recorded without mov
 #### Follow-up
 
 - either yeet this feature branch for review or continue with the next backend-owned developer-platform track after E02
+
+### session: v147
+
+- timestamp: 2026-05-03T01:01:37Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`b5dc1ec`**
+- session name: **Address PR 156 Copilot review feedback**
+
+#### Objective
+
+Address Copilot review comments on PR 156 before requesting Codex review.
+
+#### Actions Taken
+
+- made failed API v3 idempotency records re-claimable through a conditional pending transition before retrying write side effects
+- added regression coverage for retrying a failed idempotent `save_secret` request
+- updated the webhook migration to replace the legacy one-row-per-event delivery uniqueness constraint with one-row-per-attempt uniqueness
+- replaced machine-local SDK handoff paths in the API v3 engineering doc with SDK-repo-relative references
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- push the Copilot fixes, confirm CI is green again, reply to and resolve the review threads, then request Codex review if no Codex review exists yet

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4077,3 +4077,31 @@ Update stale E02 roadmap language so it reflects the current split between backe
 #### Follow-up
 
 - implement E02.5 next to inventory and define the canonical API v3 contract in this repo before changing route behavior
+
+### session: v143
+
+- timestamp: 2026-05-03T00:05:30Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`4c1a9ca`**
+- session name: **Define E02.5 API v3 backend contract**
+
+#### Objective
+
+Start and complete E02.5 by inventorying the current API v3 backend routes and locking the canonical contract before changing route behavior.
+
+#### Actions Taken
+
+- checked for incoming SDK-agent messages before API v3 contract work and found none
+- marked E02.5 completed on the current feature branch
+- expanded `docs/engineering/api-v3-developer-platform.md` with route-by-route contracts for `/api/v3/save_secret`, `/api/v3/accounts/generate`, and `/api/v3/accounts/list`
+- documented API v3 dapp authentication, v2 legacy posture, structured error expectations, secret non-exposure rules, and retry/idempotency expectations
+- kept the change documentation-only, so no outbound SDK handoff note was required
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- implement E02.6 next to harden API v3 route behavior against the contract defined in E02.5

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4105,3 +4105,35 @@ Start and complete E02.5 by inventorying the current API v3 backend routes and l
 #### Follow-up
 
 - implement E02.6 next to harden API v3 route behavior against the contract defined in E02.5
+
+### session: v144
+
+- timestamp: 2026-05-03T00:35:03Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`6dd342e`**
+- session name: **Harden E02.6 API v3 route behavior**
+
+#### Objective
+
+Complete E02.6 by tightening the active API v3 backend routes against the canonical E02.5 contract before changing or adding broader developer-platform behavior.
+
+#### Actions Taken
+
+- added a service-role-only `api_idempotency_keys` migration for API v3 write replay protection
+- added a shared Passport API v3 idempotency helper that requires `Idempotency-Key`, hashes canonical request bodies, replays completed responses, and rejects conflicting or pending keys
+- wired idempotency into `/api/v3/save_secret` and `/api/v3/accounts/generate` without changing success payload shapes
+- expanded Passport route tests for v3 auth failures, dapp ownership, idempotent replay, conflict and pending-key errors, no secret/private-key exposure, chain filtering, and partial-failure cleanup
+- updated the API v3 engineering doc and wrote an SDK-agent handoff note for the new idempotency contract
+- marked E02.6 completed in the roadmap
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- implement E02.7 next to standardize API v3 webhook contracts and delivery semantics

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -3987,3 +3987,34 @@ Address Copilot and Codex review feedback on PR #155 before returning the branch
 #### Follow-up
 
 - push the review-fix commit, confirm CI, then reply to and resolve the addressed PR #155 review threads
+
+### session: v140
+
+- timestamp: 2026-05-01T08:03:51Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`63303ad`**
+- session name: **Add E01 profile and location disclosure taxonomy**
+
+#### Objective
+
+Continue E01 by making profile and non-stamp location claims explicit in the selective-disclosure contract, then tighten dapp-facing route filters around those grants.
+
+#### Actions Taken
+
+- added Passport disclosure helpers for `profile:name`, `location:rough`, `location:approximate`, `location:exact`, and wildcard namespace grants
+- sanitized legacy dapp identity user payloads instead of spreading raw user rows back to integrators
+- gated exact, approximate, and rough location routes on matching disclosure claim granularity
+- prevented approximate location responses from returning raw address objects
+- documented the profile/location claim taxonomy and sent an SDK-impact handoff note to the canonical SDK repo
+
+#### Verification
+
+- `pnpm --filter @cubid/passport typecheck`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- add user-facing non-OIDC app disclosure history and revocation views so users can inspect and revoke Allow Page grants outside the OIDC consent panel

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4048,3 +4048,32 @@ Continue E01 by adding user-facing visibility and revocation for Allow Page disc
 #### Follow-up
 
 - yeet the E01 branch for review when ready, or close E01 metadata after the PR merges if this is the final E01 implementation slice
+
+### session: v142
+
+- timestamp: 2026-05-03T00:00:16Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-disclosure-claim-taxonomy**
+- head: **`00113f3`**
+- session name: **Reframe E02 around API v3 backend hardening**
+
+#### Objective
+
+Update stale E02 roadmap language so it reflects the current split between backend API ownership in `cubid-passport` and public SDK ownership in `Cubid-Me/cubid-sdk`.
+
+#### Actions Taken
+
+- retitled E02 around API v3 developer platform contracts, review, and hardening
+- preserved E02.1-E02.4 as SDK-ingested historical work rather than active private-repo implementation targets
+- added backend-owned E02.5-E02.8 todos for API v3 inventory, route hardening, webhook contracts, and SDK-impact coordination
+- created `docs/engineering/api-v3-developer-platform.md` as the backend-owned API v3 contract target
+- updated the SDK target-state doc so it points active E02 backend work at the API v3 engineering doc
+
+#### Verification
+
+- checked there were no incoming SDK-agent messages in `agent-context/messages-from-cubid-sdk/`
+- `git diff --check`
+
+#### Follow-up
+
+- implement E02.5 next to inventory and define the canonical API v3 contract in this repo before changing route behavior

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -522,9 +522,9 @@ Parallelization note: This section can run in parallel with `B`, `C`, and `D` on
 - Status: Started
 - Timestamp started: 2026-04-30T21:38:40Z
 - Timestamp completed: TBD
-- Feature branch: codex/e01-app-scoped-identity-disclosure
-- Head: 96ac1ff
-- Session-log reference(s): session: v126, session: v127, session: v137, session: v138
+- Feature branch: codex/e01-app-scoped-identity-disclosure; codex/e01-disclosure-claim-taxonomy
+- Head: 96ac1ff; continued from 63303ad
+- Session-log reference(s): session: v126, session: v127, session: v137, session: v138, session: v140
 
 Take the backgrounder’s core ideas seriously by making app-scoped identity and selective disclosure explicit platform capabilities instead of incidental behavior buried in Passport flows. Build a consent and disclosure service that owns per-app subject identifiers, claim release decisions, stamp-sharing permissions, and revocation behavior. Relying parties should never need raw cross-app identifiers or unnecessary PII; they should request scopes and receive only the allowed app-scoped values. This service should back the Allow Page, the OIDC consent model, SDK calls, and webhook payload filtering. Treat it as a foundational protocol service with strong typing, auditability, and user-visible history, not just a UX screen. Finishing this todo would align Cubid much more closely with the backgrounder’s privacy, protocol, and anti-tracking principles.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -530,12 +530,12 @@ Take the backgrounder’s core ideas seriously by making app-scoped identity and
 
 ### E02. Productize the developer platform: API v3 contracts, review, and hardening
 
-- Status: Ingested into cubid-sdk
+- Status: Completed
 - Timestamp started: 2026-04-28T08:28:44Z
-- Timestamp completed: 2026-04-30T14:00:53Z
-- Feature branch: Cubid-Me/cubid-sdk public SDK repository; backend review continues from cubid-passport feature branches
-- Head: see Cubid-Me/cubid-sdk SDK repo history; backend review starts after 00113f3
-- Session-log reference(s): session: v94, session: v95, session: v99, session: v100, session: v101, session: v102, session: v103, session: v104, session: v105, session: v106, session: v107, session: v114, session: v115, session: v116, session: v119, session: v120, session: v123, session: v142; Cubid-Me/cubid-sdk session: s01-core-adoption
+- Timestamp completed: 2026-05-03T00:43:54Z
+- Feature branch: Cubid-Me/cubid-sdk public SDK repository for SDK work; codex/e01-disclosure-claim-taxonomy for backend API v3 review
+- Head: see Cubid-Me/cubid-sdk SDK repo history for SDK work; backend API v3 review completed at 5b0504b
+- Session-log reference(s): session: v94, session: v95, session: v99, session: v100, session: v101, session: v102, session: v103, session: v104, session: v105, session: v106, session: v107, session: v114, session: v115, session: v116, session: v119, session: v120, session: v123, session: v142, session: v143, session: v144, session: v145, session: v146; Cubid-Me/cubid-sdk session: s01-core-adoption
 
 Reframe E02 around the current architecture split. `cubid-passport` owns the backend runtime: API behavior, route contracts, migrations, security, disclosure enforcement, v3 custody routes, and webhook delivery. `Cubid-Me/cubid-sdk` owns public SDK/API client implementation, examples, package publication, and external integration docs. The earlier E02 SDK package work has been ingested into the public SDK repo and remains historical context here. The active backend track is now API v3 review and hardening: inventory the canonical `/api/v3/*` surfaces, document which legacy `/api/v2/*` routes remain compatibility-only, tighten auth/validation/disclosure/idempotency/error behavior, and standardize webhook contracts around signed, replay-safe, disclosure-filtered protocol events. Any SDK-impacting backend change must create a handoff note for the public SDK agents instead of adding SDK code to this repo.
 
@@ -665,12 +665,12 @@ Define and harden the API v3 webhook runtime contract so downstream apps can con
 
 ### E02.8 Coordinate public SDK impact for API v3
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-05-03T00:43:54Z
+- Timestamp completed: 2026-05-03T00:43:54Z
+- Feature branch: codex/e01-disclosure-claim-taxonomy
+- Head: 5b0504b
+- Session-log reference(s): session: v146
 
 Keep the public SDK repo aligned with API v3 without reintroducing SDK implementation into `cubid-passport`. For every E02.5-E02.7 change that affects public route shape, response semantics, error categories, disclosure states, webhook payloads, examples, or migration guidance, create a concise message in `Cubid-Me/cubid-sdk` under `agent-context/messages-from-cubid-passport/`. The message should identify the backend commit or PR, describe the changed contract, say whether SDK consumers should treat it as additive, breaking, or documentation-only, and list expected SDK follow-ups. Also check `agent-context/messages-from-cubid-sdk/` in this repo before beginning each API v3 hardening slice. This todo closes when all known SDK-impact notes are created and no incoming SDK notes remain unaddressed.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -643,12 +643,12 @@ Create the backend source of truth for Cubid API v3 in `cubid-passport`, centere
 
 ### E02.6 Harden API v3 route behavior
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-05-03T00:23:24Z
+- Timestamp completed: 2026-05-03T00:35:03Z
+- Feature branch: codex/e01-disclosure-claim-taxonomy
+- Head: 6dd342e
+- Session-log reference(s): session: v144
 
 Review and harden the active API v3 routes so they are production-grade backend contracts rather than one-off feature endpoints. Keep the current route family small: `/api/v3/save_secret`, `/api/v3/accounts/generate`, and `/api/v3/accounts/list` unless the E02.5 contract intentionally adds more. Ensure every v3 route uses shared Passport API security helpers, dapp API-key authentication, explicit request schemas, ownership checks against the target dapp user, disclosure-aware behavior where relevant, stable error envelopes, request IDs, and no raw secret or private-key exposure. Add or tighten tests for malformed payloads, invalid dapp credentials, cross-dapp user attempts, unsupported chains, duplicate or retry behavior, and failure cleanup. Do not modify public SDK code here; document any SDK-visible behavior changes through the SDK handoff process.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -523,8 +523,8 @@ Parallelization note: This section can run in parallel with `B`, `C`, and `D` on
 - Timestamp started: 2026-04-30T21:38:40Z
 - Timestamp completed: TBD
 - Feature branch: codex/e01-app-scoped-identity-disclosure; codex/e01-disclosure-claim-taxonomy
-- Head: 96ac1ff; continued from 63303ad
-- Session-log reference(s): session: v126, session: v127, session: v137, session: v138, session: v140
+- Head: 96ac1ff; continued from 63303ad; 3123f99
+- Session-log reference(s): session: v126, session: v127, session: v137, session: v138, session: v140, session: v141
 
 Take the backgrounder’s core ideas seriously by making app-scoped identity and selective disclosure explicit platform capabilities instead of incidental behavior buried in Passport flows. Build a consent and disclosure service that owns per-app subject identifiers, claim release decisions, stamp-sharing permissions, and revocation behavior. Relying parties should never need raw cross-app identifiers or unnecessary PII; they should request scopes and receive only the allowed app-scoped values. This service should back the Allow Page, the OIDC consent model, SDK calls, and webhook payload filtering. Treat it as a foundational protocol service with strong typing, auditability, and user-visible history, not just a UX screen. Finishing this todo would align Cubid much more closely with the backgrounder’s privacy, protocol, and anti-tracking principles.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -528,16 +528,16 @@ Parallelization note: This section can run in parallel with `B`, `C`, and `D` on
 
 Take the backgrounder’s core ideas seriously by making app-scoped identity and selective disclosure explicit platform capabilities instead of incidental behavior buried in Passport flows. Build a consent and disclosure service that owns per-app subject identifiers, claim release decisions, stamp-sharing permissions, and revocation behavior. Relying parties should never need raw cross-app identifiers or unnecessary PII; they should request scopes and receive only the allowed app-scoped values. This service should back the Allow Page, the OIDC consent model, SDK calls, and webhook payload filtering. Treat it as a foundational protocol service with strong typing, auditability, and user-visible history, not just a UX screen. Finishing this todo would align Cubid much more closely with the backgrounder’s privacy, protocol, and anti-tracking principles.
 
-### E02. Productize the developer platform: REST API v2, React SDK, and webhook contracts
+### E02. Productize the developer platform: API v3 contracts, review, and hardening
 
 - Status: Ingested into cubid-sdk
 - Timestamp started: 2026-04-28T08:28:44Z
 - Timestamp completed: 2026-04-30T14:00:53Z
-- Feature branch: Cubid-Me/cubid-sdk public SDK repository
-- Head: see Cubid-Me/cubid-sdk SDK repo history
-- Session-log reference(s): session: v94, session: v95, session: v99, session: v100, session: v101, session: v102, session: v103, session: v104, session: v105, session: v106, session: v107, session: v114, session: v115, session: v116, session: v119, session: v120, session: v123; Cubid-Me/cubid-sdk session: s01-core-adoption
+- Feature branch: Cubid-Me/cubid-sdk public SDK repository; backend review continues from cubid-passport feature branches
+- Head: see Cubid-Me/cubid-sdk SDK repo history; backend review starts after 00113f3
+- Session-log reference(s): session: v94, session: v95, session: v99, session: v100, session: v101, session: v102, session: v103, session: v104, session: v105, session: v106, session: v107, session: v114, session: v115, session: v116, session: v119, session: v120, session: v123, session: v142; Cubid-Me/cubid-sdk session: s01-core-adoption
 
-Turn the current mixed bag of legacy routes into a coherent developer platform. Define the canonical REST API v2 surface for app onboarding, user creation, score lookup, identity queries, consent status, claim retrieval, and webhook registration. Build first-party packages on top of those stable contracts so integrators stop depending on internal UI code, local tarballs, or undocumented route behavior. That now explicitly includes a dual-target `@cubid/core` package that works from both npm and JSR, plus a publishable SDK ecosystem for React and chain-specific integrations: `@cubid/react`, `@cubid/evm`, `@cubid/wagmi`, `@cubid/solana`, `@cubid/cardano`, `@cubid/sui`, and `@cubid/near`. Standardize webhook events around meaningful protocol events such as consent granted, claim updated, score changed, stamp blacklisted, and subject revoked, with signed payloads and replay protection. Add versioning and compatibility rules so downstream apps can rely on Cubid as infrastructure rather than reverse-engineering a moving target.
+Reframe E02 around the current architecture split. `cubid-passport` owns the backend runtime: API behavior, route contracts, migrations, security, disclosure enforcement, v3 custody routes, and webhook delivery. `Cubid-Me/cubid-sdk` owns public SDK/API client implementation, examples, package publication, and external integration docs. The earlier E02 SDK package work has been ingested into the public SDK repo and remains historical context here. The active backend track is now API v3 review and hardening: inventory the canonical `/api/v3/*` surfaces, document which legacy `/api/v2/*` routes remain compatibility-only, tighten auth/validation/disclosure/idempotency/error behavior, and standardize webhook contracts around signed, replay-safe, disclosure-filtered protocol events. Any SDK-impacting backend change must create a handoff note for the public SDK agents instead of adding SDK code to this repo.
 
 ### E02.1 Publish `@cubid/core` as a dual-target runtime-agnostic package
 
@@ -629,6 +629,50 @@ Review the SDK prototype material now ingested into `Cubid-Me/cubid-sdk` as sour
 Ingested into `Cubid-Me/cubid-sdk` on 2026-04-30; continue Deno, publishing, and public-integration guidance there rather than from `cubid-passport`.
 
 Back the published packages with the DX and compatibility work needed for real external adoption. Add CI that proves `@cubid/core` is importable in Deno and usable in a Supabase-Edge-like environment, including a smoke import from the JSR form and a Deno-focused validation step in the normal package workflow. Write a dedicated integration guide for Next.js plus Supabase Edge that covers browser versus server usage, secret handling, phone OTP, provider handoff flows, and the post-return refresh pattern. Add copy-paste examples for resolving a Cubid user from an authenticated email, syncing an identity snapshot in an Edge Function, rendering linked or pending credential states in React, and collecting phone plus provider stamps after signup. Close with versioned API stability notes so downstream apps understand Cubid’s compatibility guarantees and deprecation posture.
+
+### E02.5 Inventory and define the canonical API v3 backend contract
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Create the backend source of truth for Cubid API v3 in `cubid-passport`, centered on `docs/engineering/api-v3-developer-platform.md`. Inventory every current `/api/v3/*` route, including encrypted dapp user secrets and blockchain account custody, and define the minimum canonical request/response contract for each route without moving SDK implementation into this repo. Explicitly classify `/api/v2/*` routes as legacy compatibility unless a specific future todo promotes a route into v3. Record shared expectations for dapp authentication, app-scoped identity, disclosure grants, non-exposure of secret material, structured errors, and idempotency. Before writing the contract, check for incoming SDK-agent notes in `agent-context/messages-from-cubid-sdk/`; after writing it, create outbound SDK notes only if the contract changes public SDK assumptions.
+
+### E02.6 Harden API v3 route behavior
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Review and harden the active API v3 routes so they are production-grade backend contracts rather than one-off feature endpoints. Keep the current route family small: `/api/v3/save_secret`, `/api/v3/accounts/generate`, and `/api/v3/accounts/list` unless the E02.5 contract intentionally adds more. Ensure every v3 route uses shared Passport API security helpers, dapp API-key authentication, explicit request schemas, ownership checks against the target dapp user, disclosure-aware behavior where relevant, stable error envelopes, request IDs, and no raw secret or private-key exposure. Add or tighten tests for malformed payloads, invalid dapp credentials, cross-dapp user attempts, unsupported chains, duplicate or retry behavior, and failure cleanup. Do not modify public SDK code here; document any SDK-visible behavior changes through the SDK handoff process.
+
+### E02.7 Standardize API v3 webhook contracts
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Define and harden the API v3 webhook runtime contract so downstream apps can consume Cubid events safely. Review current webhook trigger paths, signing-secret custody, disclosure filtering, retry behavior, and audit/security events, then document the canonical event families for v3: disclosure granted or revoked, stamp or claim updated, score changed, credential blacklisted, subject revoked, and custody/account lifecycle events where appropriate. Standardize signed payload fields, timestamp and nonce or event-id replay protection, delivery attempt metadata, failure recording, and redaction rules. Ensure webhook payloads never bypass app-scoped identity or disclosure grants, and ensure revoked grants stop future delivery. Add representative tests for signature generation, replay-protection inputs, disclosure-filtered payloads, failed delivery bookkeeping, and redaction of internal identifiers.
+
+### E02.8 Coordinate public SDK impact for API v3
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Keep the public SDK repo aligned with API v3 without reintroducing SDK implementation into `cubid-passport`. For every E02.5-E02.7 change that affects public route shape, response semantics, error categories, disclosure states, webhook payloads, examples, or migration guidance, create a concise message in `Cubid-Me/cubid-sdk` under `agent-context/messages-from-cubid-passport/`. The message should identify the backend commit or PR, describe the changed contract, say whether SDK consumers should treat it as additive, breaking, or documentation-only, and list expected SDK follow-ups. Also check `agent-context/messages-from-cubid-sdk/` in this repo before beginning each API v3 hardening slice. This todo closes when all known SDK-impact notes are created and no incoming SDK notes remain unaddressed.
 
 ### E03. Add agent and organization identity support, including MCP-compatible interfaces
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -654,12 +654,12 @@ Review and harden the active API v3 routes so they are production-grade backend 
 
 ### E02.7 Standardize API v3 webhook contracts
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-05-03T00:40:34Z
+- Timestamp completed: 2026-05-03T00:40:34Z
+- Feature branch: codex/e01-disclosure-claim-taxonomy
+- Head: 7f8aa93
+- Session-log reference(s): session: v145
 
 Define and harden the API v3 webhook runtime contract so downstream apps can consume Cubid events safely. Review current webhook trigger paths, signing-secret custody, disclosure filtering, retry behavior, and audit/security events, then document the canonical event families for v3: disclosure granted or revoked, stamp or claim updated, score changed, credential blacklisted, subject revoked, and custody/account lifecycle events where appropriate. Standardize signed payload fields, timestamp and nonce or event-id replay protection, delivery attempt metadata, failure recording, and redaction rules. Ensure webhook payloads never bypass app-scoped identity or disclosure grants, and ensure revoked grants stop future delivery. Add representative tests for signature generation, replay-protection inputs, disclosure-filtered payloads, failed delivery bookkeeping, and redaction of internal identifiers.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -632,12 +632,12 @@ Back the published packages with the DX and compatibility work needed for real e
 
 ### E02.5 Inventory and define the canonical API v3 backend contract
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-05-03T00:05:30Z
+- Timestamp completed: 2026-05-03T00:05:30Z
+- Feature branch: codex/e01-disclosure-claim-taxonomy
+- Head: 4c1a9ca
+- Session-log reference(s): session: v143
 
 Create the backend source of truth for Cubid API v3 in `cubid-passport`, centered on `docs/engineering/api-v3-developer-platform.md`. Inventory every current `/api/v3/*` route, including encrypted dapp user secrets and blockchain account custody, and define the minimum canonical request/response contract for each route without moving SDK implementation into this repo. Explicitly classify `/api/v2/*` routes as legacy compatibility unless a specific future todo promotes a route into v3. Record shared expectations for dapp authentication, app-scoped identity, disclosure grants, non-exposure of secret material, structured errors, and idempotency. Before writing the contract, check for incoming SDK-agent notes in `agent-context/messages-from-cubid-sdk/`; after writing it, create outbound SDK notes only if the contract changes public SDK assumptions.
 

--- a/apps/passport/components/profile/index.tsx
+++ b/apps/passport/components/profile/index.tsx
@@ -59,6 +59,26 @@ type OidcConsentSummary = {
   revokedBy: "user" | "operator" | null
 }
 
+type AppDisclosureGrantSummary = {
+  appName: string
+  appScopedSubject: string | null
+  claimClassificationSummary: Array<{
+    claim: string
+    dataClass: string
+  }>
+  consentVersion: number
+  dappId: string
+  dappUserUuid: string | null
+  grantId: string
+  grantedAt: string
+  grantedClaims: string[]
+  grantedScopes: string[]
+  policyVersion: string
+  revokedAt: string | null
+  revokedBy: "user" | "operator" | "system" | null
+  source: "allow_page"
+}
+
 type PasskeyDeviceSummary = {
   authenticatorAttachment: string | null
   backupEligible: boolean
@@ -185,6 +205,13 @@ export const Profile = () => {
   const [revokingConsentId, setRevokingConsentId] = useState<string | null>(
     null
   )
+  const [appDisclosureGrants, setAppDisclosureGrants] = useState<
+    AppDisclosureGrantSummary[]
+  >([])
+  const [appDisclosureGrantsLoading, setAppDisclosureGrantsLoading] =
+    useState(false)
+  const [revokingAppDisclosureGrantId, setRevokingAppDisclosureGrantId] =
+    useState<string | null>(null)
   const [actorProfile, setActorProfile] = useState<ActorProfileSummary | null>(
     null
   )
@@ -571,6 +598,63 @@ export const Profile = () => {
       }
     },
     [fetchOidcConsents, getOidcAuthHeaders]
+  )
+
+  const fetchAppDisclosureGrants = useCallback(async () => {
+    if (!email && !phone) {
+      setAppDisclosureGrants([])
+      return
+    }
+
+    setAppDisclosureGrantsLoading(true)
+    try {
+      const headers = await getOidcAuthHeaders()
+      const { data } = await axios.post<{ data: AppDisclosureGrantSummary[] }>(
+        "/api/disclosures/app-grants/list",
+        {},
+        { headers }
+      )
+      setAppDisclosureGrants(data.data ?? [])
+    } catch (error) {
+      console.error(error)
+      toast.error("Failed to load app disclosure grants")
+    } finally {
+      setAppDisclosureGrantsLoading(false)
+    }
+  }, [email, phone, getOidcAuthHeaders])
+
+  useEffect(() => {
+    fetchAppDisclosureGrants()
+  }, [fetchAppDisclosureGrants])
+
+  const revokeAppDisclosureGrant = useCallback(
+    async (grant: AppDisclosureGrantSummary) => {
+      if (
+        !window.confirm(
+          `Revoke Allow Page access for ${grant.appName}? This can remove shared stamp permissions for that app.`
+        )
+      ) {
+        return
+      }
+
+      setRevokingAppDisclosureGrantId(grant.grantId)
+      try {
+        const headers = await getOidcAuthHeaders()
+        await axios.post(
+          "/api/disclosures/app-grants/revoke",
+          { grantId: grant.grantId },
+          { headers }
+        )
+        toast.success("App disclosure grant revoked")
+        await fetchAppDisclosureGrants()
+      } catch (error) {
+        console.error(error)
+        toast.error("Failed to revoke app disclosure grant")
+      } finally {
+        setRevokingAppDisclosureGrantId(null)
+      }
+    },
+    [fetchAppDisclosureGrants, getOidcAuthHeaders]
   )
 
   const selectedActorPolicy = actorValidationPolicies[actorType]
@@ -1030,6 +1114,139 @@ export const Profile = () => {
             </Button>
           </CardContent>
         </Card>
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>App disclosure grants</CardTitle>
+            <CardDescription>
+              Manage non-OIDC apps that received Cubid data through Allow Page
+              sharing. Revoking a grant stops that app from seeing the granted
+              profile, location, or stamp claims through Cubid APIs.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4 flex justify-end">
+              <Button
+                disabled={appDisclosureGrantsLoading}
+                onClick={fetchAppDisclosureGrants}
+                variant="outline"
+              >
+                {appDisclosureGrantsLoading ? "Refreshing..." : "Refresh"}
+              </Button>
+            </div>
+            {appDisclosureGrantsLoading && appDisclosureGrants.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                Loading app disclosure grants...
+              </p>
+            )}
+            {!appDisclosureGrantsLoading &&
+              appDisclosureGrants.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  No non-OIDC app disclosure grants found.
+                </p>
+              )}
+            <div className="space-y-3">
+              {appDisclosureGrants.map((grant) => {
+                const isRevoked = Boolean(grant.revokedAt)
+
+                return (
+                  <div
+                    key={grant.grantId}
+                    className="rounded-lg border bg-background p-4"
+                  >
+                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="font-semibold">{grant.appName}</h3>
+                          <span
+                            className={`rounded-full px-2 py-1 text-xs ${
+                              isRevoked
+                                ? "bg-red-100 text-red-700"
+                                : "bg-emerald-100 text-emerald-700"
+                            }`}
+                          >
+                            {isRevoked ? "Revoked" : "Active"}
+                          </span>
+                          <span className="rounded-full bg-muted px-2 py-1 text-xs">
+                            Allow Page
+                          </span>
+                        </div>
+                        <p className="mt-1 break-all text-xs text-muted-foreground">
+                          Dapp {grant.dappId}
+                          {grant.dappUserUuid
+                            ? ` · user ${grant.dappUserUuid}`
+                            : ""}
+                        </p>
+                      </div>
+                      {!isRevoked && (
+                        <Button
+                          disabled={
+                            revokingAppDisclosureGrantId === grant.grantId
+                          }
+                          onClick={() => revokeAppDisclosureGrant(grant)}
+                          variant="outline"
+                        >
+                          {revokingAppDisclosureGrantId === grant.grantId
+                            ? "Revoking..."
+                            : "Revoke access"}
+                        </Button>
+                      )}
+                    </div>
+
+                    <div className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+                      <p>
+                        <span className="text-muted-foreground">Scopes:</span>{" "}
+                        {formatList(grant.grantedScopes)}
+                      </p>
+                      <p>
+                        <span className="text-muted-foreground">Claims:</span>{" "}
+                        {formatList(grant.grantedClaims)}
+                      </p>
+                      <p>
+                        <span className="text-muted-foreground">Policy:</span>{" "}
+                        {grant.policyVersion}
+                      </p>
+                      <p>
+                        <span className="text-muted-foreground">Version:</span>{" "}
+                        {grant.consentVersion}
+                      </p>
+                      <p>
+                        <span className="text-muted-foreground">Granted:</span>{" "}
+                        {dayjs(grant.grantedAt).format("YYYY-MM-DD HH:mm")}
+                      </p>
+                      <p>
+                        <span className="text-muted-foreground">Revoked:</span>{" "}
+                        {grant.revokedAt
+                          ? `${dayjs(grant.revokedAt).format(
+                              "YYYY-MM-DD HH:mm"
+                            )} by ${grant.revokedBy}`
+                          : "No"}
+                      </p>
+                    </div>
+
+                    {grant.claimClassificationSummary.length > 0 && (
+                      <div className="mt-4">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Data classifications
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {grant.claimClassificationSummary.map((entry) => (
+                            <span
+                              key={`${grant.grantId}-${entry.claim}`}
+                              className="rounded-full bg-muted px-3 py-1 text-xs"
+                            >
+                              {entry.claim}: {entry.dataClass}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+
         <Card className="md:col-span-2">
           <CardHeader>
             <CardTitle>Login with Cubid access</CardTitle>

--- a/apps/passport/lib/server/apiV3Idempotency.ts
+++ b/apps/passport/lib/server/apiV3Idempotency.ts
@@ -119,7 +119,19 @@ const handleExistingRecord = (
     )
   }
 
-  return null
+  if (record.status === "failed") {
+    throw new ApiSecurityError(
+      409,
+      "idempotency_failed",
+      "A previous request with this Idempotency-Key failed. Check operation state before retrying with a new key."
+    )
+  }
+
+  throw new ApiSecurityError(
+    409,
+    "request_in_progress",
+    "A request with this Idempotency-Key is still in progress."
+  )
 }
 
 const pendingPatch = (input: {
@@ -221,31 +233,6 @@ export async function runApiV3IdempotentWrite(input: {
       if (replay) {
         return replay
       }
-
-      const { data: reclaimedRecord, error: reclaimError } = await input.supabase
-        .from("api_idempotency_keys")
-        .update(pendingPatch({ expiresAt, requestHash, requestId: input.requestId }))
-        .eq("route", input.route)
-        .eq("actor_type", input.actorType)
-        .eq("actor_identifier", input.actorIdentifier)
-        .eq("idempotency_key", input.idempotencyKey)
-        .eq("status", record.status)
-        .select("*")
-        .maybeSingle()
-
-      if (reclaimError) {
-        throw reclaimError
-      }
-
-      if (!reclaimedRecord) {
-        throw new ApiSecurityError(
-          409,
-          "request_in_progress",
-          "A request with this Idempotency-Key is still in progress."
-        )
-      }
-
-      hasClaimedRecord = true
     }
   }
 

--- a/apps/passport/lib/server/apiV3Idempotency.ts
+++ b/apps/passport/lib/server/apiV3Idempotency.ts
@@ -122,6 +122,22 @@ const handleExistingRecord = (
   return null
 }
 
+const pendingPatch = (input: {
+  expiresAt: string
+  requestHash: string
+  requestId: string
+}) => ({
+  completed_at: null,
+  expires_at: input.expiresAt,
+  failed_at: null,
+  request_hash: input.requestHash,
+  request_id: input.requestId,
+  response_body: null,
+  response_status: null,
+  status: "pending",
+  updated_at: new Date().toISOString(),
+})
+
 export async function runApiV3IdempotentWrite(input: {
   actorIdentifier: string
   actorType: string
@@ -152,39 +168,84 @@ export async function runApiV3IdempotentWrite(input: {
   }
 
   if (existingRecord) {
+    const record = existingRecord as ApiV3IdempotencyRecord
+
     if (isExpiredRecord(existingRecord as ApiV3IdempotencyRecord)) {
-      const { error: reclaimError } = await input.supabase
+      const { data: reclaimedRecord, error: reclaimError } = await input.supabase
         .from("api_idempotency_keys")
-        .update({
-          completed_at: null,
-          expires_at: expiresAt,
-          failed_at: null,
-          request_hash: requestHash,
-          request_id: input.requestId,
-          response_body: null,
-          response_status: null,
-          status: "pending",
-          updated_at: new Date().toISOString(),
-        })
+        .update(pendingPatch({ expiresAt, requestHash, requestId: input.requestId }))
         .eq("route", input.route)
         .eq("actor_type", input.actorType)
         .eq("actor_identifier", input.actorIdentifier)
         .eq("idempotency_key", input.idempotencyKey)
+        .eq("status", record.status)
+        .select("*")
+        .maybeSingle()
 
       if (reclaimError) {
         throw reclaimError
       }
 
+      if (!reclaimedRecord) {
+        const { data: currentRecord, error: currentError } = await lookup()
+
+        if (currentError) {
+          throw currentError
+        }
+
+        if (currentRecord) {
+          const replay = handleExistingRecord(
+            currentRecord as ApiV3IdempotencyRecord,
+            requestHash
+          )
+
+          if (replay) {
+            return replay
+          }
+        }
+
+        throw new ApiSecurityError(
+          409,
+          "request_in_progress",
+          "A request with this Idempotency-Key is still in progress."
+        )
+      }
+
       hasClaimedRecord = true
     } else {
       const replay = handleExistingRecord(
-        existingRecord as ApiV3IdempotencyRecord,
+        record,
         requestHash
       )
 
       if (replay) {
         return replay
       }
+
+      const { data: reclaimedRecord, error: reclaimError } = await input.supabase
+        .from("api_idempotency_keys")
+        .update(pendingPatch({ expiresAt, requestHash, requestId: input.requestId }))
+        .eq("route", input.route)
+        .eq("actor_type", input.actorType)
+        .eq("actor_identifier", input.actorIdentifier)
+        .eq("idempotency_key", input.idempotencyKey)
+        .eq("status", record.status)
+        .select("*")
+        .maybeSingle()
+
+      if (reclaimError) {
+        throw reclaimError
+      }
+
+      if (!reclaimedRecord) {
+        throw new ApiSecurityError(
+          409,
+          "request_in_progress",
+          "A request with this Idempotency-Key is still in progress."
+        )
+      }
+
+      hasClaimedRecord = true
     }
   }
 
@@ -222,6 +283,12 @@ export async function runApiV3IdempotentWrite(input: {
         if (replay) {
           return replay
         }
+
+        throw new ApiSecurityError(
+          409,
+          "request_in_progress",
+          "A request with this Idempotency-Key is still in progress."
+        )
       }
     }
   }

--- a/apps/passport/lib/server/apiV3Idempotency.ts
+++ b/apps/passport/lib/server/apiV3Idempotency.ts
@@ -1,0 +1,265 @@
+import { createHash } from "node:crypto"
+
+import { ApiSecurityError } from "@cubid/auth/server"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { NextApiRequest } from "next"
+
+type ApiV3IdempotencyRecord = {
+  actor_identifier: string
+  actor_type: string
+  expires_at: string
+  idempotency_key: string
+  request_hash: string
+  request_id: string | null
+  response_body: unknown
+  response_status: number | null
+  route: string
+  status: string
+}
+
+export type ApiV3RouteResponse = {
+  body: unknown
+  statusCode: number
+}
+
+const IDEMPOTENCY_KEY_MAX_LENGTH = 200
+const IDEMPOTENCY_RETENTION_MS = 24 * 60 * 60 * 1000
+
+const stableValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(stableValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, stableValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+const isUniqueConstraintError = (error: unknown) => {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "23505"
+  )
+}
+
+const isExpiredRecord = (record: ApiV3IdempotencyRecord) => {
+  return new Date(record.expires_at).getTime() <= Date.now()
+}
+
+const getHeaderValue = (req: NextApiRequest, headerName: string) => {
+  const value = req.headers[headerName.toLowerCase()]
+
+  if (Array.isArray(value)) {
+    return value[0] ?? null
+  }
+
+  return typeof value === "string" ? value : null
+}
+
+export const getApiV3IdempotencyKey = (req: NextApiRequest) => {
+  const value = getHeaderValue(req, "idempotency-key")?.trim()
+
+  if (!value) {
+    throw new ApiSecurityError(
+      400,
+      "invalid_request",
+      "Missing Idempotency-Key header."
+    )
+  }
+
+  if (value.length > IDEMPOTENCY_KEY_MAX_LENGTH) {
+    throw new ApiSecurityError(
+      400,
+      "invalid_request",
+      "Idempotency-Key header is too long."
+    )
+  }
+
+  return value
+}
+
+export const hashApiV3IdempotencyRequest = (body: unknown) => {
+  return createHash("sha256")
+    .update(JSON.stringify(stableValue(body)))
+    .digest("hex")
+}
+
+const handleExistingRecord = (
+  record: ApiV3IdempotencyRecord,
+  requestHash: string
+): ApiV3RouteResponse | null => {
+  if (record.request_hash !== requestHash) {
+    throw new ApiSecurityError(
+      409,
+      "idempotency_conflict",
+      "Idempotency-Key was already used with a different request."
+    )
+  }
+
+  if (record.status === "completed") {
+    return {
+      body: record.response_body,
+      statusCode: Number(record.response_status ?? 200),
+    }
+  }
+
+  if (record.status === "pending") {
+    throw new ApiSecurityError(
+      409,
+      "request_in_progress",
+      "A request with this Idempotency-Key is still in progress."
+    )
+  }
+
+  return null
+}
+
+export async function runApiV3IdempotentWrite(input: {
+  actorIdentifier: string
+  actorType: string
+  body: unknown
+  handler: () => Promise<ApiV3RouteResponse>
+  idempotencyKey: string
+  requestId: string
+  route: string
+  supabase: SupabaseClient
+}): Promise<ApiV3RouteResponse> {
+  const requestHash = hashApiV3IdempotencyRequest(input.body)
+  const expiresAt = new Date(Date.now() + IDEMPOTENCY_RETENTION_MS).toISOString()
+  const lookup = () =>
+    input.supabase
+      .from("api_idempotency_keys")
+      .select("*")
+      .eq("route", input.route)
+      .eq("actor_type", input.actorType)
+      .eq("actor_identifier", input.actorIdentifier)
+      .eq("idempotency_key", input.idempotencyKey)
+      .maybeSingle()
+
+  const { data: existingRecord, error: existingError } = await lookup()
+  let hasClaimedRecord = false
+
+  if (existingError) {
+    throw existingError
+  }
+
+  if (existingRecord) {
+    if (isExpiredRecord(existingRecord as ApiV3IdempotencyRecord)) {
+      const { error: reclaimError } = await input.supabase
+        .from("api_idempotency_keys")
+        .update({
+          completed_at: null,
+          expires_at: expiresAt,
+          failed_at: null,
+          request_hash: requestHash,
+          request_id: input.requestId,
+          response_body: null,
+          response_status: null,
+          status: "pending",
+          updated_at: new Date().toISOString(),
+        })
+        .eq("route", input.route)
+        .eq("actor_type", input.actorType)
+        .eq("actor_identifier", input.actorIdentifier)
+        .eq("idempotency_key", input.idempotencyKey)
+
+      if (reclaimError) {
+        throw reclaimError
+      }
+
+      hasClaimedRecord = true
+    } else {
+      const replay = handleExistingRecord(
+        existingRecord as ApiV3IdempotencyRecord,
+        requestHash
+      )
+
+      if (replay) {
+        return replay
+      }
+    }
+  }
+
+  if (!hasClaimedRecord) {
+    const { error: insertError } = await input.supabase
+      .from("api_idempotency_keys")
+      .insert({
+        actor_identifier: input.actorIdentifier,
+        actor_type: input.actorType,
+        expires_at: expiresAt,
+        idempotency_key: input.idempotencyKey,
+        request_hash: requestHash,
+        request_id: input.requestId,
+        route: input.route,
+        status: "pending",
+      })
+
+    if (insertError) {
+      if (!isUniqueConstraintError(insertError)) {
+        throw insertError
+      }
+
+      const { data: racedRecord, error: racedError } = await lookup()
+
+      if (racedError) {
+        throw racedError
+      }
+
+      if (racedRecord) {
+        const replay = handleExistingRecord(
+          racedRecord as ApiV3IdempotencyRecord,
+          requestHash
+        )
+
+        if (replay) {
+          return replay
+        }
+      }
+    }
+  }
+
+  try {
+    const response = await input.handler()
+    const { error: completeError } = await input.supabase
+      .from("api_idempotency_keys")
+      .update({
+        completed_at: new Date().toISOString(),
+        response_body: response.body,
+        response_status: response.statusCode,
+        status: "completed",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("route", input.route)
+      .eq("actor_type", input.actorType)
+      .eq("actor_identifier", input.actorIdentifier)
+      .eq("idempotency_key", input.idempotencyKey)
+
+    if (completeError) {
+      throw completeError
+    }
+
+    return response
+  } catch (error) {
+    await input.supabase
+      .from("api_idempotency_keys")
+      .update({
+        failed_at: new Date().toISOString(),
+        status: "failed",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("route", input.route)
+      .eq("actor_type", input.actorType)
+      .eq("actor_identifier", input.actorIdentifier)
+      .eq("idempotency_key", input.idempotencyKey)
+
+    throw error
+  }
+}

--- a/apps/passport/lib/server/apiV3Webhooks.ts
+++ b/apps/passport/lib/server/apiV3Webhooks.ts
@@ -1,0 +1,147 @@
+import crypto from "crypto"
+
+export const API_V3_WEBHOOK_VERSION = "v3" as const
+export const API_V3_WEBHOOK_PAYLOAD_VERSION = "2026-05-03" as const
+export const API_V3_WEBHOOK_SIGNATURE_VERSION = "v1" as const
+
+export const LEGACY_TO_API_V3_WEBHOOK_EVENT = {
+  credential_added: "stamp.created",
+  credential_blacklisted: "credential.blacklisted",
+  credential_expired: "credential.expired",
+  credential_removed: "stamp.removed",
+  credential_whitelisted: "credential.whitelisted",
+  score_decrease: "score.decreased",
+  score_increase: "score.increased",
+} as const
+
+export type LegacyWebhookEventType = keyof typeof LEGACY_TO_API_V3_WEBHOOK_EVENT
+
+export type ApiV3WebhookPayload = {
+  apiVersion: typeof API_V3_WEBHOOK_VERSION
+  createdAt: string
+  dapp: {
+    id: string
+  }
+  data: {
+    stampId: number
+  }
+  eventId: string
+  eventType: (typeof LEGACY_TO_API_V3_WEBHOOK_EVENT)[LegacyWebhookEventType]
+  legacyEventType: LegacyWebhookEventType
+  payloadVersion: typeof API_V3_WEBHOOK_PAYLOAD_VERSION
+  requestId: string
+  subject: {
+    dappUserUuid: string
+  }
+}
+
+const sha256Hex = (value: string) =>
+  crypto.createHash("sha256").update(value).digest("hex")
+
+export const buildApiV3WebhookEventId = (input: {
+  dappId: number | string
+  dappUserUuid: string
+  legacyEventType: LegacyWebhookEventType
+  stampId: number
+}) => {
+  const digest = sha256Hex(
+    [
+      API_V3_WEBHOOK_VERSION,
+      input.dappId,
+      input.dappUserUuid,
+      input.legacyEventType,
+      input.stampId,
+    ].join(":")
+  )
+  return `wh_evt_${digest.slice(0, 32)}`
+}
+
+export const buildApiV3WebhookPayload = (input: {
+  createdAt?: string
+  dappId: number | string
+  dappUserUuid: string
+  legacyEventType: LegacyWebhookEventType
+  requestId: string
+  stampId: number
+}): ApiV3WebhookPayload => {
+  return {
+    apiVersion: API_V3_WEBHOOK_VERSION,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    dapp: {
+      id: String(input.dappId),
+    },
+    data: {
+      stampId: input.stampId,
+    },
+    eventId: buildApiV3WebhookEventId(input),
+    eventType: LEGACY_TO_API_V3_WEBHOOK_EVENT[input.legacyEventType],
+    legacyEventType: input.legacyEventType,
+    payloadVersion: API_V3_WEBHOOK_PAYLOAD_VERSION,
+    requestId: input.requestId,
+    subject: {
+      dappUserUuid: input.dappUserUuid,
+    },
+  }
+}
+
+export const serializeApiV3WebhookPayload = (
+  payload: ApiV3WebhookPayload
+) => JSON.stringify(payload)
+
+export const signApiV3WebhookPayload = (input: {
+  body: string
+  eventId: string
+  secret: string
+  timestamp: string
+}) => {
+  const signedPayload = [
+    input.eventId,
+    input.timestamp,
+    input.body,
+  ].join(".")
+  const digest = crypto
+    .createHmac("sha256", input.secret)
+    .update(signedPayload)
+    .digest("hex")
+
+  return `${API_V3_WEBHOOK_SIGNATURE_VERSION}=${digest}`
+}
+
+export const buildApiV3WebhookHeaders = (input: {
+  body: string
+  eventId: string
+  secret: string
+  timestamp?: string
+}) => {
+  const timestamp = input.timestamp ?? new Date().toISOString()
+  return {
+    "Content-Type": "application/json",
+    "X-Cubid-Event-Id": input.eventId,
+    "X-Cubid-Signature": signApiV3WebhookPayload({
+      body: input.body,
+      eventId: input.eventId,
+      secret: input.secret,
+      timestamp,
+    }),
+    "X-Cubid-Signature-Version": API_V3_WEBHOOK_SIGNATURE_VERSION,
+    "X-Cubid-Timestamp": timestamp,
+  }
+}
+
+export const classifyApiV3WebhookDeliveryError = (error: unknown) => {
+  const maybeAxiosError = error as {
+    code?: unknown
+    response?: { status?: unknown }
+  }
+
+  if (maybeAxiosError.response) {
+    const status = Number(maybeAxiosError.response.status ?? 0)
+    return status >= 500 ? "server_error" : "client_error"
+  }
+
+  if (typeof maybeAxiosError.code === "string") {
+    return "network_error"
+  }
+
+  return "request_error"
+}

--- a/apps/passport/lib/server/appDisclosureManagement.ts
+++ b/apps/passport/lib/server/appDisclosureManagement.ts
@@ -1,0 +1,386 @@
+import { randomUUID } from "node:crypto"
+import type { NextApiRequest } from "next"
+import { ApiSecurityError } from "@cubid/auth/server"
+import { getStampTypeId } from "@cubid/stamps"
+
+import {
+  normalizeStringArray,
+  requirePassportFirebaseUser,
+} from "./oidcConsentManagement"
+import { getPassportSupabase } from "./supabase"
+
+type AppScopedSubjectRow = {
+  app_scoped_subject: string
+  cubid_user_id: number | string | null
+  dapp_id: number | string | null
+  dapp_user_uuid: string | null
+  id: string
+}
+
+type AppDisclosureGrantRow = {
+  app_scoped_subject_id: string
+  consent_version: number
+  dapp_id: number | string
+  granted_at: string
+  granted_claims: unknown
+  granted_scopes: unknown
+  id: string
+  metadata: unknown
+  policy_version: string
+  revoked_at: string | null
+  revoked_by: "user" | "operator" | "system" | null
+  source: string
+  status: "active" | "revoked"
+}
+
+type DappRow = {
+  appname?: string | null
+  id: number | string
+}
+
+type StampRow = {
+  id: number | string
+  stamptype: number | string
+}
+
+export type PassportAppDisclosureGrantSummary = {
+  appName: string
+  appScopedSubject: string | null
+  claimClassificationSummary: Array<{
+    claim: string
+    dataClass: string
+  }>
+  consentVersion: number
+  dappId: string
+  dappUserUuid: string | null
+  grantId: string
+  grantedAt: string
+  grantedClaims: string[]
+  grantedScopes: string[]
+  policyVersion: string
+  revokedAt: string | null
+  revokedBy: "user" | "operator" | "system" | null
+  source: "allow_page"
+}
+
+const normalizeGrantedClaims = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.flatMap((entry) => {
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as { claim?: unknown }).claim === "string"
+    ) {
+      return [(entry as { claim: string }).claim]
+    }
+
+    if (typeof entry === "string") {
+      return [entry]
+    }
+
+    return []
+  })
+}
+
+const normalizeClaimClassificationSummary = (value: unknown) => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.flatMap((entry) => {
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as { claim?: unknown }).claim === "string"
+    ) {
+      return [
+        {
+          claim: (entry as { claim: string }).claim,
+          dataClass:
+            typeof (entry as { dataClass?: unknown }).dataClass === "string"
+              ? (entry as { dataClass: string }).dataClass
+              : "json",
+        },
+      ]
+    }
+
+    return []
+  })
+}
+
+const resolvePassportUserIds = async (req: NextApiRequest) => {
+  const token = await requirePassportFirebaseUser(req)
+  const supabase = getPassportSupabase()
+  const userIds = new Set<number>()
+
+  if (token.email) {
+    const { data, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("email", token.email)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+    if (typeof data?.id === "number") {
+      userIds.add(data.id)
+    }
+  }
+
+  if (token.phone_number) {
+    const { data, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("phone", token.phone_number)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+    if (typeof data?.id === "number") {
+      userIds.add(data.id)
+    }
+  }
+
+  return [...userIds]
+}
+
+const loadOwnedAllowPageGrants = async (req: NextApiRequest) => {
+  const supabase = getPassportSupabase()
+  const userIds = await resolvePassportUserIds(req)
+
+  if (userIds.length === 0) {
+    return {
+      dappsById: new Map<string, DappRow>(),
+      grantRows: [] as AppDisclosureGrantRow[],
+      subjectsById: new Map<string, AppScopedSubjectRow>(),
+      userIds,
+    }
+  }
+
+  const { data: subjectRows, error: subjectError } = await supabase
+    .from("app_scoped_subjects")
+    .select("id,app_scoped_subject,dapp_id,dapp_user_uuid,cubid_user_id")
+    .in("cubid_user_id", userIds)
+    .eq("status", "active")
+
+  if (subjectError) {
+    throw subjectError
+  }
+
+  const ownedSubjects = ((subjectRows ?? []) as AppScopedSubjectRow[]).filter(
+    (subject) => subject.dapp_id !== null && subject.dapp_id !== undefined
+  )
+  const subjectIds = ownedSubjects.map((subject) => subject.id)
+  const subjectsById = new Map(
+    ownedSubjects.map((subject) => [subject.id, subject])
+  )
+
+  if (subjectIds.length === 0) {
+    return {
+      dappsById: new Map<string, DappRow>(),
+      grantRows: [] as AppDisclosureGrantRow[],
+      subjectsById,
+      userIds,
+    }
+  }
+
+  const { data: grantRows, error: grantError } = await supabase
+    .from("selective_disclosure_grants")
+    .select(
+      "id,app_scoped_subject_id,dapp_id,source,granted_scopes,granted_claims,policy_version,consent_version,status,granted_at,revoked_at,revoked_by,metadata"
+    )
+    .in("app_scoped_subject_id", subjectIds)
+    .eq("source", "allow_page")
+
+  if (grantError) {
+    throw grantError
+  }
+
+  const dappIds = [
+    ...new Set(
+      ((grantRows ?? []) as AppDisclosureGrantRow[]).map((grant) =>
+        String(grant.dapp_id)
+      )
+    ),
+  ]
+  const dappsById = new Map<string, DappRow>()
+
+  if (dappIds.length > 0) {
+    const { data: dappRows, error: dappError } = await supabase
+      .from("dapps")
+      .select("id,appname")
+      .in("id", dappIds)
+
+    if (dappError) {
+      throw dappError
+    }
+
+    for (const dapp of (dappRows ?? []) as DappRow[]) {
+      dappsById.set(String(dapp.id), dapp)
+    }
+  }
+
+  return {
+    dappsById,
+    grantRows: ((grantRows ?? []) as AppDisclosureGrantRow[]).sort((left, right) =>
+      String(right.granted_at).localeCompare(String(left.granted_at))
+    ),
+    subjectsById,
+    userIds,
+  }
+}
+
+export const listPassportAppDisclosureGrants = async (
+  req: NextApiRequest
+): Promise<PassportAppDisclosureGrantSummary[]> => {
+  const { dappsById, grantRows, subjectsById } = await loadOwnedAllowPageGrants(req)
+
+  return grantRows.map((grant) => {
+    const subject = subjectsById.get(grant.app_scoped_subject_id) ?? null
+    const dappId = String(grant.dapp_id)
+    return {
+      appName: dappsById.get(dappId)?.appname ?? `Dapp ${dappId}`,
+      appScopedSubject: subject?.app_scoped_subject ?? null,
+      claimClassificationSummary: normalizeClaimClassificationSummary(
+        grant.granted_claims
+      ),
+      consentVersion: grant.consent_version,
+      dappId,
+      dappUserUuid: subject?.dapp_user_uuid ?? null,
+      grantId: grant.id,
+      grantedAt: grant.granted_at,
+      grantedClaims: normalizeGrantedClaims(grant.granted_claims),
+      grantedScopes: normalizeStringArray(grant.granted_scopes),
+      policyVersion: grant.policy_version,
+      revokedAt: grant.revoked_at,
+      revokedBy: grant.revoked_by,
+      source: "allow_page",
+    }
+  })
+}
+
+const revokeLegacyStampPermissions = async (input: {
+  dappUserUuid: string | null
+  grant: AppDisclosureGrantRow
+  userId: number | string | null
+}) => {
+  if (!input.dappUserUuid || input.userId === null || input.userId === undefined) {
+    return
+  }
+
+  const stampTypeIds = normalizeGrantedClaims(input.grant.granted_claims)
+    .filter((claim) => claim.startsWith("stamp:") && claim !== "stamp:*")
+    .map((claim) => getStampTypeId(claim.slice("stamp:".length)))
+    .filter((value): value is number => value !== null)
+
+  if (stampTypeIds.length === 0) {
+    return
+  }
+
+  const supabase = getPassportSupabase()
+  const { data: stamps, error: stampsError } = await supabase
+    .from("stamps")
+    .select("id,stamptype")
+    .eq("created_by_user_id", input.userId)
+    .in("stamptype", stampTypeIds)
+
+  if (stampsError) {
+    throw stampsError
+  }
+
+  for (const stamp of (stamps ?? []) as StampRow[]) {
+    const { error } = await supabase
+      .from("stamp_dappuser_permissions")
+      .delete()
+      .eq("dappuser_id", input.dappUserUuid)
+      .eq("stamp_id", stamp.id)
+
+    if (error) {
+      throw error
+    }
+  }
+}
+
+export const revokePassportAppDisclosureGrant = async (
+  req: NextApiRequest,
+  grantId: string,
+  requestId: string
+) => {
+  if (!grantId) {
+    throw new ApiSecurityError(400, "invalid_request", "grantId is required.")
+  }
+
+  const supabase = getPassportSupabase()
+  const { grantRows, subjectsById, userIds } = await loadOwnedAllowPageGrants(req)
+  const grant = grantRows.find((row) => row.id === grantId)
+
+  if (!grant) {
+    throw new ApiSecurityError(404, "not_found", "Disclosure grant not found.")
+  }
+
+  const subject = subjectsById.get(grant.app_scoped_subject_id)
+  if (!subject || !userIds.map(String).includes(String(subject.cubid_user_id))) {
+    throw new ApiSecurityError(404, "not_found", "Disclosure grant not found.")
+  }
+
+  if (grant.revoked_at || grant.status === "revoked") {
+    return {
+      grantId,
+      revokedAt: grant.revoked_at,
+    }
+  }
+
+  const revokedAt = new Date().toISOString()
+
+  const { error: revokeError } = await supabase
+    .from("selective_disclosure_grants")
+    .update({
+      revoked_at: revokedAt,
+      revoked_by: "user",
+      status: "revoked",
+      updated_at: revokedAt,
+    })
+    .eq("id", grantId)
+    .eq("status", "active")
+
+  if (revokeError) {
+    throw revokeError
+  }
+
+  await revokeLegacyStampPermissions({
+    dappUserUuid: subject.dapp_user_uuid,
+    grant,
+    userId: subject.cubid_user_id,
+  })
+
+  const { error: eventError } = await supabase
+    .from("selective_disclosure_events")
+    .insert({
+      actor_identifier: subject.app_scoped_subject,
+      actor_type: "user",
+      app_scoped_subject_id: subject.id,
+      details: {
+        dapp_id: grant.dapp_id,
+        revoked_by: "user",
+        source: "allow_page",
+      },
+      disclosure_grant_id: grantId,
+      event_type: "disclosure.revoked",
+      outcome: "success",
+      request_id: requestId || `passport_${randomUUID()}`,
+    })
+
+  if (eventError) {
+    throw eventError
+  }
+
+  return {
+    grantId,
+    revokedAt,
+  }
+}

--- a/apps/passport/lib/server/disclosureGrants.ts
+++ b/apps/passport/lib/server/disclosureGrants.ts
@@ -29,6 +29,8 @@ type LegacyPermissionRow = {
 
 export type DappDisclosureGrantSet = {
   appScopedSubject: string | null
+  grantedClaims: Set<string>
+  grantedScopes: Set<string>
   grantedStampTypes: Set<string>
   hasStampScope: boolean
   legacyGrantedStampIds: Set<string>
@@ -36,10 +38,23 @@ export type DappDisclosureGrantSet = {
 
 const createEmptyDappDisclosureGrants = (): DappDisclosureGrantSet => ({
   appScopedSubject: null,
+  grantedClaims: new Set(),
+  grantedScopes: new Set(),
   grantedStampTypes: new Set(),
   hasStampScope: false,
   legacyGrantedStampIds: new Set(),
 })
+
+export const DISCLOSURE_CLAIMS = {
+  locationApproximate: "location:approximate",
+  locationExact: "location:exact",
+  locationRough: "location:rough",
+  locationWildcard: "location:*",
+  profileName: "profile:name",
+  profileWildcard: "profile:*",
+} as const
+
+export type LocationDisclosureLevel = "rough" | "approximate" | "exact"
 
 export async function loadDappDisclosureGrants(
   supabase: SupabaseClient,
@@ -60,11 +75,17 @@ function mergeGrantRows(
   grants: SelectiveDisclosureGrantRow[],
   legacyPermissions: LegacyPermissionRow[] = []
 ): DappDisclosureGrantSet {
+  const grantedClaims = new Set<string>()
+  const grantedScopes = new Set<string>()
   const grantedStampTypes = new Set<string>()
   let hasStampScope = false
 
   for (const grant of grants) {
-    if ((grant.granted_scopes ?? []).includes("cubid:stamps")) {
+    for (const scope of grant.granted_scopes ?? []) {
+      grantedScopes.add(scope)
+    }
+
+    if (grantedScopes.has("cubid:stamps")) {
       hasStampScope = true
     }
 
@@ -72,6 +93,7 @@ function mergeGrantRows(
       if (typeof claim.claim !== "string") {
         continue
       }
+      grantedClaims.add(claim.claim)
       if (claim.claim === "stamp:*") {
         grantedStampTypes.add("*")
         continue
@@ -84,6 +106,8 @@ function mergeGrantRows(
 
   return {
     appScopedSubject: appScopedSubject?.app_scoped_subject ?? null,
+    grantedClaims,
+    grantedScopes,
     grantedStampTypes,
     hasStampScope,
     legacyGrantedStampIds: new Set(
@@ -92,6 +116,91 @@ function mergeGrantRows(
         .filter((value): value is number | string => value !== null && value !== undefined)
         .map(String)
     ),
+  }
+}
+
+export function hasDisclosedClaim(
+  grants: DappDisclosureGrantSet | undefined,
+  claim: string
+): boolean {
+  if (!grants) {
+    return false
+  }
+
+  if (grants.grantedClaims.has(claim)) {
+    return true
+  }
+
+  const namespace = claim.split(":")[0]
+  return Boolean(namespace && grants.grantedClaims.has(`${namespace}:*`))
+}
+
+export function isProfileNameDisclosed(
+  grants: DappDisclosureGrantSet | undefined
+): boolean {
+  return (
+    hasDisclosedClaim(grants, DISCLOSURE_CLAIMS.profileName) ||
+    Boolean(
+      grants?.grantedScopes.has("profile") ||
+        grants?.grantedScopes.has("cubid:profile")
+    )
+  )
+}
+
+export function isLocationDisclosed(
+  grants: DappDisclosureGrantSet | undefined,
+  level: LocationDisclosureLevel
+): boolean {
+  if (!grants) {
+    return false
+  }
+
+  if (hasDisclosedClaim(grants, DISCLOSURE_CLAIMS.locationWildcard)) {
+    return true
+  }
+
+  const grantedLevels = new Set<LocationDisclosureLevel>()
+  if (hasDisclosedClaim(grants, DISCLOSURE_CLAIMS.locationExact)) {
+    grantedLevels.add("exact")
+    grantedLevels.add("approximate")
+    grantedLevels.add("rough")
+  }
+  if (hasDisclosedClaim(grants, DISCLOSURE_CLAIMS.locationApproximate)) {
+    grantedLevels.add("approximate")
+    grantedLevels.add("rough")
+  }
+  if (hasDisclosedClaim(grants, DISCLOSURE_CLAIMS.locationRough)) {
+    grantedLevels.add("rough")
+  }
+
+  return grantedLevels.has(level)
+}
+
+export function sanitizeDisclosedUserProfile<TUser extends Record<string, any>>(
+  user: TUser | null | undefined,
+  grants: DappDisclosureGrantSet | undefined
+): Record<string, unknown> | null {
+  if (!user) {
+    return null
+  }
+
+  const exactLocationDisclosed = isLocationDisclosed(grants, "exact")
+  const approximateLocationDisclosed = isLocationDisclosed(grants, "approximate")
+  const roughLocationDisclosed = isLocationDisclosed(grants, "rough")
+
+  return {
+    address: exactLocationDisclosed ? user.address ?? null : null,
+    cubid_country:
+      roughLocationDisclosed || approximateLocationDisclosed || exactLocationDisclosed
+        ? user.cubid_country ?? null
+        : null,
+    cubid_postalcode:
+      approximateLocationDisclosed || exactLocationDisclosed
+        ? user.cubid_postalcode ?? null
+        : null,
+    email: isStampTypeDisclosed(grants, "email") ? user.email ?? null : null,
+    nickname: isProfileNameDisclosed(grants) ? user.nickname ?? null : null,
+    phone: isStampTypeDisclosed(grants, "phone") ? user.phone ?? null : null,
   }
 }
 

--- a/apps/passport/pages/api/cubid-webhook/expired-cron.ts
+++ b/apps/passport/pages/api/cubid-webhook/expired-cron.ts
@@ -1,8 +1,13 @@
-import crypto from "crypto"
 import type { NextApiRequest, NextApiResponse } from "next"
 import axios from "axios"
 
 import { handlePassportRoute } from "@/lib/server/passportApi"
+import {
+  buildApiV3WebhookHeaders,
+  buildApiV3WebhookPayload,
+  classifyApiV3WebhookDeliveryError,
+  serializeApiV3WebhookPayload,
+} from "@/lib/server/apiV3Webhooks"
 import {
   isStampDisclosed,
   loadDappDisclosureGrantsForStamp,
@@ -26,10 +31,6 @@ async function fetchOldStamps() {
   return data ?? []
 }
 
-function createSignature(payload: string, secret: string) {
-  return crypto.createHmac("sha256", secret).update(payload).digest("hex")
-}
-
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -43,7 +44,7 @@ export default async function handler(
       rateLimitGroup: "passport_internal",
       route: "internal.cubid_webhook.expired_cron",
     },
-    async () => {
+    async ({ context }) => {
       const supabase = getPassportSupabase()
       const allStampsToFetch = await fetchOldStamps()
       const webhook = "credential_expired"
@@ -113,34 +114,45 @@ export default async function handler(
                 return
               }
 
-              const signature = createSignature(
-                JSON.stringify({ stampid }),
-                signingSecret
-              )
+              const payload = buildApiV3WebhookPayload({
+                dappId,
+                dappUserUuid: dappUser.uuid,
+                legacyEventType: webhook,
+                requestId: context.requestId,
+                stampId: stampid,
+              })
+              const payloadBody = serializeApiV3WebhookPayload(payload)
+              const headers = buildApiV3WebhookHeaders({
+                body: payloadBody,
+                eventId: payload.eventId,
+                secret: signingSecret,
+              })
 
               let insertedData: any
               const { data: existingEvents, error: existingEventsError } =
                 await supabase
                   .from("webhook_events")
                   .select("*")
-                  .match({
-                    event_type: webhook,
-                    payload: {
-                      stampid,
-                    },
-                  })
+                  .eq("dapp_id", dappId)
+                  .eq("event_id", payload.eventId)
 
               if (existingEventsError) {
                 throw existingEventsError
               }
 
-              if ((webhookRows ?? []).length !== 0) {
+              const attemptNumber = Number(existingEvents?.[0]?.retries ?? 0) + 1
+              if (existingEvents?.[0]) {
                 const { data: updatedEvents, error: updateError } = await supabase
                   .from("webhook_events")
                   .update({
+                    api_version: payload.apiVersion,
+                    dapp_id: dappId,
+                    event_id: payload.eventId,
                     event_type: webhook,
-                    payload: { stampid },
-                    retires: (existingEvents ?? []).length,
+                    last_attempt_at: new Date().toISOString(),
+                    payload,
+                    payload_version: payload.payloadVersion,
+                    retries: attemptNumber,
                   })
                   .eq("id", existingEvents?.[0]?.id)
                   .select("*")
@@ -154,9 +166,14 @@ export default async function handler(
                 const { data: insertedEvents, error: insertError } = await supabase
                   .from("webhook_events")
                   .insert({
+                    api_version: payload.apiVersion,
+                    dapp_id: dappId,
+                    event_id: payload.eventId,
                     event_type: webhook,
-                    payload: { stampid },
-                    retires: (existingEvents ?? []).length,
+                    last_attempt_at: new Date().toISOString(),
+                    payload,
+                    payload_version: payload.payloadVersion,
+                    retries: attemptNumber,
                   })
                   .select("*")
 
@@ -170,22 +187,32 @@ export default async function handler(
               try {
                 const response = await axios.post(
                   targetUrl,
-                  { stampid },
+                  payloadBody,
                   {
-                    headers: {
-                      "X-Cubid-Signature": signature,
-                    },
+                    headers,
                   }
                 )
 
                 const { error: deliveryError } = await supabase
                   .from("webhook_event_deliveries")
                   .insert({
-                    attempt_number: insertedData?.attempt_number,
+                    attempt_number: attemptNumber,
                     delivery_status: "succeeded",
                     dapp_id: dappId,
-                    response_body: response.data,
+                    event_id: payload.eventId,
+                    request_body: payload,
+                    request_headers: {
+                      "X-Cubid-Event-Id": headers["X-Cubid-Event-Id"],
+                      "X-Cubid-Signature-Version":
+                        headers["X-Cubid-Signature-Version"],
+                      "X-Cubid-Timestamp": headers["X-Cubid-Timestamp"],
+                    },
+                    response_body:
+                      typeof response.data === "string"
+                        ? response.data
+                        : JSON.stringify(response.data ?? null),
                     response_status_code: response.status,
+                    signature_version: headers["X-Cubid-Signature-Version"],
                     webhook_event_id: insertedData.id,
                   })
 
@@ -194,12 +221,28 @@ export default async function handler(
                 }
               } catch (error: any) {
                 await supabase.from("webhook_event_deliveries").insert({
-                  attempt_number: insertedData?.attempt_number,
+                  attempt_number: attemptNumber,
                   delivery_status: "failed",
                   dapp_id: dappId,
-                  error_category: error?.response ? "client_error" : "request_error",
-                  response_body: error?.response?.data ?? error?.message ?? error,
+                  error_category: classifyApiV3WebhookDeliveryError(error),
+                  event_id: payload.eventId,
+                  request_body: payload,
+                  request_headers: {
+                    "X-Cubid-Event-Id": headers["X-Cubid-Event-Id"],
+                    "X-Cubid-Signature-Version":
+                      headers["X-Cubid-Signature-Version"],
+                    "X-Cubid-Timestamp": headers["X-Cubid-Timestamp"],
+                  },
+                  response_body:
+                    typeof error?.response?.data === "string"
+                      ? error.response.data
+                      : JSON.stringify(
+                          error?.response?.data ??
+                            error?.message ??
+                            "Unknown error"
+                        ),
                   response_status_code: error?.response?.status ?? null,
+                  signature_version: headers["X-Cubid-Signature-Version"],
                   webhook_event_id: insertedData.id,
                 })
               }

--- a/apps/passport/pages/api/cubid-webhook/trigger-url.ts
+++ b/apps/passport/pages/api/cubid-webhook/trigger-url.ts
@@ -1,21 +1,22 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 import axios from "axios"
-import crypto from "crypto"
 
 import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
 import {
+  buildApiV3WebhookHeaders,
+  buildApiV3WebhookPayload,
+  classifyApiV3WebhookDeliveryError,
+  serializeApiV3WebhookPayload,
+} from "@/lib/server/apiV3Webhooks"
+import {
   isStampDisclosed,
   loadDappDisclosureGrantsForStamp,
 } from "@/lib/server/disclosureGrants"
 import { getPassportSupabase } from "@/lib/server/supabase"
 import { resolveWebhookSigningSecret } from "@/lib/server/webhookSigningSecrets"
-
-function createSignature(payload: string, secret: string): string {
-  return crypto.createHmac("sha256", secret).update(payload).digest("hex")
-}
 
 const schema = passportSchemas.z.object({
   stamparray: passportSchemas.z.array(passportSchemas.z.number().int().positive()),
@@ -42,7 +43,7 @@ export default async function handler(
       rateLimitGroup: "passport_internal",
       route: "passport.internal.webhook_trigger",
     },
-    async ({ body }) => {
+    async ({ body, context }) => {
       const supabase = getPassportSupabase()
 
       await Promise.all(
@@ -113,34 +114,45 @@ export default async function handler(
                 return
               }
 
-              const signature = createSignature(
-                JSON.stringify({ stampid }),
-                signingSecret
-              )
+              const payload = buildApiV3WebhookPayload({
+                dappId: dappUser.dapp_id,
+                dappUserUuid: dappUser.uuid,
+                legacyEventType: body.webhook,
+                requestId: context.requestId,
+                stampId: stampid,
+              })
+              const payloadBody = serializeApiV3WebhookPayload(payload)
+              const headers = buildApiV3WebhookHeaders({
+                body: payloadBody,
+                eventId: payload.eventId,
+                secret: signingSecret,
+              })
 
               const { data: existingEvents, error: existingEventsError } =
                 await supabase
                   .from("webhook_events")
                   .select("*")
-                  .match({
-                    dapp_id: dappUser.dapp_id,
-                    event_type: body.webhook,
-                    payload: { stampid },
-                  })
+                  .eq("dapp_id", dappUser.dapp_id)
+                  .eq("event_id", payload.eventId)
 
               if (existingEventsError) {
                 throw existingEventsError
               }
 
               let eventRow = existingEvents?.[0] ?? null
+              const attemptNumber = Number(eventRow?.retries ?? 0) + 1
               if (eventRow) {
                 const { data: updatedEvents, error: updateError } = await supabase
                   .from("webhook_events")
                   .update({
+                    api_version: payload.apiVersion,
                     dapp_id: dappUser.dapp_id,
+                    event_id: payload.eventId,
                     event_type: body.webhook,
-                    payload: { stampid },
-                    retries: (existingEvents ?? []).length,
+                    last_attempt_at: new Date().toISOString(),
+                    payload,
+                    payload_version: payload.payloadVersion,
+                    retries: attemptNumber,
                   })
                   .eq("id", eventRow.id)
                   .select("*")
@@ -154,10 +166,14 @@ export default async function handler(
                 const { data: insertedEvents, error: insertError } = await supabase
                   .from("webhook_events")
                   .insert({
+                    api_version: payload.apiVersion,
                     dapp_id: dappUser.dapp_id,
+                    event_id: payload.eventId,
                     event_type: body.webhook,
-                    payload: { stampid },
-                    retries: 0,
+                    last_attempt_at: new Date().toISOString(),
+                    payload,
+                    payload_version: payload.payloadVersion,
+                    retries: attemptNumber,
                   })
                   .select("*")
 
@@ -171,22 +187,32 @@ export default async function handler(
               try {
                 const response = await axios.post(
                   subscription.webhook_url,
-                  { stampid },
+                  payloadBody,
                   {
-                    headers: {
-                      "X-Cubid-Signature": signature,
-                    },
+                    headers,
                   }
                 )
 
                 const { error: deliveryError } = await supabase
                   .from("webhook_event_deliveries")
                   .insert({
-                    attempt_number: Number(eventRow?.retries ?? 0) + 1,
+                    attempt_number: attemptNumber,
                     delivery_status: "succeeded",
                     dapp_id: dappUser.dapp_id,
-                    response_body: response.data,
+                    event_id: payload.eventId,
+                    request_body: payload,
+                    request_headers: {
+                      "X-Cubid-Event-Id": headers["X-Cubid-Event-Id"],
+                      "X-Cubid-Signature-Version":
+                        headers["X-Cubid-Signature-Version"],
+                      "X-Cubid-Timestamp": headers["X-Cubid-Timestamp"],
+                    },
+                    response_body:
+                      typeof response.data === "string"
+                        ? response.data
+                        : JSON.stringify(response.data ?? null),
                     response_status_code: response.status,
+                    signature_version: headers["X-Cubid-Signature-Version"],
                     webhook_event_id: eventRow?.id,
                   })
 
@@ -197,12 +223,28 @@ export default async function handler(
                 const { error: deliveryError } = await supabase
                   .from("webhook_event_deliveries")
                   .insert({
-                    attempt_number: Number(eventRow?.retries ?? 0) + 1,
+                    attempt_number: attemptNumber,
                     delivery_status: "failed",
                     dapp_id: dappUser.dapp_id,
-                    error_category: error?.response ? "client_error" : "network_error",
-                    response_body: error?.response?.data ?? error?.message ?? "Unknown error",
+                    error_category: classifyApiV3WebhookDeliveryError(error),
+                    event_id: payload.eventId,
+                    request_body: payload,
+                    request_headers: {
+                      "X-Cubid-Event-Id": headers["X-Cubid-Event-Id"],
+                      "X-Cubid-Signature-Version":
+                        headers["X-Cubid-Signature-Version"],
+                      "X-Cubid-Timestamp": headers["X-Cubid-Timestamp"],
+                    },
+                    response_body:
+                      typeof error?.response?.data === "string"
+                        ? error.response.data
+                        : JSON.stringify(
+                            error?.response?.data ??
+                              error?.message ??
+                              "Unknown error"
+                          ),
                     response_status_code: error?.response?.status ?? 500,
+                    signature_version: headers["X-Cubid-Signature-Version"],
                     webhook_event_id: eventRow?.id,
                   })
 

--- a/apps/passport/pages/api/dapp/get_identity.ts
+++ b/apps/passport/pages/api/dapp/get_identity.ts
@@ -7,8 +7,8 @@ import {
 import { ApiSecurityError } from "@cubid/auth/server"
 import {
   filterDisclosedStamps,
-  isStampTypeDisclosed,
   loadDappDisclosureGrants,
+  sanitizeDisclosedUserProfile,
 } from "@/lib/server/disclosureGrants"
 import { getPassportSupabase } from "@/lib/server/supabase"
 import { getStampTypeName } from "@cubid/stamps"
@@ -71,17 +71,10 @@ export default async function handler(
       ).map((item: any) => ({
         [getStampTypeName(Number(item.stamptype))]: item.uniquevalue,
       }))
-      const user = dappUser.users
-        ? {
-            ...dappUser.users,
-            email: isStampTypeDisclosed(disclosureGrants, "email")
-              ? dappUser.users.email
-              : null,
-            phone: isStampTypeDisclosed(disclosureGrants, "phone")
-              ? dappUser.users.phone
-              : null,
-          }
-        : null
+      const user = sanitizeDisclosedUserProfile(
+        dappUser.users,
+        disclosureGrants
+      )
 
       return res.status(200).json({
         score_details: scoreDetails,

--- a/apps/passport/pages/api/disclosures/app-grants/list.ts
+++ b/apps/passport/pages/api/disclosures/app-grants/list.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { listPassportAppDisclosureGrants } from "@/lib/server/appDisclosureManagement"
+
+const listAppGrants = async (req: NextApiRequest, res: NextApiResponse) => {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      bodySchema: passportSchemas.z.object({}).passthrough(),
+      rateLimitGroup: "passport_user_read",
+      route: "passport.disclosures.app_grants.list",
+    },
+    async () => {
+      const data = await listPassportAppDisclosureGrants(req)
+      return res.status(200).json({ data })
+    }
+  )
+}
+
+export default listAppGrants

--- a/apps/passport/pages/api/disclosures/app-grants/revoke.ts
+++ b/apps/passport/pages/api/disclosures/app-grants/revoke.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { revokePassportAppDisclosureGrant } from "@/lib/server/appDisclosureManagement"
+
+const revokeAppGrant = async (req: NextApiRequest, res: NextApiResponse) => {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      bodySchema: passportSchemas.z.object({
+        grantId: passportSchemas.z.string().min(1),
+      }),
+      rateLimitGroup: "passport_user_mutation",
+      route: "passport.disclosures.app_grants.revoke",
+    },
+    async ({ body, context }) => {
+      const data = await revokePassportAppDisclosureGrant(
+        req,
+        body.grantId,
+        context.requestId
+      )
+      return res.status(200).json({ data })
+    }
+  )
+}
+
+export default revokeAppGrant

--- a/apps/passport/pages/api/v2/get_approximate_user_location.ts
+++ b/apps/passport/pages/api/v2/get_approximate_user_location.ts
@@ -4,6 +4,11 @@ import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
+import { ApiSecurityError } from "@cubid/auth/server"
+import {
+  isLocationDisclosed,
+  loadDappDisclosureGrants,
+} from "@/lib/server/disclosureGrants"
 import { getPassportSupabase } from "@/lib/server/supabase"
 
 const schema = passportSchemas.z.object({
@@ -37,9 +42,30 @@ export default async function handler(
         throw error
       }
 
-      const user = data?.[0]?.users
+      const dappUser = data?.[0]
+      if (!dappUser) {
+        throw new ApiSecurityError(
+          404,
+          "not_found",
+          "User not found for this dapp."
+        )
+      }
+
+      const disclosureGrants = await loadDappDisclosureGrants(getPassportSupabase(), {
+        dappId: context.dapp.id,
+        dappUserUuid: body.user_id,
+      })
+      if (!isLocationDisclosed(disclosureGrants, "approximate")) {
+        return res.status(200).json({
+          address: null,
+          cubid_country: null,
+          cubid_postalcode: null,
+        })
+      }
+
+      const user = dappUser.users
       return res.status(200).json({
-        address: user?.address ?? null,
+        address: null,
         cubid_country: user?.cubid_country ?? null,
         cubid_postalcode: user?.cubid_postalcode ?? null,
       })

--- a/apps/passport/pages/api/v2/get_user_location.ts
+++ b/apps/passport/pages/api/v2/get_user_location.ts
@@ -4,6 +4,11 @@ import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
+import { ApiSecurityError } from "@cubid/auth/server"
+import {
+  isLocationDisclosed,
+  loadDappDisclosureGrants,
+} from "@/lib/server/disclosureGrants"
 import { getPassportSupabase } from "@/lib/server/supabase"
 
 const schema = passportSchemas.z.object({
@@ -37,7 +42,28 @@ export default async function handler(
         throw error
       }
 
-      const user = data?.[0]?.users
+      const dappUser = data?.[0]
+      if (!dappUser) {
+        throw new ApiSecurityError(
+          404,
+          "not_found",
+          "User not found for this dapp."
+        )
+      }
+
+      const disclosureGrants = await loadDappDisclosureGrants(getPassportSupabase(), {
+        dappId: context.dapp.id,
+        dappUserUuid: body.user_id,
+      })
+      if (!isLocationDisclosed(disclosureGrants, "exact")) {
+        return res.status(200).json({
+          address: null,
+          cubid_country: null,
+          cubid_postalcode: null,
+        })
+      }
+
+      const user = dappUser.users
       return res.status(200).json({
         address: user?.address ?? null,
         cubid_country: user?.cubid_country ?? null,

--- a/apps/passport/pages/api/v2/identity/fetch_approx_location.ts
+++ b/apps/passport/pages/api/v2/identity/fetch_approx_location.ts
@@ -5,6 +5,11 @@ import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
+import { ApiSecurityError } from "@cubid/auth/server"
+import {
+  isLocationDisclosed,
+  loadDappDisclosureGrants,
+} from "@/lib/server/disclosureGrants"
 import { getPassportSupabase } from "@/lib/server/supabase"
 
 import { getLocationDetailsFromPlusCode } from "../../utils/locationMethods"
@@ -36,8 +41,9 @@ export default async function handler(
       rateLimitGroup: "passport_dapp_read",
       route: "v2.identity.fetch_approx_location",
     },
-    async ({ body }) => {
-      const { data: dappUsers, error } = await getPassportSupabase()
+    async ({ body, context }) => {
+      const supabase = getPassportSupabase()
+      const { data: dappUsers, error } = await supabase
         .from("dapp_users")
         .select("*,users:user_id(*),dapps:dapp_id(*)")
         .eq("uuid", body.user_id)
@@ -46,7 +52,26 @@ export default async function handler(
         throw error
       }
 
-      const userAddress = dappUsers?.[0]?.users?.address
+      const dappUser = dappUsers?.[0]
+      if (!dappUser || String(dappUser.dapp_id) !== String(context.dapp.id)) {
+        throw new ApiSecurityError(
+          404,
+          "not_found",
+          "User not found for this dapp."
+        )
+      }
+
+      const disclosureGrants = await loadDappDisclosureGrants(supabase, {
+        dappId: context.dapp.id,
+        dappUserUuid: body.user_id,
+      })
+      if (!isLocationDisclosed(disclosureGrants, "approximate")) {
+        return res.status(200).json({
+          error: "Location not disclosed for this dapp",
+        })
+      }
+
+      const userAddress = dappUser.users?.address
       const latitude =
         userAddress?.locationDetails?.geometry?.location?.lat ??
         userAddress?.coordinates?.lat

--- a/apps/passport/pages/api/v2/identity/fetch_exact_location.ts
+++ b/apps/passport/pages/api/v2/identity/fetch_exact_location.ts
@@ -4,6 +4,11 @@ import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
+import { ApiSecurityError } from "@cubid/auth/server"
+import {
+  isLocationDisclosed,
+  loadDappDisclosureGrants,
+} from "@/lib/server/disclosureGrants"
 import { getPassportSupabase } from "@/lib/server/supabase"
 
 const { OpenLocationCode } = require("open-location-code")
@@ -28,8 +33,9 @@ export default async function handler(
       rateLimitGroup: "passport_dapp_read",
       route: "v2.identity.fetch_exact_location",
     },
-    async ({ body }) => {
-      const { data: dappUsers, error } = await getPassportSupabase()
+    async ({ body, context }) => {
+      const supabase = getPassportSupabase()
+      const { data: dappUsers, error } = await supabase
         .from("dapp_users")
         .select("*,users:user_id(*),dapps:dapp_id(*)")
         .eq("uuid", body.user_id)
@@ -38,7 +44,24 @@ export default async function handler(
         throw error
       }
 
-      const address = dappUsers?.[0]?.users?.address
+      const dappUser = dappUsers?.[0]
+      if (!dappUser || String(dappUser.dapp_id) !== String(context.dapp.id)) {
+        throw new ApiSecurityError(
+          404,
+          "not_found",
+          "User not found for this dapp."
+        )
+      }
+
+      const disclosureGrants = await loadDappDisclosureGrants(supabase, {
+        dappId: context.dapp.id,
+        dappUserUuid: body.user_id,
+      })
+      if (!isLocationDisclosed(disclosureGrants, "exact")) {
+        return res.status(200).json({ error: "Location not disclosed for this dapp" })
+      }
+
+      const address = dappUser.users?.address
       const latitude =
         address?.locationDetails?.geometry?.location?.lat ??
         address?.coordinates?.lat

--- a/apps/passport/pages/api/v2/identity/fetch_rough_location.ts
+++ b/apps/passport/pages/api/v2/identity/fetch_rough_location.ts
@@ -4,6 +4,11 @@ import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
+import { ApiSecurityError } from "@cubid/auth/server"
+import {
+  isLocationDisclosed,
+  loadDappDisclosureGrants,
+} from "@/lib/server/disclosureGrants"
 import { getPassportSupabase } from "@/lib/server/supabase"
 
 const { OpenLocationCode } = require("open-location-code")
@@ -30,8 +35,9 @@ export default async function handler(
       rateLimitGroup: "passport_dapp_read",
       route: "v2.identity.fetch_rough_location",
     },
-    async ({ body }) => {
-      const { data: dappUsers, error } = await getPassportSupabase()
+    async ({ body, context }) => {
+      const supabase = getPassportSupabase()
+      const { data: dappUsers, error } = await supabase
         .from("dapp_users")
         .select("*,users:user_id(*),dapps:dapp_id(*)")
         .eq("uuid", body.user_id)
@@ -40,7 +46,24 @@ export default async function handler(
         throw error
       }
 
-      const address = dappUsers?.[0]?.users?.address
+      const dappUser = dappUsers?.[0]
+      if (!dappUser || String(dappUser.dapp_id) !== String(context.dapp.id)) {
+        throw new ApiSecurityError(
+          404,
+          "not_found",
+          "User not found for this dapp."
+        )
+      }
+
+      const disclosureGrants = await loadDappDisclosureGrants(supabase, {
+        dappId: context.dapp.id,
+        dappUserUuid: body.user_id,
+      })
+      if (!isLocationDisclosed(disclosureGrants, "rough")) {
+        return res.status(200).json({ error: "Location not disclosed for this dapp" })
+      }
+
+      const address = dappUser.users?.address
       const latitude =
         address?.locationDetails?.geometry?.location?.lat ??
         address?.coordinates?.lat

--- a/apps/passport/pages/api/v2/identity/fetch_user_data.ts
+++ b/apps/passport/pages/api/v2/identity/fetch_user_data.ts
@@ -4,6 +4,12 @@ import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
+import { ApiSecurityError } from "@cubid/auth/server"
+import {
+  isLocationDisclosed,
+  isProfileNameDisclosed,
+  loadDappDisclosureGrants,
+} from "@/lib/server/disclosureGrants"
 import { getPassportSupabase } from "@/lib/server/supabase"
 
 const { OpenLocationCode } = require("open-location-code")
@@ -37,8 +43,9 @@ export default async function handler(
       rateLimitGroup: "passport_dapp_read",
       route: "v2.identity.fetch_user_data",
     },
-    async ({ body }) => {
-      const { data: dappUsers, error } = await getPassportSupabase()
+    async ({ body, context }) => {
+      const supabase = getPassportSupabase()
+      const { data: dappUsers, error } = await supabase
         .from("dapp_users")
         .select("*,users:user_id(*),dapps:dapp_id(*)")
         .eq("uuid", body.user_id)
@@ -47,7 +54,21 @@ export default async function handler(
         throw error
       }
 
-      const address = dappUsers?.[0]?.users?.address
+      const dappUser = dappUsers?.[0]
+      if (!dappUser || String(dappUser.dapp_id) !== String(context.dapp.id)) {
+        throw new ApiSecurityError(
+          404,
+          "not_found",
+          "User not found for this dapp."
+        )
+      }
+
+      const disclosureGrants = await loadDappDisclosureGrants(supabase, {
+        dappId: context.dapp.id,
+        dappUserUuid: body.user_id,
+      })
+      const locationDisclosed = isLocationDisclosed(disclosureGrants, "approximate")
+      const address = locationDisclosed ? dappUser.users?.address : null
       const latitude =
         address?.locationDetails?.geometry?.location?.lat ??
         address?.coordinates?.lat
@@ -73,7 +94,9 @@ export default async function handler(
             : null,
         country: locationDetails?.country ?? null,
         error: null,
-        name: dappUsers?.[0]?.users?.nickname ?? null,
+        name: isProfileNameDisclosed(disclosureGrants)
+          ? dappUser.users?.nickname ?? null
+          : null,
         placename: locationDetails?.formattedAddress
           ? removePlusCode(locationDetails.formattedAddress)
           : null,

--- a/apps/passport/pages/api/v3/accounts/generate.ts
+++ b/apps/passport/pages/api/v3/accounts/generate.ts
@@ -1,9 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 
+import { ApiSecurityError } from "@cubid/auth/server"
 import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
+import {
+  getApiV3IdempotencyKey,
+  runApiV3IdempotentWrite,
+} from "@/lib/server/apiV3Idempotency"
 import { createGeneratedBlockchainAccount } from "@/lib/server/blockchainAccounts"
 import { getPassportSupabase } from "@/lib/server/supabase"
 
@@ -33,26 +38,38 @@ export default async function handler(
       route: "v3.accounts.generate",
     },
     async ({ body, context }) => {
-      const account = await createGeneratedBlockchainAccount({
-        chain: body.chain,
-        dappId: context.dapp.id,
-        dappUserUuid: body.dapp_user_uuid,
-        label: body.label ?? null,
+      const supabase = getPassportSupabase()
+      const response = await runApiV3IdempotentWrite({
+        actorIdentifier: context.actorIdentifier,
+        actorType: context.actorType,
+        body,
+        idempotencyKey: getApiV3IdempotencyKey(req),
         requestId: context.requestId,
-        supabase: getPassportSupabase(),
+        route: "v3.accounts.generate",
+        supabase,
+        handler: async () => {
+          const account = await createGeneratedBlockchainAccount({
+            chain: body.chain,
+            dappId: context.dapp.id,
+            dappUserUuid: body.dapp_user_uuid,
+            label: body.label ?? null,
+            requestId: context.requestId,
+            supabase,
+          })
+
+          if (!account) {
+            throw new ApiSecurityError(
+              404,
+              "not_found",
+              "Dapp user was not found for the authenticated app."
+            )
+          }
+
+          return { body: { data: account }, statusCode: 200 }
+        },
       })
 
-      if (!account) {
-        return res.status(404).json({
-          error: {
-            code: "not_found",
-            message: "Dapp user was not found for the authenticated app.",
-            requestId: context.requestId,
-          },
-        })
-      }
-
-      return res.status(200).json({ data: account })
+      return res.status(response.statusCode).json(response.body)
     }
   )
 }

--- a/apps/passport/pages/api/v3/save_secret.ts
+++ b/apps/passport/pages/api/v3/save_secret.ts
@@ -1,10 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 import { randomUUID } from "node:crypto"
 
+import { ApiSecurityError } from "@cubid/auth/server"
 import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
+import {
+  getApiV3IdempotencyKey,
+  runApiV3IdempotentWrite,
+} from "@/lib/server/apiV3Idempotency"
 import {
   DAPP_USER_SECRET_LEGACY_SENTINEL,
   DAPP_USER_SECRET_PURPOSE,
@@ -87,69 +92,80 @@ export default async function handler(
     },
     async ({ body, context }) => {
       const supabase = getPassportSupabase()
-      const { data: dappUser, error: dappUserError } = await supabase
-        .from("dapp_users")
-        .select("uuid,dapp_id")
-        .eq("uuid", body.user_id)
-        .eq("dapp_id", context.dapp.id)
-        .maybeSingle()
-
-      if (dappUserError) {
-        throw dappUserError
-      }
-
-      if (!dappUser) {
-        return res.status(404).json({
-          error: {
-            code: "not_found",
-            message: "Dapp user was not found for the authenticated app.",
-            requestId: context.requestId,
-          },
-        })
-      }
-
-      const encryptedSecret = await encryptDappUserSecret(
+      const response = await runApiV3IdempotentWrite({
+        actorIdentifier: context.actorIdentifier,
+        actorType: context.actorType,
+        body,
+        idempotencyKey: getApiV3IdempotencyKey(req),
+        requestId: context.requestId,
+        route: "v3.save_secret",
         supabase,
-        body.secret,
-        {
-          dappId: context.dapp.id,
-          dappUserUuid: body.user_id,
-          purpose: DAPP_USER_SECRET_PURPOSE,
-        }
-      )
+        handler: async () => {
+          const { data: dappUser, error: dappUserError } = await supabase
+            .from("dapp_users")
+            .select("uuid,dapp_id")
+            .eq("uuid", body.user_id)
+            .eq("dapp_id", context.dapp.id)
+            .maybeSingle()
 
-      await insertEncryptedSecretWithSequence(
-        supabase,
-        {
-          ...encryptedSecret,
-          dapp_user_uuid: body.user_id,
-          secret: DAPP_USER_SECRET_LEGACY_SENTINEL,
+          if (dappUserError) {
+            throw dappUserError
+          }
+
+          if (!dappUser) {
+            throw new ApiSecurityError(
+              404,
+              "not_found",
+              "Dapp user was not found for the authenticated app."
+            )
+          }
+
+          const encryptedSecret = await encryptDappUserSecret(
+            supabase,
+            body.secret,
+            {
+              dappId: context.dapp.id,
+              dappUserUuid: body.user_id,
+              purpose: DAPP_USER_SECRET_PURPOSE,
+            }
+          )
+
+          await insertEncryptedSecretWithSequence(
+            supabase,
+            {
+              ...encryptedSecret,
+              dapp_user_uuid: body.user_id,
+              secret: DAPP_USER_SECRET_LEGACY_SENTINEL,
+            },
+            body.user_id
+          )
+
+          const { error: auditError } = await supabase
+            .from("api_security_events")
+            .insert({
+              actor_identifier: context.actorIdentifier,
+              actor_type: context.actorType,
+              details: {
+                dappId: String(context.dapp.id),
+                dappUserUuid: body.user_id,
+                purpose: DAPP_USER_SECRET_PURPOSE,
+              },
+              event_id: `api_event_${randomUUID().replace(/-/g, "")}`,
+              event_type: "dapp_user_secret.encrypted",
+              outcome: "success",
+              request_id: context.requestId,
+              route: "v3.save_secret",
+            })
+
+          if (auditError) {
+            throw auditError
+          }
+
+          return { body: { success: true }, statusCode: 200 }
         },
-        body.user_id
-      )
+      })
 
-      const { error: auditError } = await supabase
-        .from("api_security_events")
-        .insert({
-          actor_identifier: context.actorIdentifier,
-          actor_type: context.actorType,
-          details: {
-            dappId: String(context.dapp.id),
-            dappUserUuid: body.user_id,
-            purpose: DAPP_USER_SECRET_PURPOSE,
-          },
-          event_id: `api_event_${randomUUID().replace(/-/g, "")}`,
-          event_type: "dapp_user_secret.encrypted",
-          outcome: "success",
-          request_id: context.requestId,
-          route: "v3.save_secret",
-        })
-
-      if (auditError) {
-        throw auditError
-      }
-
-      return res.status(200).json({ success: true })
+      return res.status(response.statusCode).json(response.body)
     }
   )
 }

--- a/apps/passport/tests/disclosureGrants.test.ts
+++ b/apps/passport/tests/disclosureGrants.test.ts
@@ -3,8 +3,11 @@ import test from "node:test"
 
 import {
   filterDisclosedStamps,
+  isLocationDisclosed,
+  isProfileNameDisclosed,
   isStampDisclosed,
   loadDappDisclosureGrants,
+  sanitizeDisclosedUserProfile,
 } from "../lib/server/disclosureGrants"
 
 import { MockPassportSupabase } from "./helpers"
@@ -93,4 +96,81 @@ test("loadDappDisclosureGrants preserves legacy stamp permissions during rollout
 
   assert.equal(isStampDisclosed(grants, { id: 99, stamptype: 13 }), true)
   assert.equal(isStampDisclosed(grants, { id: 100, stamptype: 13 }), false)
+})
+
+test("loadDappDisclosureGrants exposes profile and location claim taxonomy", async () => {
+  const supabase = new MockPassportSupabase()
+  supabase.appScopedSubjects.push({
+    app_identifier: "dapp:42",
+    app_scoped_subject: "app_subject_42",
+    dapp_id: 42,
+    dapp_user_uuid: "dapp_user_1",
+    id: "subject_1",
+    status: "active",
+  })
+  supabase.selectiveDisclosureGrants.push({
+    app_scoped_subject_id: "subject_1",
+    dapp_id: 42,
+    granted_claims: [
+      {
+        claim: "profile:name",
+        dataClass: "identity",
+        purpose: "Display name sharing",
+        required: false,
+      },
+      {
+        claim: "location:approximate",
+        dataClass: "json",
+        purpose: "Approximate location sharing",
+        required: false,
+      },
+    ],
+    granted_scopes: ["cubid:profile", "cubid:location"],
+    id: "grant_1",
+    status: "active",
+  })
+
+  const grants = await loadDappDisclosureGrants(supabase as never, {
+    dappId: 42,
+    dappUserUuid: "dapp_user_1",
+  })
+
+  assert.equal(isProfileNameDisclosed(grants), true)
+  assert.equal(isLocationDisclosed(grants, "rough"), true)
+  assert.equal(isLocationDisclosed(grants, "approximate"), true)
+  assert.equal(isLocationDisclosed(grants, "exact"), false)
+})
+
+test("sanitizeDisclosedUserProfile removes non-granted profile and location fields", () => {
+  const grants = {
+    appScopedSubject: "app_subject_42",
+    grantedClaims: new Set(["profile:name", "location:rough", "stamp:email"]),
+    grantedScopes: new Set(["cubid:profile", "cubid:location", "cubid:stamps"]),
+    grantedStampTypes: new Set(["email"]),
+    hasStampScope: true,
+    legacyGrantedStampIds: new Set<string>(),
+  }
+
+  assert.deepEqual(
+    sanitizeDisclosedUserProfile(
+      {
+        address: { city: "Toronto", coordinates: { lat: 43.65, lon: -79.38 } },
+        cubid_country: "Canada",
+        cubid_postalcode: "M5V",
+        email: "person@example.com",
+        id: 123,
+        nickname: "Person",
+        phone: "+15555550100",
+      },
+      grants
+    ),
+    {
+      address: null,
+      cubid_country: "Canada",
+      cubid_postalcode: null,
+      email: "person@example.com",
+      nickname: "Person",
+      phone: null,
+    }
+  )
 })

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -36,6 +36,7 @@ export class MockPassportSupabase {
   readonly actorProfiles = new Map<string, Record<string, unknown>>()
   readonly buckets = new Map<string, BucketRow>()
   readonly dappApiKeys = new Map<string, DappApiKeyRow>()
+  readonly apiIdempotencyKeys: Array<Record<string, unknown>> = []
   readonly dappUserAccounts: Array<Record<string, unknown>> = []
   readonly dappUserSecrets: Array<Record<string, unknown>> = []
   readonly privateDappUserSecrets: Array<Record<string, unknown>> = []
@@ -50,6 +51,7 @@ export class MockPassportSupabase {
   readonly stamps: Array<Record<string, unknown>> = []
   readonly userAccounts: Array<Record<string, unknown>> = []
   readonly users = new Map<number, Record<string, unknown>>()
+  failNextPrivateKeyInsert = false
   private nextEmailOtpId = 1
 
   rpc(name: string, params: Record<string, unknown>) {
@@ -173,6 +175,83 @@ export class MockPassportSupabase {
             window_start: String(row.window_start ?? ""),
           })
           return { error: null }
+        },
+      }
+    }
+
+    if (table === "api_idempotency_keys") {
+      const createFilteredQuery = () => {
+        const filters: Record<string, unknown> = {}
+        const resolve = () =>
+          this.apiIdempotencyKeys.filter((row) =>
+            Object.entries(filters).every(
+              ([column, value]) => String(row[column]) === String(value)
+            )
+          )
+        const query = {
+          eq: (column: string, value: unknown) => {
+            filters[column] = value
+            return query
+          },
+          maybeSingle: async () => ({
+            data: resolve()[0] ?? null,
+            error: null,
+          }),
+          then: (
+            resolveThen: (value: {
+              data: Record<string, unknown>[]
+              error: null
+            }) => unknown
+          ) => Promise.resolve({ data: resolve(), error: null }).then(resolveThen),
+        }
+        return query
+      }
+
+      return {
+        insert: async (row: Record<string, unknown>) => {
+          const existing = this.apiIdempotencyKeys.find(
+            (candidate) =>
+              candidate.route === row.route &&
+              candidate.actor_type === row.actor_type &&
+              candidate.actor_identifier === row.actor_identifier &&
+              candidate.idempotency_key === row.idempotency_key
+          )
+
+          if (existing) {
+            return { error: { code: "23505", message: "duplicate key" } }
+          }
+
+          this.apiIdempotencyKeys.push({
+            created_at: new Date().toISOString(),
+            id: this.apiIdempotencyKeys.length + 1,
+            updated_at: new Date().toISOString(),
+            ...row,
+          })
+          return { error: null }
+        },
+        select: createFilteredQuery,
+        update: (patch: Record<string, unknown>) => {
+          const filters: Record<string, unknown> = {}
+          const updateQuery = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return updateQuery
+            },
+            then: (resolveThen: (value: { error: null }) => unknown) => {
+              for (const row of this.apiIdempotencyKeys) {
+                if (
+                  Object.entries(filters).every(
+                    ([filterColumn, filterValue]) =>
+                      String(row[filterColumn]) === String(filterValue)
+                  )
+                ) {
+                  Object.assign(row, patch)
+                }
+              }
+              return Promise.resolve({ error: null }).then(resolveThen)
+            },
+          }
+          return updateQuery
         },
       }
     }
@@ -832,6 +911,11 @@ export class MockPassportSupabase {
           },
         }),
         insert: async (row: Record<string, unknown>) => {
+          if (this.failNextPrivateKeyInsert) {
+            this.failNextPrivateKeyInsert = false
+            return { error: new Error("private key insert failed") }
+          }
+
           this.privateKeys.push({
             created_at: new Date().toISOString(),
             id: `private_key_${this.privateKeys.length + 1}`,

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -243,24 +243,36 @@ export class MockPassportSupabase {
         select: createFilteredQuery,
         update: (patch: Record<string, unknown>) => {
           const filters: Record<string, unknown> = {}
+          const updateRows = () => {
+            const updatedRows: Record<string, unknown>[] = []
+            for (const row of this.apiIdempotencyKeys) {
+              if (
+                Object.entries(filters).every(
+                  ([filterColumn, filterValue]) =>
+                    String(row[filterColumn]) === String(filterValue)
+                )
+              ) {
+                Object.assign(row, patch)
+                updatedRows.push(row)
+              }
+            }
+            return updatedRows
+          }
           const updateQuery = {
             eq: (column: string, value: unknown) => {
               filters[column] = value
               return updateQuery
             },
             then: (resolveThen: (value: { error: null }) => unknown) => {
-              for (const row of this.apiIdempotencyKeys) {
-                if (
-                  Object.entries(filters).every(
-                    ([filterColumn, filterValue]) =>
-                      String(row[filterColumn]) === String(filterValue)
-                  )
-                ) {
-                  Object.assign(row, patch)
-                }
-              }
+              updateRows()
               return Promise.resolve({ error: null }).then(resolveThen)
             },
+            select: () => ({
+              maybeSingle: async () => {
+                const updatedRows = updateRows()
+                return { data: updatedRows[0] ?? null, error: null }
+              },
+            }),
           }
           return updateQuery
         },

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -51,6 +51,9 @@ export class MockPassportSupabase {
   readonly stamps: Array<Record<string, unknown>> = []
   readonly userAccounts: Array<Record<string, unknown>> = []
   readonly users = new Map<number, Record<string, unknown>>()
+  readonly webhookEventDeliveries: Array<Record<string, unknown>> = []
+  readonly webhookEvents: Array<Record<string, unknown>> = []
+  readonly webhookSubscriptions: Array<Record<string, unknown>> = []
   failNextPrivateKeyInsert = false
   private nextEmailOtpId = 1
 
@@ -149,6 +152,14 @@ export class MockPassportSupabase {
       id: row.id ?? this.nextEmailOtpId++,
     })
     this.emailOtps.set(row.email, rows)
+  }
+
+  setWebhookSubscription(row: Record<string, unknown>) {
+    this.webhookSubscriptions.push({
+      id: this.webhookSubscriptions.length + 1,
+      secret_reference_id: `webhook_secret_${this.webhookSubscriptions.length + 1}`,
+      ...row,
+    })
   }
 
   schema(name: string) {
@@ -495,6 +506,133 @@ export class MockPassportSupabase {
       }
     }
 
+    if (table === "dapp_webhook_subscriptions") {
+      return {
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const resolve = () => {
+            const rows = this.webhookSubscriptions.filter((row) =>
+              Object.entries(filters).every(
+                ([column, value]) => String(row[column]) === String(value)
+              )
+            )
+            return { data: rows, error: null }
+          }
+          const query = {
+            match: (criteria: Record<string, unknown>) => {
+              Object.assign(filters, criteria)
+              return query
+            },
+            then: (
+              resolveThen: (value: {
+                data: Record<string, unknown>[]
+                error: null
+              }) => unknown
+            ) => Promise.resolve(resolve()).then(resolveThen),
+          }
+          return query
+        },
+      }
+    }
+
+    if (table === "webhook_events") {
+      return {
+        insert: (row: Record<string, unknown>) => {
+          const inserted = {
+            created_at: new Date().toISOString(),
+            id: this.webhookEvents.length + 1,
+            ...row,
+          }
+          this.webhookEvents.push(inserted)
+          return {
+            select: () => ({
+              then: (
+                resolveThen: (value: {
+                  data: Record<string, unknown>[]
+                  error: null
+                }) => unknown
+              ) => Promise.resolve({ data: [inserted], error: null }).then(resolveThen),
+            }),
+          }
+        },
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const resolve = () => {
+            const rows = this.webhookEvents.filter((row) =>
+              Object.entries(filters).every(
+                ([column, value]) => String(row[column]) === String(value)
+              )
+            )
+            return { data: rows, error: null }
+          }
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            match: (criteria: Record<string, unknown>) => {
+              Object.assign(filters, criteria)
+              return query
+            },
+            then: (
+              resolveThen: (value: {
+                data: Record<string, unknown>[]
+                error: null
+              }) => unknown
+            ) => Promise.resolve(resolve()).then(resolveThen),
+          }
+          return query
+        },
+        update: (patch: Record<string, unknown>) => {
+          const filters: Record<string, unknown> = {}
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            select: () => ({
+              then: (
+                resolveThen: (value: {
+                  data: Record<string, unknown>[]
+                  error: null
+                }) => unknown
+              ) => {
+                const updatedRows: Record<string, unknown>[] = []
+                for (const row of this.webhookEvents) {
+                  if (
+                    Object.entries(filters).every(
+                      ([column, value]) => String(row[column]) === String(value)
+                    )
+                  ) {
+                    Object.assign(row, patch)
+                    updatedRows.push(row)
+                  }
+                }
+                return Promise.resolve({
+                  data: updatedRows,
+                  error: null,
+                }).then(resolveThen)
+              },
+            }),
+          }
+          return query
+        },
+      }
+    }
+
+    if (table === "webhook_event_deliveries") {
+      return {
+        insert: async (row: Record<string, unknown>) => {
+          this.webhookEventDeliveries.push({
+            delivered_at: new Date().toISOString(),
+            id: this.webhookEventDeliveries.length + 1,
+            ...row,
+          })
+          return { error: null }
+        },
+      }
+    }
+
     if (table === "selective_disclosure_events") {
       return {
         insert: async (row: Record<string, unknown>) => {
@@ -665,6 +803,21 @@ export class MockPassportSupabase {
                 return { data: null, error: null }
               }
               return { data: { user_id: 1234, ...row }, error: null }
+            },
+            then: (
+              resolveThen: (value: {
+                data: Record<string, unknown>[]
+                error: null
+              }) => unknown
+            ) => {
+              const rows = [...this.dappUsers.values()].filter((row) =>
+                Object.entries(filters).every(
+                  ([column, value]) =>
+                    String((row as Record<string, unknown>)[column]) ===
+                    String(value)
+                )
+              )
+              return Promise.resolve({ data: rows, error: null }).then(resolveThen)
             },
           }
           return query

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -47,7 +47,9 @@ export class MockPassportSupabase {
   readonly privateKeys: Array<Record<string, unknown>> = []
   readonly selectiveDisclosureGrants: Array<Record<string, unknown>> = []
   readonly stampPermissions: Array<Record<string, unknown>> = []
+  readonly stamps: Array<Record<string, unknown>> = []
   readonly userAccounts: Array<Record<string, unknown>> = []
+  readonly users = new Map<number, Record<string, unknown>>()
   private nextEmailOtpId = 1
 
   rpc(name: string, params: Record<string, unknown>) {
@@ -127,6 +129,14 @@ export class MockPassportSupabase {
 
   setDappUser(row: DappUserRow) {
     this.dappUsers.set(row.uuid, row)
+  }
+
+  setStamp(row: Record<string, unknown> & { id: number }) {
+    this.stamps.push(row)
+  }
+
+  setUser(row: Record<string, unknown> & { id: number }) {
+    this.users.set(row.id, row)
   }
 
   setEmailOtp(row: EmailOtpRow) {
@@ -295,6 +305,28 @@ export class MockPassportSupabase {
           }
           return query
         },
+        update: (patch: Record<string, unknown>) => {
+          const filters: Record<string, unknown> = {}
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            then: (resolveThen: (value: { error: null }) => unknown) => {
+              for (const row of this.selectiveDisclosureGrants) {
+                if (
+                  Object.entries(filters).every(
+                    ([column, value]) => String(row[column]) === String(value)
+                  )
+                ) {
+                  Object.assign(row, patch)
+                }
+              }
+              return Promise.resolve({ error: null }).then(resolveThen)
+            },
+          }
+          return query
+        },
       }
     }
 
@@ -384,6 +416,15 @@ export class MockPassportSupabase {
       }
     }
 
+    if (table === "selective_disclosure_events") {
+      return {
+        insert: async (row: Record<string, unknown>) => {
+          this.eventInserts.push(row)
+          return { error: null }
+        },
+      }
+    }
+
     if (table === "actor_profiles") {
       return {
         select: () => {
@@ -424,14 +465,109 @@ export class MockPassportSupabase {
 
     if (table === "dapps") {
       return {
-        select: () => ({
-          eq: (_column: string, value: number) => ({
-            maybeSingle: async () => ({
-              data: this.dapps.get(Number(value)) ?? null,
-              error: null,
-            }),
-          }),
-        }),
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const resolve = () => {
+            const rows = [...this.dapps.values()].filter((row) =>
+              Object.entries(filters).every(([column, value]) => {
+                if (Array.isArray(value)) {
+                  return value.includes(String(row[column]))
+                }
+                return String(row[column]) === String(value)
+              })
+            )
+            return { data: rows, error: null }
+          }
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return {
+                maybeSingle: async () => ({
+                  data: this.dapps.get(Number(value)) ?? null,
+                  error: null,
+                }),
+              }
+            },
+            in: (column: string, values: unknown[]) => {
+              filters[column] = values.map(String)
+              return query
+            },
+            then: (
+              resolveThen: (value: {
+                data: Record<string, unknown>[]
+                error: null
+              }) => unknown
+            ) => Promise.resolve(resolve()).then(resolveThen),
+          }
+          return query
+        },
+      }
+    }
+
+    if (table === "users") {
+      return {
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const resolve = () => {
+            const rows = [...this.users.values()].filter((row) =>
+              Object.entries(filters).every(
+                ([column, value]) => String(row[column]) === String(value)
+              )
+            )
+            return { data: rows, error: null }
+          }
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            maybeSingle: async () => {
+              const result = resolve()
+              return { data: result.data[0] ?? null, error: null }
+            },
+          }
+          return query
+        },
+      }
+    }
+
+    if (table === "stamps") {
+      return {
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const resolve = () => {
+            const rows = this.stamps.filter((row) =>
+              Object.entries(filters).every(([column, value]) => {
+                if (Array.isArray(value)) {
+                  return value.includes(String(row[column]))
+                }
+                return String(row[column]) === String(value)
+              })
+            )
+            return { data: rows, error: null }
+          }
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            in: (column: string, values: unknown[]) => {
+              filters[column] = values.map(String)
+              return query
+            },
+            maybeSingle: async () => {
+              const result = resolve()
+              return { data: result.data[0] ?? null, error: null }
+            },
+            then: (
+              resolveThen: (value: {
+                data: Record<string, unknown>[]
+                error: null
+              }) => unknown
+            ) => Promise.resolve(resolve()).then(resolveThen),
+          }
+          return query
+        },
       }
     }
 

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
+import axios from "axios"
 import { hashDappApiKey } from "@cubid/auth/server"
 
 import actorProfileGetHandler from "../pages/api/actors/profile/get"
@@ -19,6 +20,7 @@ import saveSecretV3Handler from "../pages/api/v3/save_secret"
 import webhookTriggerHandler from "../pages/api/cubid-webhook/trigger-url"
 import createUserHandler from "../pages/api/v2/create_user"
 import { hashApiV3IdempotencyRequest } from "../lib/server/apiV3Idempotency"
+import { signApiV3WebhookPayload } from "../lib/server/apiV3Webhooks"
 import { decryptBlockchainPrivateKeyWithKey } from "../lib/server/blockchainAccounts"
 import {
   DAPP_USER_SECRET_LEGACY_SENTINEL,
@@ -46,7 +48,10 @@ type DataResponse<T> = {
   data: T
 }
 
+const originalAxiosPost = axios.post
+
 test.afterEach(() => {
+  axios.post = originalAxiosPost
   setPassportSupabaseForTests(null)
   setPassportFirebaseAdminAuthForTests(null)
   setSendOtpEmailForTests(null)
@@ -1354,4 +1359,174 @@ test("Passport internal webhook trigger rejects missing internal bearer tokens",
     (res.body as { error: { message: string } }).error.message,
     "Missing or invalid internal bearer token."
   )
+})
+
+test("Passport API v3 webhook trigger sends signed disclosure-filtered payloads", async () => {
+  const supabase = new MockPassportSupabase()
+  const dappUserUuid = "00000000-0000-4000-8000-000000000061"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.setStamp({
+    created_by_user_id: 1234,
+    id: 610,
+    stamptype: 13,
+  })
+  supabase.stampPermissions.push({
+    dappuser_id: dappUserUuid,
+    stamp_id: 610,
+  })
+  supabase.setWebhookSubscription({
+    dapp: 42,
+    secret: "webhook-signing-secret",
+    webhook: "credential_added",
+    webhook_url: "https://example.test/webhook",
+  })
+  setPassportSupabaseForTests(supabase as never)
+
+  let deliveredBody = ""
+  let deliveredHeaders: Record<string, string> = {}
+  axios.post = (async (_url: string, body: unknown, config?: unknown) => {
+    deliveredBody = String(body)
+    deliveredHeaders = ((config as { headers?: Record<string, string> })
+      ?.headers ?? {}) as Record<string, string>
+    return { data: "accepted", status: 202 }
+  }) as typeof axios.post
+
+  const req = createApiRequest({
+    body: {
+      stamparray: [610],
+      webhook: "credential_added",
+    },
+    headers: {
+      authorization: "Bearer passport-internal-test-token",
+      "x-request-id": "passport_webhook_v3_1",
+    },
+    url: "/api/cubid-webhook/trigger-url",
+  })
+  const res = createApiResponse()
+
+  await webhookTriggerHandler(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(supabase.webhookEvents.length, 1)
+  assert.equal(supabase.webhookEventDeliveries.length, 1)
+
+  const payload = JSON.parse(deliveredBody) as Record<string, unknown>
+  assert.equal(payload.apiVersion, "v3")
+  assert.equal(payload.eventType, "stamp.created")
+  assert.equal(payload.legacyEventType, "credential_added")
+  assert.equal(payload.requestId, "passport_webhook_v3_1")
+  assert.deepEqual(payload.data, { stampId: 610 })
+  assert.deepEqual(payload.subject, { dappUserUuid })
+  assert.equal(JSON.stringify(payload).includes("created_by_user_id"), false)
+  assert.equal(JSON.stringify(payload).includes("human_subject_key"), false)
+
+  const expectedSignature = signApiV3WebhookPayload({
+    body: deliveredBody,
+    eventId: String(payload.eventId),
+    secret: "webhook-signing-secret",
+    timestamp: deliveredHeaders["X-Cubid-Timestamp"],
+  })
+  assert.equal(deliveredHeaders["X-Cubid-Event-Id"], payload.eventId)
+  assert.equal(deliveredHeaders["X-Cubid-Signature"], expectedSignature)
+  assert.equal(deliveredHeaders["X-Cubid-Signature-Version"], "v1")
+
+  assert.equal(supabase.webhookEvents[0].event_id, payload.eventId)
+  assert.equal(supabase.webhookEvents[0].api_version, "v3")
+  assert.equal(supabase.webhookEventDeliveries[0].delivery_status, "succeeded")
+  assert.equal(supabase.webhookEventDeliveries[0].attempt_number, 1)
+  assert.equal(supabase.webhookEventDeliveries[0].event_id, payload.eventId)
+})
+
+test("Passport API v3 webhook trigger skips undisclosed stamps", async () => {
+  const supabase = new MockPassportSupabase()
+  const dappUserUuid = "00000000-0000-4000-8000-000000000062"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.setStamp({
+    created_by_user_id: 1234,
+    id: 620,
+    stamptype: 13,
+  })
+  supabase.setWebhookSubscription({
+    dapp: 42,
+    secret: "webhook-signing-secret",
+    webhook: "credential_added",
+    webhook_url: "https://example.test/webhook",
+  })
+  setPassportSupabaseForTests(supabase as never)
+  let wasDelivered = false
+  axios.post = (async () => {
+    wasDelivered = true
+    return { data: "accepted", status: 202 }
+  }) as typeof axios.post
+
+  await webhookTriggerHandler(
+    createApiRequest({
+      body: {
+        stamparray: [620],
+        webhook: "credential_added",
+      },
+      headers: {
+        authorization: "Bearer passport-internal-test-token",
+      },
+      url: "/api/cubid-webhook/trigger-url",
+    }),
+    createApiResponse()
+  )
+
+  assert.equal(wasDelivered, false)
+  assert.equal(supabase.webhookEvents.length, 0)
+  assert.equal(supabase.webhookEventDeliveries.length, 0)
+})
+
+test("Passport API v3 webhook trigger records failed delivery attempts and retry metadata", async () => {
+  const supabase = new MockPassportSupabase()
+  const dappUserUuid = "00000000-0000-4000-8000-000000000063"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.setStamp({
+    created_by_user_id: 1234,
+    id: 630,
+    stamptype: 13,
+  })
+  supabase.stampPermissions.push({
+    dappuser_id: dappUserUuid,
+    stamp_id: 630,
+  })
+  supabase.setWebhookSubscription({
+    dapp: 42,
+    secret: "webhook-signing-secret",
+    webhook: "credential_removed",
+    webhook_url: "https://example.test/webhook",
+  })
+  setPassportSupabaseForTests(supabase as never)
+  axios.post = (async () => {
+    throw {
+      response: {
+        data: { error: "temporarily unavailable" },
+        status: 503,
+      },
+    }
+  }) as typeof axios.post
+
+  const makeReq = () =>
+    createApiRequest({
+      body: {
+        stamparray: [630],
+        webhook: "credential_removed",
+      },
+      headers: {
+        authorization: "Bearer passport-internal-test-token",
+      },
+      url: "/api/cubid-webhook/trigger-url",
+    })
+
+  await webhookTriggerHandler(makeReq(), createApiResponse())
+  await webhookTriggerHandler(makeReq(), createApiResponse())
+
+  assert.equal(supabase.webhookEvents.length, 1)
+  assert.equal(supabase.webhookEvents[0].retries, 2)
+  assert.equal(supabase.webhookEventDeliveries.length, 2)
+  assert.equal(supabase.webhookEventDeliveries[0].delivery_status, "failed")
+  assert.equal(supabase.webhookEventDeliveries[0].error_category, "server_error")
+  assert.equal(supabase.webhookEventDeliveries[0].attempt_number, 1)
+  assert.equal(supabase.webhookEventDeliveries[1].attempt_number, 2)
 })

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -5,6 +5,8 @@ import { hashDappApiKey } from "@cubid/auth/server"
 
 import actorProfileGetHandler from "../pages/api/actors/profile/get"
 import actorProfileUpsertHandler from "../pages/api/actors/profile/upsert"
+import appDisclosureGrantListHandler from "../pages/api/disclosures/app-grants/list"
+import appDisclosureGrantRevokeHandler from "../pages/api/disclosures/app-grants/revoke"
 import consentListHandler from "../pages/api/oidc/consents/list"
 import supabaseSelectHandler from "../pages/api/supabase/select"
 import sendOtpHandler from "../pages/api/twillio/send-otp"
@@ -123,6 +125,96 @@ test("Passport OIDC consent list uses the shared user baseline for missing beare
       requestId: res.headers["x-request-id"],
     },
   })
+})
+
+test("Passport app disclosure grants list and revoke Allow Page grants", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setDapp({ appname: "Allow Test App", id: 42 })
+  supabase.appScopedSubjects.push({
+    app_identifier: "dapp:42",
+    app_scoped_subject: "app_subject_42",
+    cubid_user_id: 1234,
+    dapp_id: 42,
+    dapp_user_uuid: "dapp_user_1",
+    id: "subject_1",
+    status: "active",
+  })
+  supabase.selectiveDisclosureGrants.push({
+    app_scoped_subject_id: "subject_1",
+    consent_version: 1,
+    dapp_id: 42,
+    granted_at: "2026-05-01T00:00:00Z",
+    granted_claims: [
+      {
+        claim: "stamp:email",
+        dataClass: "identity",
+        purpose: "Allow Page stamp sharing",
+        required: false,
+      },
+    ],
+    granted_scopes: ["cubid:stamps"],
+    id: "grant_1",
+    policy_version: "allow-page:v1",
+    revoked_at: null,
+    revoked_by: null,
+    source: "allow_page",
+    status: "active",
+  })
+  supabase.setStamp({
+    created_by_user_id: 1234,
+    id: 99,
+    stamptype: 13,
+  })
+  supabase.stampPermissions.push({
+    dappuser_id: "dapp_user_1",
+    stamp_id: 99,
+  })
+
+  const listReq = createApiRequest({
+    body: {},
+    headers: {
+      authorization: "Bearer firebase-token",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/disclosures/app-grants/list",
+  })
+  const listRes = createApiResponse()
+  await appDisclosureGrantListHandler(listReq, listRes)
+
+  assert.equal(listRes.statusCode, 200)
+  assert.deepEqual(
+    (listRes.body as DataResponse<Array<{ appName: string; grantId: string }>>)
+      .data.map((grant) => ({
+        appName: grant.appName,
+        grantId: grant.grantId,
+      })),
+    [{ appName: "Allow Test App", grantId: "grant_1" }]
+  )
+
+  const revokeReq = createApiRequest({
+    body: { grantId: "grant_1" },
+    headers: {
+      authorization: "Bearer firebase-token",
+      origin: "https://passport.cubid.me",
+      "x-request-id": "passport_revoke_grant_1",
+    },
+    url: "/api/disclosures/app-grants/revoke",
+  })
+  const revokeRes = createApiResponse()
+  await appDisclosureGrantRevokeHandler(revokeReq, revokeRes)
+
+  assert.equal(revokeRes.statusCode, 200)
+  assert.equal(supabase.selectiveDisclosureGrants[0]?.status, "revoked")
+  assert.equal(supabase.stampPermissions.length, 0)
+  assert.equal(
+    supabase.eventInserts.some(
+      (event) => event.event_type === "disclosure.revoked"
+    ),
+    true
+  )
 })
 
 test("Passport actor profile get defaults signed-in users to human", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -18,6 +18,7 @@ import listAccountsV3Handler from "../pages/api/v3/accounts/list"
 import saveSecretV3Handler from "../pages/api/v3/save_secret"
 import webhookTriggerHandler from "../pages/api/cubid-webhook/trigger-url"
 import createUserHandler from "../pages/api/v2/create_user"
+import { hashApiV3IdempotencyRequest } from "../lib/server/apiV3Idempotency"
 import { decryptBlockchainPrivateKeyWithKey } from "../lib/server/blockchainAccounts"
 import {
   DAPP_USER_SECRET_LEGACY_SENTINEL,
@@ -636,6 +637,7 @@ test("Passport v3 save_secret stores only encrypted dapp user secrets", async ()
       user_id: userId,
     },
     headers: {
+      "idempotency-key": "save-secret-primary",
       origin: "https://passport.cubid.me",
     },
     url: "/api/v3/save_secret",
@@ -685,6 +687,7 @@ test("Passport v3 save_secret stores only encrypted dapp user secrets", async ()
       user_id: userId,
     },
     headers: {
+      "idempotency-key": "save-secret-second",
       origin: "https://passport.cubid.me",
     },
     url: "/api/v3/save_secret",
@@ -712,6 +715,7 @@ test("Passport v3 save_secret rejects dapp users outside the authenticated app",
       user_id: userId,
     },
     headers: {
+      "idempotency-key": "save-secret-cross-dapp",
       origin: "https://passport.cubid.me",
     },
     url: "/api/v3/save_secret",
@@ -732,6 +736,187 @@ test("Passport v3 save_secret rejects dapp users outside the authenticated app",
   })
 })
 
+test("Passport v3 save_secret requires and replays Idempotency-Key writes", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const userId = "00000000-0000-4000-8000-000000000044"
+  supabase.setDappUser({ dapp_id: 42, uuid: userId })
+  setPassportSupabaseForTests(supabase as never)
+
+  const body = {
+    api_key: apiKey,
+    secret: "idempotent dapp user secret",
+    user_id: userId,
+  }
+  const makeReq = () =>
+    createApiRequest({
+      body,
+      headers: {
+        "idempotency-key": "save-secret-replay",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/save_secret",
+    })
+
+  const firstRes = createApiResponse()
+  await saveSecretV3Handler(makeReq(), firstRes)
+  const replayRes = createApiResponse()
+  await saveSecretV3Handler(makeReq(), replayRes)
+
+  assert.equal(firstRes.statusCode, 200)
+  assert.equal(replayRes.statusCode, 200)
+  assert.deepEqual(replayRes.body, { success: true })
+  assert.equal(supabase.privateDappUserSecrets.length, 1)
+  assert.equal(
+    supabase.apiIdempotencyKeys[0]?.status,
+    "completed"
+  )
+})
+
+test("Passport v3 save_secret rejects missing, conflicting, and pending idempotency keys", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const userId = "00000000-0000-4000-8000-000000000045"
+  const body = {
+    api_key: apiKey,
+    secret: "first secret",
+    user_id: userId,
+  }
+  supabase.setDappUser({ dapp_id: 42, uuid: userId })
+  setPassportSupabaseForTests(supabase as never)
+
+  const missingKeyRes = createApiResponse()
+  await saveSecretV3Handler(
+    createApiRequest({
+      body,
+      headers: {
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/save_secret",
+    }),
+    missingKeyRes
+  )
+  assert.equal(missingKeyRes.statusCode, 400)
+  assert.equal(
+    (missingKeyRes.body as { error: { message: string } }).error.message,
+    "Missing Idempotency-Key header."
+  )
+
+  await saveSecretV3Handler(
+    createApiRequest({
+      body,
+      headers: {
+        "idempotency-key": "save-secret-conflict",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/save_secret",
+    }),
+    createApiResponse()
+  )
+
+  const conflictRes = createApiResponse()
+  await saveSecretV3Handler(
+    createApiRequest({
+      body: {
+        ...body,
+        secret: "different secret",
+      },
+      headers: {
+        "idempotency-key": "save-secret-conflict",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/save_secret",
+    }),
+    conflictRes
+  )
+  assert.equal(conflictRes.statusCode, 409)
+  assert.equal(
+    (conflictRes.body as { error: { code: string } }).error.code,
+    "idempotency_conflict"
+  )
+
+  supabase.apiIdempotencyKeys.push({
+    actor_identifier: "42",
+    actor_type: "dapp",
+    expires_at: new Date(Date.now() + 60000).toISOString(),
+    idempotency_key: "save-secret-pending",
+    request_hash: hashApiV3IdempotencyRequest(body),
+    request_id: "passport_pending_1",
+    route: "v3.save_secret",
+    status: "pending",
+  })
+  const pendingRes = createApiResponse()
+  await saveSecretV3Handler(
+    createApiRequest({
+      body,
+      headers: {
+        "idempotency-key": "save-secret-pending",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/save_secret",
+    }),
+    pendingRes
+  )
+  assert.equal(pendingRes.statusCode, 409)
+  assert.equal(
+    (pendingRes.body as { error: { code: string } }).error.code,
+    "request_in_progress"
+  )
+})
+
+test("Passport v3 save_secret rejects dapp-id mismatches and rate-limit denials", async () => {
+  const now = Date.now()
+  const windowStartMs = now - (now % 60000)
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const userId = "00000000-0000-4000-8000-000000000046"
+  supabase.setDappUser({ dapp_id: 42, uuid: userId })
+  setPassportSupabaseForTests(supabase as never)
+
+  const mismatchRes = createApiResponse()
+  await saveSecretV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_id: 99,
+        secret: "raw dapp user secret",
+        user_id: userId,
+      },
+      headers: {
+        "idempotency-key": "save-secret-dapp-mismatch",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/save_secret",
+    }),
+    mismatchRes
+  )
+  assert.equal(mismatchRes.statusCode, 403)
+  assert.equal(
+    (mismatchRes.body as { error: { code: string } }).error.code,
+    "forbidden"
+  )
+
+  supabase.setBucket(`passport_dapp_mutation:42:${windowStartMs}`, 20)
+  const rateLimitedRes = createApiResponse()
+  await saveSecretV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        secret: "raw dapp user secret",
+        user_id: userId,
+      },
+      headers: {
+        "idempotency-key": "save-secret-rate-limited",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/save_secret",
+    }),
+    rateLimitedRes
+  )
+  assert.equal(rateLimitedRes.statusCode, 429)
+  assert.equal(supabase.privateDappUserSecrets.length, 0)
+})
+
 test("Passport v3 account generation encrypts private keys and links only the triggering dapp user", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
@@ -747,6 +932,7 @@ test("Passport v3 account generation encrypts private keys and links only the tr
       label: "Primary EVM",
     },
     headers: {
+      "idempotency-key": "generate-evm-primary",
       origin: "https://passport.cubid.me",
     },
     url: "/api/v3/accounts/generate",
@@ -809,6 +995,7 @@ test("Passport v3 account generation rejects dapp users outside the authenticate
       dapp_user_uuid: dappUserUuid,
     },
     headers: {
+      "idempotency-key": "generate-cross-dapp",
       origin: "https://passport.cubid.me",
     },
     url: "/api/v3/accounts/generate",
@@ -837,6 +1024,7 @@ test("Passport v3 account generation rejects unsupported Sui requests", async ()
       dapp_user_uuid: dappUserUuid,
     },
     headers: {
+      "idempotency-key": "generate-sui",
       origin: "https://passport.cubid.me",
     },
     url: "/api/v3/accounts/generate",
@@ -848,6 +1036,148 @@ test("Passport v3 account generation rejects unsupported Sui requests", async ()
   assert.equal(res.statusCode, 400)
   assert.equal((res.body as { error: { code: string } }).error.code, "invalid_request")
   assert.equal(supabase.userAccounts.length, 0)
+})
+
+test("Passport v3 account generation replays Idempotency-Key writes without creating duplicate accounts", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000056"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  const body = {
+    api_key: apiKey,
+    chain: "near",
+    dapp_user_uuid: dappUserUuid,
+    label: "Primary NEAR",
+  }
+  const makeReq = () =>
+    createApiRequest({
+      body,
+      headers: {
+        "idempotency-key": "generate-near-replay",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    })
+
+  const firstRes = createApiResponse()
+  await generateAccountV3Handler(makeReq(), firstRes)
+  const replayRes = createApiResponse()
+  await generateAccountV3Handler(makeReq(), replayRes)
+
+  assert.equal(firstRes.statusCode, 200)
+  assert.equal(replayRes.statusCode, 200)
+  assert.deepEqual(replayRes.body, firstRes.body)
+  assert.equal(supabase.userAccounts.length, 1)
+  assert.equal(supabase.privateKeys.length, 1)
+  assert.equal(supabase.dappUserAccounts.length, 1)
+})
+
+test("Passport v3 account generation rejects idempotency conflicts and pending requests", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000057"
+  const body = {
+    api_key: apiKey,
+    chain: "evm",
+    dapp_user_uuid: dappUserUuid,
+  }
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  await generateAccountV3Handler(
+    createApiRequest({
+      body,
+      headers: {
+        "idempotency-key": "generate-conflict",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    createApiResponse()
+  )
+
+  const conflictRes = createApiResponse()
+  await generateAccountV3Handler(
+    createApiRequest({
+      body: {
+        ...body,
+        label: "Different body",
+      },
+      headers: {
+        "idempotency-key": "generate-conflict",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    conflictRes
+  )
+  assert.equal(conflictRes.statusCode, 409)
+  assert.equal(
+    (conflictRes.body as { error: { code: string } }).error.code,
+    "idempotency_conflict"
+  )
+
+  supabase.apiIdempotencyKeys.push({
+    actor_identifier: "42",
+    actor_type: "dapp",
+    expires_at: new Date(Date.now() + 60000).toISOString(),
+    idempotency_key: "generate-pending",
+    request_hash: hashApiV3IdempotencyRequest(body),
+    request_id: "passport_pending_2",
+    route: "v3.accounts.generate",
+    status: "pending",
+  })
+  const pendingRes = createApiResponse()
+  await generateAccountV3Handler(
+    createApiRequest({
+      body,
+      headers: {
+        "idempotency-key": "generate-pending",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    pendingRes
+  )
+  assert.equal(pendingRes.statusCode, 409)
+  assert.equal(
+    (pendingRes.body as { error: { code: string } }).error.code,
+    "request_in_progress"
+  )
+})
+
+test("Passport v3 account generation cleans up public account rows on private-key failure", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000058"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.failNextPrivateKeyInsert = true
+  setPassportSupabaseForTests(supabase as never)
+
+  const res = createApiResponse()
+  await generateAccountV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        chain: "evm",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        "idempotency-key": "generate-private-key-failure",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 500)
+  assert.equal(supabase.userAccounts.length, 0)
+  assert.equal(supabase.privateKeys.length, 0)
+  assert.equal(supabase.dappUserAccounts.length, 0)
+  assert.equal(supabase.apiIdempotencyKeys[0]?.status, "failed")
 })
 
 test("Passport v3 account list returns dapp-user-visible metadata without secret material", async () => {
@@ -864,6 +1194,7 @@ test("Passport v3 account list returns dapp-user-visible metadata without secret
       dapp_user_uuid: dappUserUuid,
     },
     headers: {
+      "idempotency-key": "generate-solana-for-list",
       origin: "https://passport.cubid.me",
     },
     url: "/api/v3/accounts/generate",
@@ -891,6 +1222,115 @@ test("Passport v3 account list returns dapp-user-visible metadata without secret
   assert.equal(accounts[0].dappUserUuid, dappUserUuid)
   assert.equal(JSON.stringify(listRes.body).includes("ciphertext"), false)
   assert.equal(JSON.stringify(listRes.body).includes("private"), false)
+})
+
+test("Passport v3 account list validates auth, payloads, ownership, and chain filtering", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000059"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  const invalidAuthRes = createApiResponse()
+  await listAccountsV3Handler(
+    createApiRequest({
+      body: {
+        api_key: "cubid_live_missing_secret",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/list",
+    }),
+    invalidAuthRes
+  )
+  assert.equal(invalidAuthRes.statusCode, 401)
+
+  const malformedRes = createApiResponse()
+  await listAccountsV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: "not-a-uuid",
+      },
+      headers: {
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/list",
+    }),
+    malformedRes
+  )
+  assert.equal(malformedRes.statusCode, 400)
+
+  const crossDappRes = createApiResponse()
+  await listAccountsV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: "00000000-0000-4000-8000-000000000060",
+      },
+      headers: {
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/list",
+    }),
+    crossDappRes
+  )
+  assert.equal(crossDappRes.statusCode, 404)
+
+  await generateAccountV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        chain: "evm",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        "idempotency-key": "generate-evm-for-filter",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    createApiResponse()
+  )
+  await generateAccountV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        chain: "solana",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        "idempotency-key": "generate-solana-for-filter",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    createApiResponse()
+  )
+
+  const filteredRes = createApiResponse()
+  await listAccountsV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        chain: "evm",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        origin: "https://passport.cubid.me",
+        "x-request-id": "passport_v3_list_filter",
+      },
+      url: "/api/v3/accounts/list",
+    }),
+    filteredRes
+  )
+  const accounts = (filteredRes.body as DataResponse<Array<Record<string, unknown>>>).data
+  assert.equal(filteredRes.statusCode, 200)
+  assert.equal(filteredRes.headers["x-request-id"], "passport_v3_list_filter")
+  assert.equal(accounts.length, 1)
+  assert.equal(accounts[0].chain, "evm")
 })
 
 test("Passport internal webhook trigger rejects missing internal bearer tokens", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -867,6 +867,41 @@ test("Passport v3 save_secret rejects missing, conflicting, and pending idempote
     (pendingRes.body as { error: { code: string } }).error.code,
     "request_in_progress"
   )
+
+  supabase.apiIdempotencyKeys.push({
+    actor_identifier: "42",
+    actor_type: "dapp",
+    expires_at: new Date(Date.now() + 60000).toISOString(),
+    idempotency_key: "save-secret-failed",
+    request_hash: hashApiV3IdempotencyRequest(body),
+    request_id: "passport_failed_1",
+    route: "v3.save_secret",
+    status: "failed",
+  })
+  const priorSecretCount = supabase.privateDappUserSecrets.length
+  const failedRetryRes = createApiResponse()
+  await saveSecretV3Handler(
+    createApiRequest({
+      body,
+      headers: {
+        "idempotency-key": "save-secret-failed",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/save_secret",
+    }),
+    failedRetryRes
+  )
+  assert.equal(failedRetryRes.statusCode, 200)
+  assert.equal(
+    supabase.privateDappUserSecrets.length,
+    priorSecretCount + 1
+  )
+  assert.equal(
+    supabase.apiIdempotencyKeys.find(
+      (row) => row.idempotency_key === "save-secret-failed"
+    )?.status,
+    "completed"
+  )
 })
 
 test("Passport v3 save_secret rejects dapp-id mismatches and rate-limit denials", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -891,16 +891,20 @@ test("Passport v3 save_secret rejects missing, conflicting, and pending idempote
     }),
     failedRetryRes
   )
-  assert.equal(failedRetryRes.statusCode, 200)
+  assert.equal(failedRetryRes.statusCode, 409)
+  assert.equal(
+    (failedRetryRes.body as { error: { code: string } }).error.code,
+    "idempotency_failed"
+  )
   assert.equal(
     supabase.privateDappUserSecrets.length,
-    priorSecretCount + 1
+    priorSecretCount
   )
   assert.equal(
     supabase.apiIdempotencyKeys.find(
       (row) => row.idempotency_key === "save-secret-failed"
     )?.status,
-    "completed"
+    "failed"
   )
 })
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -1,0 +1,99 @@
+# API v3 Developer Platform
+
+Last updated: 2026-05-03
+Status: E02 review and hardening target
+
+## Purpose
+
+API v3 is Cubid's forward path for developer-facing backend contracts. This
+repo owns the runtime behavior: routes, migrations, validation, authorization,
+disclosure enforcement, secret custody, webhook delivery, and operational
+events. Public SDK implementation, package publication, examples, and
+external-integration docs belong in the canonical public SDK repo,
+`Cubid-Me/cubid-sdk`.
+
+The old E02 SDK/package implementation work is historical context in this repo.
+Do not add new public SDK code under `packages/core` or any other
+`cubid-passport` workspace.
+
+## Current API v3 Inventory
+
+The current backend-owned API v3 routes are:
+
+- `POST /api/v3/save_secret`: dapp-authenticated encrypted dapp-user secret
+  write path backed by `private.dapp_user_secrets`.
+- `POST /api/v3/accounts/generate`: dapp-authenticated custodial account
+  generation for supported chains, storing encrypted private-key material in
+  the `private` schema and returning only public account metadata.
+- `POST /api/v3/accounts/list`: dapp-authenticated account metadata listing
+  scoped to the target dapp user.
+
+Existing `/api/v2/*` routes remain legacy compatibility surfaces unless a
+future todo explicitly promotes a capability into API v3. New developer-facing
+backend capabilities should default to API v3 and should not expand v2.
+
+## Backend Contract Rules
+
+API v3 routes must use the shared Passport API baseline:
+
+- explicit HTTP method and `zod` request validation
+- dapp API-key authentication through hashed `dapp_api_keys`
+- dapp-user ownership checks before any user-scoped read or write
+- request IDs and structured Passport error envelopes
+- rate limits and security-event logging for denials
+- no raw private keys, encrypted key material, token hashes, secret plaintext,
+  service-role outputs, human subject keys, raw Cubid user IDs, or cross-app
+  identifiers in public responses
+
+API v3 identity-adjacent responses must respect app-scoped identity and
+selective-disclosure grants. If a value is not granted, the route should omit
+it, return `null`, or return an explicit non-granted state as documented by the
+route contract. It must not leak the value through score details, webhooks, or
+fallback legacy permissions.
+
+## Webhook Contract Target
+
+API v3 webhooks should become protocol events rather than ad hoc table-change
+notifications. The target event families are:
+
+- disclosure granted or revoked
+- stamp or claim updated
+- score changed
+- credential blacklisted or revoked
+- app-scoped subject revoked
+- custody/account lifecycle events where appropriate
+
+Webhook payloads must be signed with encrypted-at-rest webhook signing secrets,
+include replay-protection inputs such as a stable event id and timestamp, record
+delivery attempts, and be filtered through the same app-scoped disclosure
+contract as API responses.
+
+## SDK Coordination
+
+Every backend change that affects public route shape, response semantics, error
+categories, disclosure states, webhook payloads, examples, or migration guidance
+must create a message for the public SDK agents in the SDK repo's
+`agent-context/messages-from-cubid-passport/` directory.
+
+Before starting API v3 work in this repo, check
+`agent-context/messages-from-cubid-sdk/` for incoming SDK-agent notes and
+address any relevant requests.
+
+## Validation Expectations
+
+API v3 hardening work should add focused Passport tests for:
+
+- malformed request payloads
+- missing, invalid, revoked, or mismatched dapp credentials
+- cross-dapp dapp-user access attempts
+- unsupported chains or unsupported custody operations
+- retry, idempotency, and partial-failure cleanup behavior
+- non-exposure of secrets, private keys, ciphertext, and internal identifiers
+- disclosure-denied identity values
+- webhook signing, replay-protection inputs, redaction, and failure recording
+
+Run at minimum:
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -41,6 +41,13 @@ body field while the shared Passport dapp actor helper verifies the key against
 but do not authorize access; the authenticated dapp from the API key is the
 authority.
 
+Write routes require an `Idempotency-Key` header. The key is scoped to the
+authenticated dapp actor plus route and retained for 24 hours. Repeating the
+same key with the same request body after a successful write replays the stored
+status and response body without repeating side effects. Reusing the same key
+with a different request body returns `409 idempotency_conflict`; retrying while
+the original request is still pending returns `409 request_in_progress`.
+
 ### `POST /api/v3/save_secret`
 
 Purpose: store a retrievable dapp-user secret using the v3 encrypted custody
@@ -59,6 +66,7 @@ Request body:
 
 Rules:
 
+- `Idempotency-Key` is required.
 - `user_id` is the dapp user UUID and must belong to the authenticated dapp.
 - `secret` must be non-empty and is encrypted before storage.
 - Writes go to `private.dapp_user_secrets` with `secret` set to the non-secret
@@ -95,6 +103,7 @@ Request body:
 
 Rules:
 
+- `Idempotency-Key` is required.
 - `dapp_user_uuid` must belong to the authenticated dapp.
 - Supported generated chains are currently `evm`, `near`, and `solana`. Sui is
   explicitly deferred to `C05.2.1`.
@@ -214,11 +223,10 @@ it, return `null`, or return an explicit non-granted state as documented by the
 route contract. It must not leak the value through score details, webhooks, or
 fallback legacy permissions.
 
-API v3 write routes should become explicitly idempotent where retries are part
-of normal integrator behavior. Until a route documents an idempotency key or
-natural idempotency rule, callers should treat successful writes as non-idempotent
-and retry only after checking the resulting resource state. E02.6 owns tightening
-that behavior per route without changing the public SDK from this repo.
+API v3 write routes use the shared `api_idempotency_keys` store. Route
+implementations must hash the canonical request body instead of storing raw
+payloads, and idempotency records must never store submitted secrets or private
+keys in plaintext.
 
 ## Webhook Contract Target
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -230,20 +230,51 @@ keys in plaintext.
 
 ## Webhook Contract Target
 
-API v3 webhooks should become protocol events rather than ad hoc table-change
-notifications. The target event families are:
+API v3 webhooks are protocol events rather than ad hoc table-change
+notifications. Current legacy subscription names are preserved for lookup, but
+deliveries use canonical v3 event names:
 
-- disclosure granted or revoked
-- stamp or claim updated
-- score changed
-- credential blacklisted or revoked
-- app-scoped subject revoked
-- custody/account lifecycle events where appropriate
+- `credential_added` -> `stamp.created`
+- `credential_removed` -> `stamp.removed`
+- `credential_expired` -> `credential.expired`
+- `credential_blacklisted` -> `credential.blacklisted`
+- `credential_whitelisted` -> `credential.whitelisted`
+- `score_increase` -> `score.increased`
+- `score_decrease` -> `score.decreased`
 
-Webhook payloads must be signed with encrypted-at-rest webhook signing secrets,
-include replay-protection inputs such as a stable event id and timestamp, record
-delivery attempts, and be filtered through the same app-scoped disclosure
-contract as API responses.
+Delivered payloads use this shape:
+
+```json
+{
+  "apiVersion": "v3",
+  "payloadVersion": "2026-05-03",
+  "eventId": "wh_evt_...",
+  "eventType": "stamp.created",
+  "legacyEventType": "credential_added",
+  "createdAt": "2026-05-03T00:00:00.000Z",
+  "requestId": "passport_...",
+  "dapp": { "id": "42" },
+  "subject": { "dappUserUuid": "00000000-0000-4000-8000-000000000000" },
+  "data": { "stampId": 123 }
+}
+```
+
+Delivery requests include replay-protection headers:
+
+- `X-Cubid-Event-Id`: stable event id for the dapp, event type, dapp user, and
+  stamp.
+- `X-Cubid-Timestamp`: delivery timestamp.
+- `X-Cubid-Signature-Version`: currently `v1`.
+- `X-Cubid-Signature`: `v1=<hex hmac sha256>` over
+  `eventId.timestamp.rawBody` using the subscription signing secret.
+
+Webhook delivery remains disclosure-gated. A stamp event is delivered to a dapp
+only when the corresponding dapp user has an active disclosure grant or legacy
+stamp permission for that stamp during the rollout window. Payloads must not
+include raw Cubid user ids, human subject keys, raw stamp rows, signing secrets,
+or private custody material. Delivery attempts record event id, request body,
+redacted request headers, signature version, status, response code/body, failure
+category, and attempt number in `webhook_event_deliveries`.
 
 ## SDK Coordination
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -287,6 +287,21 @@ Before starting API v3 work in this repo, check
 `agent-context/messages-from-cubid-sdk/` for incoming SDK-agent notes and
 address any relevant requests.
 
+Current E02 coordination status:
+
+- E02.5 was documentation-only and did not require an outbound SDK handoff.
+- E02.6 created
+  `/Users/botmaster/src/cubid/cubid-sdk-v2/agent-context/messages-from-cubid-passport/2026-05-03-e02-6-api-v3-idempotency.md`
+  for the required `Idempotency-Key` write-route contract.
+- E02.7 created
+  `/Users/botmaster/src/cubid/cubid-sdk-v2/agent-context/messages-from-cubid-passport/2026-05-03-e02-7-api-v3-webhooks.md`
+  for the canonical v3 webhook payload/signature contract.
+- As of E02.8, there are no incoming SDK-agent notes in
+  `agent-context/messages-from-cubid-sdk/` in this repo.
+- The outbound SDK handoff notes are intentionally committed or ingested from
+  the SDK repo, not from `cubid-passport`; this repo records the coordination
+  state only.
+
 ## Validation Expectations
 
 API v3 hardening work should add focused Passport tests for:

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -1,7 +1,7 @@
 # API v3 Developer Platform
 
 Last updated: 2026-05-03
-Status: E02 review and hardening target
+Status: E02.5 canonical contract
 
 ## Purpose
 
@@ -32,6 +32,169 @@ Existing `/api/v2/*` routes remain legacy compatibility surfaces unless a
 future todo explicitly promotes a capability into API v3. New developer-facing
 backend capabilities should default to API v3 and should not expand v2.
 
+## Canonical Route Contracts
+
+All current API v3 routes are `POST` JSON endpoints and are dapp-authenticated.
+Callers may send the API key using the legacy-compatible `api_key` or `apikey`
+body field while the shared Passport dapp actor helper verifies the key against
+`dapp_api_keys`. Optional `dapp_id` body fields are accepted for compatibility
+but do not authorize access; the authenticated dapp from the API key is the
+authority.
+
+### `POST /api/v3/save_secret`
+
+Purpose: store a retrievable dapp-user secret using the v3 encrypted custody
+model. This is the encrypted replacement for legacy `/api/v2/save_secret`; it
+does not add a public retrieval endpoint.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "user_id": "00000000-0000-4000-8000-000000000000",
+  "secret": "plaintext supplied by the dapp"
+}
+```
+
+Rules:
+
+- `user_id` is the dapp user UUID and must belong to the authenticated dapp.
+- `secret` must be non-empty and is encrypted before storage.
+- Writes go to `private.dapp_user_secrets` with `secret` set to the non-secret
+  sentinel `__cubid_encrypted_dapp_user_secret__`.
+- The route assigns a per-dapp-user sequential id and retries unique conflicts
+  up to three times.
+- A success event `dapp_user_secret.encrypted` is written to
+  `api_security_events`.
+
+Success response:
+
+```json
+{ "success": true }
+```
+
+No response may contain the raw secret, ciphertext, wrapped data key, IVs, auth
+tags, human subject keys, raw Cubid user ids, or service-role data.
+
+### `POST /api/v3/accounts/generate`
+
+Purpose: generate a Cubid-custodied blockchain account for one dapp user and
+store the private key using the v3 encrypted private-key custody model.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "dapp_user_uuid": "00000000-0000-4000-8000-000000000000",
+  "chain": "evm",
+  "label": "Primary wallet"
+}
+```
+
+Rules:
+
+- `dapp_user_uuid` must belong to the authenticated dapp.
+- Supported generated chains are currently `evm`, `near`, and `solana`. Sui is
+  explicitly deferred to `C05.2.1`.
+- The route creates `public.user_accounts`, encrypted `private.private_keys`,
+  and one `public.dapp_user_accounts` link for the triggering dapp user.
+- If private-key or link creation fails, the route performs compensating cleanup
+  so orphaned generated accounts are not left behind.
+- A success event `blockchain_account.generated` is written to
+  `api_security_events`.
+
+Success response shape:
+
+```json
+{
+  "data": {
+    "accountId": "account id",
+    "chain": "evm",
+    "createdAt": "2026-05-01T00:00:00.000Z",
+    "custodyStatus": "cubid_custodied",
+    "dappUserAccountId": "link id",
+    "dappUserUuid": "00000000-0000-4000-8000-000000000000",
+    "label": "Primary wallet",
+    "publicAddress": "0x..."
+  }
+}
+```
+
+The route never returns the raw private key, encrypted private-key material,
+wrapped data keys, or internal custody metadata.
+
+### `POST /api/v3/accounts/list`
+
+Purpose: list public account metadata visible to the authenticated dapp for one
+dapp user.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "dapp_user_uuid": "00000000-0000-4000-8000-000000000000",
+  "chain": "solana"
+}
+```
+
+Rules:
+
+- `dapp_user_uuid` must belong to the authenticated dapp.
+- `chain` is optional and filters to `evm`, `near`, or `solana` when present.
+- Only active dapp-user account links and active user accounts are returned.
+
+Success response shape:
+
+```json
+{
+  "data": [
+    {
+      "accountId": "account id",
+      "chain": "solana",
+      "createdAt": "2026-05-01T00:00:00.000Z",
+      "custodyStatus": "cubid_custodied",
+      "dappUserAccountId": "link id",
+      "dappUserUuid": "00000000-0000-4000-8000-000000000000",
+      "label": null,
+      "linkStatus": "active",
+      "publicAddress": "...",
+      "updatedAt": "2026-05-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+The route returns public metadata only. It must not expose private keys,
+ciphertexts, wrapped keys, internal user ids, or account records not linked to
+the authenticated dapp user.
+
+## Error Contract
+
+API v3 uses the Passport structured error envelope for non-OIDC APIs:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Dapp user was not found for the authenticated app.",
+    "requestId": "passport_..."
+  }
+}
+```
+
+Expected route-level failures include:
+
+- `400 invalid_request` for malformed payloads, unsupported enum values, or
+  validation failures.
+- `401 unauthorized` for missing or invalid dapp credentials.
+- `404 not_found` when the target dapp user does not belong to the
+  authenticated dapp.
+- `429 rate_limited` for Passport API baseline rate-limit denials.
+- `500` only for unexpected server/storage failures.
+
 ## Backend Contract Rules
 
 API v3 routes must use the shared Passport API baseline:
@@ -50,6 +213,12 @@ selective-disclosure grants. If a value is not granted, the route should omit
 it, return `null`, or return an explicit non-granted state as documented by the
 route contract. It must not leak the value through score details, webhooks, or
 fallback legacy permissions.
+
+API v3 write routes should become explicitly idempotent where retries are part
+of normal integrator behavior. Until a route documents an idempotency key or
+natural idempotency rule, callers should treat successful writes as non-idempotent
+and retry only after checking the resulting resource state. E02.6 owns tightening
+that behavior per route without changing the public SDK from this repo.
 
 ## Webhook Contract Target
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -291,10 +291,10 @@ Current E02 coordination status:
 
 - E02.5 was documentation-only and did not require an outbound SDK handoff.
 - E02.6 created
-  `/Users/botmaster/src/cubid/cubid-sdk-v2/agent-context/messages-from-cubid-passport/2026-05-03-e02-6-api-v3-idempotency.md`
+  `Cubid-Me/cubid-sdk:agent-context/messages-from-cubid-passport/2026-05-03-e02-6-api-v3-idempotency.md`
   for the required `Idempotency-Key` write-route contract.
 - E02.7 created
-  `/Users/botmaster/src/cubid/cubid-sdk-v2/agent-context/messages-from-cubid-passport/2026-05-03-e02-7-api-v3-webhooks.md`
+  `Cubid-Me/cubid-sdk:agent-context/messages-from-cubid-passport/2026-05-03-e02-7-api-v3-webhooks.md`
   for the canonical v3 webhook payload/signature contract.
 - As of E02.8, there are no incoming SDK-agent notes in
   `agent-context/messages-from-cubid-sdk/` in this repo.

--- a/docs/engineering/app-scoped-identity-selective-disclosure.md
+++ b/docs/engineering/app-scoped-identity-selective-disclosure.md
@@ -92,6 +92,15 @@ subscription, and skip delivery when the changed stamp has not been disclosed to
 that dapp. The first pass preserves the existing webhook payload shape while
 preventing undisclosed stamp events from being sent.
 
+Passport Profile now exposes non-OIDC Allow Page disclosure history separately
+from OIDC Login with Cubid consent. Users can inspect active and revoked dapp
+grants, see the dapp name, scopes, claims, policy version, grant version, data
+classifications, and grant timestamps, and revoke active Allow Page grants. The
+revocation route updates `selective_disclosure_grants`, writes a
+`selective_disclosure_events` audit event, and removes matching legacy
+`stamp_dappuser_permissions` rows for stamp claims in the revoked grant so the
+temporary compatibility fallback does not preserve access after revocation.
+
 Passport requires `PASSPORT_APP_SCOPED_SUBJECT_SECRET` for Allow Page subject
 derivation. OIDC currently derives its broader app-scoped subject from the same
 server-held secret used for pairwise subject derivation so the two OIDC subject

--- a/docs/engineering/app-scoped-identity-selective-disclosure.md
+++ b/docs/engineering/app-scoped-identity-selective-disclosure.md
@@ -67,6 +67,25 @@ revoked before a production backfill has run.
 Score and score-detail endpoints also calculate only from disclosed stamps so a
 dapp cannot infer undisclosed credentials from score contributions.
 
+Profile and location values are now treated as explicit non-stamp disclosure
+claims. The current taxonomy is:
+
+- `profile:name`: releases display-name or nickname-style profile values.
+- `profile:*`: releases all current profile claims in this namespace.
+- `location:rough`: releases country-level or rough location values.
+- `location:approximate`: releases approximate location values and satisfies
+  rough-location reads.
+- `location:exact`: releases exact address or coordinate values and satisfies
+  approximate and rough-location reads.
+- `location:*`: releases all current location granularities.
+
+The `profile` and `cubid:profile` scopes are accepted as profile-name grants
+for compatibility with standard profile-style consent. Location reads require a
+location claim; a broad `cubid:location` scope alone is not enough to release
+exact, approximate, or rough location data. Approximate location routes must not
+return raw address objects, and legacy dapp identity routes must sanitize user
+objects instead of spreading raw database rows.
+
 Webhook delivery is also grant-gated. Internal webhook trigger jobs look up the
 dapp user's active disclosure grants before sending credential events to a dapp
 subscription, and skip delivery when the changed stamp has not been disclosed to
@@ -132,7 +151,8 @@ sequence is:
 4. Update SDK-facing identity routes to return only app-scoped subject and
    granted claims.
 5. Use disclosure grants to filter webhook payloads.
-6. Add user-facing disclosure history and revocation views that cover both OIDC
+6. Extend the grant taxonomy beyond stamps to profile and location claims.
+7. Add user-facing disclosure history and revocation views that cover both OIDC
    and non-OIDC app grants.
 
 ## Non-Goals In This Slice

--- a/docs/engineering/sdk-package-target-state.md
+++ b/docs/engineering/sdk-package-target-state.md
@@ -68,19 +68,18 @@ but should not accumulate heavy crypto custody dependencies.
 
 ## Current E02 Direction
 
-E02 starts by publishing `@cubid/core` as the dual-target npm/JSR foundation,
-then layers in package-ready integration surfaces:
+The original E02 SDK/package work has been ingested into `Cubid-Me/cubid-sdk`.
+This repo now treats those items as historical context only. The active
+`cubid-passport` side of E02 is API v3 backend review and hardening:
 
-- `@cubid/core` now owns the runtime-agnostic API client, identity sync helpers,
-  normalized responses, Deno validation, and Edge examples.
-- `@cubid/react` owns React-only profile completion primitives, including phone
-  OTP UI, provider connect buttons, AllowPage URL helpers, callback-state
-  helpers, and missing-recommended-credential summaries.
-- Chain package workspaces now exist as dependency-isolated homes for
-  chain-specific wallet/stamp contracts. The first slice keeps them lightweight
-  and does not yet add heavy SDKs or signing implementations.
-- `@cubid/wagmi` is the only package with a wagmi peer boundary. It can add
-  wagmi hooks/connectors later without leaking wagmi into core or React.
+- `cubid-passport` owns API v3 route behavior, migrations, security,
+  disclosure enforcement, custody behavior, and webhook runtime contracts.
+- `Cubid-Me/cubid-sdk` owns public SDK packages, examples, publication, and
+  external integration docs.
+- `packages/core` in this repo is a historical snapshot and is not a publication
+  target.
+- SDK-impacting backend changes must be communicated through the SDK handoff
+  message process, not by editing public SDK code here.
 
-Live npm/JSR publication still requires trusted-publisher setup and explicit
-release workflow execution.
+See `docs/engineering/api-v3-developer-platform.md` for the backend-owned API v3
+contract target.

--- a/supabase/migrations/20260503003000_api_v3_idempotency_keys.sql
+++ b/supabase/migrations/20260503003000_api_v3_idempotency_keys.sql
@@ -1,0 +1,32 @@
+create table if not exists public.api_idempotency_keys (
+  id bigserial primary key,
+  route text not null,
+  actor_type text not null,
+  actor_identifier text not null,
+  idempotency_key text not null,
+  request_hash text not null,
+  status text not null check (status in ('pending', 'completed', 'failed')),
+  response_status integer,
+  response_body jsonb,
+  request_id text,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  completed_at timestamptz,
+  failed_at timestamptz,
+  unique (route, actor_type, actor_identifier, idempotency_key)
+);
+
+create index if not exists api_idempotency_keys_expires_at_idx
+  on public.api_idempotency_keys (expires_at);
+
+create index if not exists api_idempotency_keys_request_id_idx
+  on public.api_idempotency_keys (request_id)
+  where request_id is not null;
+
+alter table public.api_idempotency_keys enable row level security;
+
+revoke all on public.api_idempotency_keys from anon;
+revoke all on public.api_idempotency_keys from authenticated;
+grant select, insert, update, delete on public.api_idempotency_keys to service_role;
+grant usage, select on sequence public.api_idempotency_keys_id_seq to service_role;

--- a/supabase/migrations/20260503010000_api_v3_webhook_contract.sql
+++ b/supabase/migrations/20260503010000_api_v3_webhook_contract.sql
@@ -1,0 +1,22 @@
+alter table if exists public.webhook_events
+  add column if not exists event_id text,
+  add column if not exists api_version text,
+  add column if not exists payload_version text;
+
+create unique index if not exists webhook_events_dapp_event_id_idx
+  on public.webhook_events (dapp_id, event_id)
+  where event_id is not null;
+
+create index if not exists webhook_events_api_version_idx
+  on public.webhook_events (api_version)
+  where api_version is not null;
+
+alter table if exists public.webhook_event_deliveries
+  add column if not exists request_body jsonb,
+  add column if not exists request_headers jsonb,
+  add column if not exists event_id text,
+  add column if not exists signature_version text;
+
+create index if not exists webhook_event_deliveries_event_id_idx
+  on public.webhook_event_deliveries (event_id)
+  where event_id is not null;

--- a/supabase/migrations/20260503010000_api_v3_webhook_contract.sql
+++ b/supabase/migrations/20260503010000_api_v3_webhook_contract.sql
@@ -17,6 +17,12 @@ alter table if exists public.webhook_event_deliveries
   add column if not exists event_id text,
   add column if not exists signature_version text;
 
+alter table if exists public.webhook_event_deliveries
+  drop constraint if exists unique_delivery_attempt;
+
+create unique index if not exists webhook_event_deliveries_attempt_idx
+  on public.webhook_event_deliveries (webhook_event_id, dapp_id, attempt_number);
+
 create index if not exists webhook_event_deliveries_event_id_idx
   on public.webhook_event_deliveries (event_id)
   where event_id is not null;


### PR DESCRIPTION
## Summary
- Adds first-class app-scoped disclosure grant persistence and user-facing non-OIDC disclosure history/revocation.
- Tightens profile, location, and stamp disclosure filtering for app-facing API paths and webhook payloads.
- Reframes E02 around API v3 backend contracts in this repo, with public SDK implementation kept in `Cubid-Me/cubid-sdk`.
- Hardens active API v3 routes with idempotency and standardizes v3 webhook payload/signature/retry contracts.

## Objective
Make app-scoped identity and selective disclosure enforceable as a backend contract, then define and harden the API v3 developer-platform surfaces that SDKs and integrators depend on.

## Changes
- Adds disclosure grant taxonomy and persistence for Allow Page and OIDC consent-backed app data sharing.
- Adds non-OIDC grant list/revoke surfaces so users can inspect and revoke app disclosure grants outside the OIDC consent panel.
- Filters SDK-facing identity routes and webhook payloads through persisted disclosure grants.
- Documents the API v3 backend contract and closes SDK coordination via handoff notes for the public SDK repo.
- Adds `api_idempotency_keys` support for API v3 write routes and requires `Idempotency-Key` on `save_secret` and `accounts/generate`.
- Adds v3 webhook event contract helpers, delivery metadata, replay-relevant signature fields, and route tests.

## Validation
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'` passed under Node 24.15.0.
- `pnpm --filter @cubid/passport typecheck` passed.
- `pnpm --filter @cubid/passport build` passed.
- Build output still includes pre-existing frontend lint warnings and the known Celo `fs` browser warning.

## Reviewer Notes
- Suggested review order: disclosure grant schema/routes first, then API v3 idempotency/webhook helpers, then docs/todo/session-log updates.
- Public SDK implementation is intentionally not included in this repo; SDK-impacting changes are coordinated through notes to the public SDK workspace.
- The SDK handoff notes were created in the local SDK repo for SDK agents and are not committed in this private backend repo.

## Follow-ups
- Public SDK agents should ingest the API v3 idempotency and webhook handoff notes.
- Live database migrations/deploys are not performed by this PR.
- Existing v2 endpoints remain legacy compatibility surfaces unless a future todo explicitly deprecates them.
