### PR TITLE
[codex] close E01 disclosure foundation

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4256,3 +4256,33 @@ Address the Codex review finding that failed idempotency records must not re-run
 #### Follow-up
 
 - push the terminal failed-idempotency fix, confirm CI is green, then reply to and resolve the Copilot and Codex review threads
+
+### session: v149
+
+- timestamp: 2026-05-03T13:44:24Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-closeout-reconciliation**
+- head: **`87013e2`**
+- session name: **Close out E01 app-scoped disclosure foundation**
+
+#### Objective
+
+Reconcile E01 after PR 156 merged and decide whether the parent app-scoped identity and selective-disclosure todo should remain open or be split into precise follow-ups.
+
+#### Actions Taken
+
+- verified the merged runtime covers Allow Page grant persistence, OIDC consent mirroring, SDK-facing route filtering, webhook filtering, profile/location claim taxonomy, and user-facing non-OIDC disclosure history/revocation
+- marked E01 completed in the roadmap
+- added `E01.1` for production backfill and retirement of the legacy `stamp_dappuser_permissions` compatibility fallback
+- added `E01.2` for Admin/Ops visibility into app-scoped subjects, disclosure grants, and grant/revoke events
+- updated the E01 engineering doc from foundation/adoption-sequence language to implemented-status language with rollout follow-ups
+
+#### Verification
+
+- `git status -sb`
+- `rg -n "Status: (Started|Not started)|^## [A-Z][0-9]|^### [A-Z][0-9]" agent-context/todo.md`
+- reviewed `docs/engineering/app-scoped-identity-selective-disclosure.md`
+
+#### Follow-up
+
+- tackle `E01.1` next if the priority is production rollout safety, or `E01.2` next if operators need visibility before disabling legacy fallback behavior

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4316,3 +4316,33 @@ Complete `E01.1` by adding the production backfill path for legacy stamp permiss
 #### Follow-up
 
 - run the backfill script in production dry-run mode before write mode, then consider `E01.2` for Admin/Ops disclosure visibility
+
+### session: v151
+
+- timestamp: 2026-05-03T17:20:46Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-closeout-reconciliation**
+- head: **`44e6eb5`**
+- session name: **Add disclosure operations visibility**
+
+#### Objective
+
+Complete `E01.2` by adding read-only Admin/Ops visibility for app-scoped subjects, selective-disclosure grants, and disclosure grant/revoke events.
+
+#### Actions Taken
+
+- added a disclosure operations server mapper and Admin overview API under the shared Admin security baseline
+- added a read-only `Disclosure Ops` Admin tab with grant health, dapp summaries, OIDC-client summaries, and redacted recent events
+- added tests for disclosure ops aggregation/redaction and route baseline wiring
+- updated the E01 engineering doc and roadmap metadata to reflect the completed operations visibility slice
+
+#### Verification
+
+- `pnpm --filter @cubid/admin test`
+- `pnpm --filter @cubid/admin typecheck`
+- `pnpm --filter @cubid/admin build`
+- `git diff --check`
+
+#### Follow-up
+
+- yeet the E01 closeout branch for review, then start the next platform slice from `dev`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4346,3 +4346,35 @@ Complete `E01.2` by adding read-only Admin/Ops visibility for app-scoped subject
 #### Follow-up
 
 - yeet the E01 closeout branch for review, then start the next platform slice from `dev`
+
+### session: v152
+
+- timestamp: 2026-05-03T20:54:11Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-closeout-reconciliation**
+- head: **`6b99aa6`**
+- session name: **Address PR 157 disclosure ops review**
+
+#### Objective
+
+Address Copilot and Codex review comments on PR 157 before completing the yeet review flow.
+
+#### Actions Taken
+
+- replaced Disclosure Ops sample-derived totals with service-role SQL aggregate functions for grant totals, active subject counts, 7-day event counts, dapp summaries, and OIDC-client summaries
+- changed the Admin overview payload so sampled recent grants are labeled as samples rather than scanned totals
+- paginated the legacy stamp-permission backfill script and batched reference lookups per page
+- updated tests and engineering docs for the aggregate-backed operations contract
+
+#### Verification
+
+- `pnpm --filter @cubid/admin test`
+- `pnpm --filter @cubid/admin typecheck`
+- `pnpm --filter @cubid/admin build`
+- `pnpm --filter @cubid/passport typecheck`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `git diff --check`
+
+#### Follow-up
+
+- push the review fixes, confirm CI is green again, reply to and resolve the Copilot and Codex review threads

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4286,3 +4286,33 @@ Reconcile E01 after PR 156 merged and decide whether the parent app-scoped ident
 #### Follow-up
 
 - tackle `E01.1` next if the priority is production rollout safety, or `E01.2` next if operators need visibility before disabling legacy fallback behavior
+
+### session: v150
+
+- timestamp: 2026-05-03T13:54:17Z
+- agent: **OpenAI Codex**
+- branch: **codex/e01-closeout-reconciliation**
+- head: **`d483ab1`**
+- session name: **Retire legacy disclosure fallback**
+
+#### Objective
+
+Complete `E01.1` by adding the production backfill path for legacy stamp permissions and making selective-disclosure grants the only runtime authorization source for app-facing disclosure.
+
+#### Actions Taken
+
+- added a Passport dry-run/write script to backfill `stamp_dappuser_permissions` into `selective_disclosure_grants`
+- removed legacy stamp-permission fallback reads from disclosure grant loading and stamp filtering
+- updated webhook and disclosure tests so SDK-facing and webhook outputs require grant-backed disclosure
+- updated the engineering doc, Passport script contract, roadmap metadata, and SDK handoff note
+
+#### Verification
+
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- run the backfill script in production dry-run mode before write mode, then consider `E01.2` for Admin/Ops disclosure visibility

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -519,14 +519,36 @@ Parallelization note: This section can run in parallel with `B`, `C`, and `D` on
 
 ### E01. Rebuild app-scoped identity and selective disclosure as first-class platform services
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-04-30T21:38:40Z
-- Timestamp completed: TBD
-- Feature branch: codex/e01-app-scoped-identity-disclosure; codex/e01-disclosure-claim-taxonomy
-- Head: 96ac1ff; continued from 63303ad; 3123f99
-- Session-log reference(s): session: v126, session: v127, session: v137, session: v138, session: v140, session: v141
+- Timestamp completed: 2026-05-03T13:44:24Z
+- Feature branch: codex/e01-app-scoped-identity-disclosure; codex/e01-disclosure-claim-taxonomy; codex/e01-closeout-reconciliation
+- Head: 87013e2
+- Session-log reference(s): session: v126, session: v127, session: v137, session: v138, session: v140, session: v141, session: v149
 
 Take the backgrounder’s core ideas seriously by making app-scoped identity and selective disclosure explicit platform capabilities instead of incidental behavior buried in Passport flows. Build a consent and disclosure service that owns per-app subject identifiers, claim release decisions, stamp-sharing permissions, and revocation behavior. Relying parties should never need raw cross-app identifiers or unnecessary PII; they should request scopes and receive only the allowed app-scoped values. This service should back the Allow Page, the OIDC consent model, SDK calls, and webhook payload filtering. Treat it as a foundational protocol service with strong typing, auditability, and user-visible history, not just a UX screen. Finishing this todo would align Cubid much more closely with the backgrounder’s privacy, protocol, and anti-tracking principles.
+
+### E01.1 Backfill disclosure grants and retire legacy stamp-permission fallback
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Complete the production rollout tail for app-scoped disclosure by backfilling legacy `stamp_dappuser_permissions` rows into `selective_disclosure_grants`, validating that active relying-party access is represented in the new grant table, and then removing the temporary compatibility fallback from SDK-facing identity, score, and webhook paths. This should be treated as a deployment-safe migration task, not a product redesign. Add a dry-run script or SQL report that counts legacy permissions by dapp, dapp user, and stamp type; write encrypted or private data nowhere; and confirm revocation semantics still remove access after the fallback is disabled. Once production smoke passes, update the engineering doc and tests so the selective-disclosure contract is the only authorization source for new app-facing stamp release.
+
+### E01.2 Promote disclosure-grant operations into Admin/Ops visibility
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add operator visibility for app-scoped subjects and selective-disclosure grants without exposing raw internal identifiers or secret material. Admin should be able to inspect aggregate grant counts, recent grant/revoke events, source split between Allow Page and OIDC, revoked versus active grants, and dapp/client-level disclosure health. Keep controls conservative: read-only observability first, with any operator-driven revocation or repair flow requiring a separate authorization design. This follow-up helps support production rollout and debugging after E01, especially when an integrator reports missing identity, stamp, score, location, or webhook data. It should reuse existing security-event and audit patterns, redact human subject keys and raw Cubid user IDs, and document how operators trace a user-facing revocation from Profile to route filtering and webhook suppression.
 
 ### E02. Productize the developer platform: API v3 contracts, review, and hardening
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -530,12 +530,12 @@ Take the backgrounder’s core ideas seriously by making app-scoped identity and
 
 ### E01.1 Backfill disclosure grants and retire legacy stamp-permission fallback
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-05-03T13:49:32Z
+- Timestamp completed: 2026-05-03T13:54:17Z
+- Feature branch: codex/e01-closeout-reconciliation
+- Head: d483ab1
+- Session-log reference(s): session: v150
 
 Complete the production rollout tail for app-scoped disclosure by backfilling legacy `stamp_dappuser_permissions` rows into `selective_disclosure_grants`, validating that active relying-party access is represented in the new grant table, and then removing the temporary compatibility fallback from SDK-facing identity, score, and webhook paths. This should be treated as a deployment-safe migration task, not a product redesign. Add a dry-run script or SQL report that counts legacy permissions by dapp, dapp user, and stamp type; write encrypted or private data nowhere; and confirm revocation semantics still remove access after the fallback is disabled. Once production smoke passes, update the engineering doc and tests so the selective-disclosure contract is the only authorization source for new app-facing stamp release.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -541,12 +541,12 @@ Complete the production rollout tail for app-scoped disclosure by backfilling le
 
 ### E01.2 Promote disclosure-grant operations into Admin/Ops visibility
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-05-03T17:15:29Z
+- Timestamp completed: 2026-05-03T17:20:46Z
+- Feature branch: codex/e01-closeout-reconciliation
+- Head: 44e6eb5
+- Session-log reference(s): session: v151
 
 Add operator visibility for app-scoped subjects and selective-disclosure grants without exposing raw internal identifiers or secret material. Admin should be able to inspect aggregate grant counts, recent grant/revoke events, source split between Allow Page and OIDC, revoked versus active grants, and dapp/client-level disclosure health. Keep controls conservative: read-only observability first, with any operator-driven revocation or repair flow requiring a separate authorization design. This follow-up helps support production rollout and debugging after E01, especially when an integrator reports missing identity, stamp, score, location, or webhook data. It should reuse existing security-event and audit patterns, redact human subject keys and raw Cubid user IDs, and document how operators trace a user-facing revocation from Profile to route filtering and webhook suppression.
 

--- a/apps/admin/app/admin/disclosureOps.tsx
+++ b/apps/admin/app/admin/disclosureOps.tsx
@@ -278,8 +278,8 @@ export default function DisclosureOps() {
             value={overview.totals.recentGrantEvents7d}
           />
           <MetricCard
-            label='Rows scanned'
-            value={overview.totals.grantRowsScanned}
+            label='Grant samples'
+            value={overview.totals.recentGrantSamples}
           />
         </div>
         <p className='mt-3 text-xs text-gray-500'>

--- a/apps/admin/app/admin/disclosureOps.tsx
+++ b/apps/admin/app/admin/disclosureOps.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import dayjs from 'dayjs';
+import useAuth from 'hooks/useAuth';
+import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+
+import type {
+  DisclosureOpsDappSummary,
+  DisclosureOpsEvent,
+  DisclosureOpsGrantSample,
+  DisclosureOpsOidcClientSummary,
+  DisclosureOpsOverviewPayload,
+} from './shared';
+import { loadDisclosureOpsOverview } from '../../features/disclosure-ops/api';
+
+const formatDate = (value: string | null) => {
+  if (!value) {
+    return 'Never';
+  }
+
+  return dayjs(value).format('YYYY-MM-DD HH:mm');
+};
+
+const formatSources = (sources: Record<string, number>) => {
+  const entries = Object.entries(sources);
+  if (entries.length === 0) {
+    return 'None';
+  }
+
+  return entries.map(([source, count]) => `${source}: ${count}`).join(', ');
+};
+
+const MetricCard = ({ label, value }: { label: string; value: number }) => (
+  <div className='rounded-lg border border-gray-800 bg-gray-900/70 px-3 py-2'>
+    <p className='text-[11px] uppercase tracking-wide text-gray-500'>{label}</p>
+    <p className='mt-1 text-lg font-semibold text-white'>{value}</p>
+  </div>
+);
+
+const GrantSamples = ({ grants }: { grants: DisclosureOpsGrantSample[] }) => {
+  if (grants.length === 0) {
+    return <p className='text-sm text-gray-500'>No recent grants.</p>;
+  }
+
+  return (
+    <div className='space-y-2'>
+      {grants.map((grant) => (
+        <div
+          className='rounded-lg border border-gray-800 bg-gray-950/40 p-3 text-xs text-gray-300'
+          key={`${grant.source}-${grant.grantedAt}-${grant.policyVersion}`}
+        >
+          <div className='flex flex-wrap items-center justify-between gap-2'>
+            <p className='font-medium text-white'>{grant.source}</p>
+            <span
+              className={`rounded-full px-2 py-1 uppercase tracking-wide ${
+                grant.status === 'active'
+                  ? 'bg-emerald-500/10 text-emerald-300'
+                  : 'bg-amber-500/10 text-amber-300'
+              }`}
+            >
+              {grant.status}
+            </span>
+          </div>
+          <p className='mt-1 text-gray-500'>
+            {grant.scopeCount} scopes · {grant.claimCount} claims · policy{' '}
+            {grant.policyVersion} · consent v{grant.consentVersion}
+          </p>
+          <p className='mt-1 text-gray-500'>
+            Granted {formatDate(grant.grantedAt)}
+            {grant.revokedAt ? ` · revoked ${formatDate(grant.revokedAt)}` : ''}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const DisclosureEventList = ({ events }: { events: DisclosureOpsEvent[] }) => {
+  if (events.length === 0) {
+    return <p className='text-sm text-gray-500'>No recent grant events.</p>;
+  }
+
+  return (
+    <div className='space-y-2'>
+      {events.map((event) => (
+        <div
+          className='rounded-lg border border-gray-800 bg-gray-950/40 p-3'
+          key={`${event.eventType}-${event.createdAt}-${
+            event.requestId ?? 'no-request'
+          }`}
+        >
+          <div className='flex flex-wrap items-center justify-between gap-2'>
+            <p className='text-sm font-medium text-white'>{event.eventType}</p>
+            <span
+              className={`rounded-full px-2 py-1 text-[11px] uppercase tracking-wide ${
+                event.outcome === 'success'
+                  ? 'bg-emerald-500/10 text-emerald-300'
+                  : 'bg-amber-500/10 text-amber-300'
+              }`}
+            >
+              {event.outcome}
+            </span>
+          </div>
+          <p className='mt-1 text-xs text-gray-500'>
+            {formatDate(event.createdAt)} · {event.actorType}
+            {event.requestId ? ` · ${event.requestId}` : ''}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const DappCard = ({ dapp }: { dapp: DisclosureOpsDappSummary }) => (
+  <section className='rounded-xl border border-gray-800 bg-gray-900/70 p-5 shadow-lg'>
+    <div className='flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between'>
+      <div>
+        <h2 className='text-lg font-semibold text-white'>{dapp.appName}</h2>
+        <p className='mt-1 text-xs text-gray-500'>Dapp {dapp.dappId}</p>
+      </div>
+      <p className='rounded-lg border border-gray-800 bg-gray-950/50 px-3 py-2 text-xs text-gray-300'>
+        {formatSources(dapp.sources)}
+      </p>
+    </div>
+    <div className='mt-4 grid gap-3 sm:grid-cols-4'>
+      <MetricCard label='Active grants' value={dapp.activeGrantCount} />
+      <MetricCard label='Revoked grants' value={dapp.revokedGrantCount} />
+      <MetricCard label='Active subjects' value={dapp.activeSubjectCount} />
+      <MetricCard
+        label='Recent grants'
+        value={dapp.recentGrants.length}
+      />
+    </div>
+    <div className='mt-4 grid gap-4 lg:grid-cols-2'>
+      <div className='space-y-2 text-sm text-gray-300'>
+        <p>
+          <span className='text-gray-500'>Last grant:</span>{' '}
+          {formatDate(dapp.lastGrantedAt)}
+        </p>
+        <p>
+          <span className='text-gray-500'>Last revoke:</span>{' '}
+          {formatDate(dapp.lastRevokedAt)}
+        </p>
+      </div>
+      <GrantSamples grants={dapp.recentGrants} />
+    </div>
+  </section>
+);
+
+const OidcClientCard = ({
+  client,
+}: {
+  client: DisclosureOpsOidcClientSummary;
+}) => (
+  <section className='rounded-xl border border-gray-800 bg-gray-900/70 p-5 shadow-lg'>
+    <div className='flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between'>
+      <div>
+        <h2 className='text-lg font-semibold text-white'>{client.clientName}</h2>
+        <p className='mt-1 break-all text-xs text-gray-500'>
+          {client.clientId}
+        </p>
+      </div>
+      <p className='rounded-lg border border-gray-800 bg-gray-950/50 px-3 py-2 text-xs text-gray-300'>
+        {formatSources(client.sources)}
+      </p>
+    </div>
+    <div className='mt-4 grid gap-3 sm:grid-cols-3'>
+      <MetricCard label='Active grants' value={client.activeGrantCount} />
+      <MetricCard label='Revoked grants' value={client.revokedGrantCount} />
+      <MetricCard
+        label='Recent grants'
+        value={client.recentGrants.length}
+      />
+    </div>
+    <div className='mt-4 grid gap-4 lg:grid-cols-2'>
+      <div className='space-y-2 text-sm text-gray-300'>
+        <p>
+          <span className='text-gray-500'>Last grant:</span>{' '}
+          {formatDate(client.lastGrantedAt)}
+        </p>
+        <p>
+          <span className='text-gray-500'>Last revoke:</span>{' '}
+          {formatDate(client.lastRevokedAt)}
+        </p>
+      </div>
+      <GrantSamples grants={client.recentGrants} />
+    </div>
+  </section>
+);
+
+export default function DisclosureOps() {
+  const { user } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [overview, setOverview] = useState<DisclosureOpsOverviewPayload | null>(
+    null
+  );
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadOverview = async (showRefreshingState = false) => {
+    if (showRefreshingState) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+
+    try {
+      setOverview(await loadDisclosureOpsOverview());
+    } catch {
+      toast.error('Failed to load disclosure operations overview');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    if (user?.email) {
+      loadOverview();
+    }
+  }, [user?.email]);
+
+  if (loading) {
+    return (
+      <div className='p-3 text-sm text-gray-400'>
+        Loading disclosure operations...
+      </div>
+    );
+  }
+
+  if (!overview) {
+    return (
+      <div className='p-3 text-sm text-gray-400'>
+        Disclosure operations data is unavailable.
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-6 p-3'>
+      <div className='flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between'>
+        <div>
+          <h1 className='text-2xl font-semibold text-white'>
+            Disclosure Operations
+          </h1>
+          <p className='mt-2 max-w-3xl text-sm text-gray-400'>
+            Read-only visibility into app-scoped disclosure grants, sources,
+            revocations, and recent grant events without exposing raw subject
+            identifiers or secret material.
+          </p>
+          <p className='mt-1 text-xs text-gray-500'>
+            Generated {formatDate(overview.generatedAt)}
+          </p>
+        </div>
+        <button
+          className='rounded-md border border-gray-700 px-4 py-2 text-sm font-medium text-gray-200 transition hover:border-gray-500 hover:text-white disabled:opacity-50'
+          disabled={refreshing}
+          onClick={() => loadOverview(true)}
+        >
+          {refreshing ? 'Refreshing...' : 'Refresh'}
+        </button>
+      </div>
+
+      <section className='rounded-xl border border-gray-800 bg-gray-900/70 p-5 shadow-lg'>
+        <h2 className='text-lg font-semibold text-white'>Grant health</h2>
+        <div className='mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5'>
+          <MetricCard label='Active grants' value={overview.totals.activeGrants} />
+          <MetricCard
+            label='Revoked grants'
+            value={overview.totals.revokedGrants}
+          />
+          <MetricCard
+            label='Active subjects'
+            value={overview.totals.activeSubjects}
+          />
+          <MetricCard
+            label='Grant events 7d'
+            value={overview.totals.recentGrantEvents7d}
+          />
+          <MetricCard
+            label='Rows scanned'
+            value={overview.totals.grantRowsScanned}
+          />
+        </div>
+        <p className='mt-3 text-xs text-gray-500'>
+          Sources: {formatSources(overview.totals.grantsBySource)} · Statuses:{' '}
+          {formatSources(overview.totals.grantsByStatus)}
+        </p>
+      </section>
+
+      <section className='space-y-4'>
+        <h2 className='text-lg font-semibold text-white'>Dapp disclosure health</h2>
+        {overview.dapps.length === 0 && (
+          <p className='rounded-xl border border-gray-800 bg-gray-900/70 p-5 text-sm text-gray-400'>
+            No dapp disclosure grants found.
+          </p>
+        )}
+        {overview.dapps.map((dapp) => (
+          <DappCard key={dapp.dappId} dapp={dapp} />
+        ))}
+      </section>
+
+      <section className='space-y-4'>
+        <h2 className='text-lg font-semibold text-white'>
+          OIDC disclosure health
+        </h2>
+        {overview.oidcClients.length === 0 && (
+          <p className='rounded-xl border border-gray-800 bg-gray-900/70 p-5 text-sm text-gray-400'>
+            No OIDC disclosure grants found.
+          </p>
+        )}
+        {overview.oidcClients.map((client) => (
+          <OidcClientCard key={client.clientId} client={client} />
+        ))}
+      </section>
+
+      <section className='rounded-xl border border-gray-800 bg-gray-900/70 p-5'>
+        <h2 className='text-lg font-semibold text-white'>
+          Recent disclosure events
+        </h2>
+        <div className='mt-4'>
+          <DisclosureEventList events={overview.recentEvents} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/admin/app/admin/page.tsx
+++ b/apps/admin/app/admin/page.tsx
@@ -5,12 +5,13 @@ import { Header } from 'components/header';
 import React, { useState } from 'react';
 
 import AppList from './appList';
+import DisclosureOps from './disclosureOps';
 import OidcOps from './oidcOps';
 import OidcRegistry from './oidcRegistry';
 import Webhooks from './webhook';
 
 // Define the type for the tab state
-type Tab = 'apps' | 'oidc' | 'oidc-ops' | 'webhooks';
+type Tab = 'apps' | 'disclosure-ops' | 'oidc' | 'oidc-ops' | 'webhooks';
 
 export default function Admin() {
   const [activeTab, setActiveTab] = useState<Tab>('apps'); // Define state with Tab type
@@ -40,6 +41,12 @@ export default function Admin() {
               OIDC Ops
             </button>
             <button
+              onClick={() => setActiveTab('disclosure-ops')}
+              className={`pb-2 ${activeTab === 'disclosure-ops' ? 'border-b-2 border-blue-500 text-blue-500' : ''}`}
+            >
+              Disclosure Ops
+            </button>
+            <button
               onClick={() => setActiveTab('webhooks')}
               className={`pb-2 ${activeTab === 'webhooks' ? 'border-b-2 border-blue-500 text-blue-500' : ''}`}
             >
@@ -50,6 +57,7 @@ export default function Admin() {
             {activeTab === 'apps' && <AppList />}
             {activeTab === 'oidc' && <OidcRegistry />}
             {activeTab === 'oidc-ops' && <OidcOps />}
+            {activeTab === 'disclosure-ops' && <DisclosureOps />}
             {activeTab === 'webhooks' && <Webhooks />}
           </div>
         </div>

--- a/apps/admin/app/admin/shared.ts
+++ b/apps/admin/app/admin/shared.ts
@@ -220,8 +220,8 @@ export interface DisclosureOpsOverviewPayload {
     activeSubjects: number;
     grantsBySource: Record<string, number>;
     grantsByStatus: Record<string, number>;
-    grantRowsScanned: number;
     recentGrantEvents7d: number;
+    recentGrantSamples: number;
     revokedGrants: number;
   };
 }

--- a/apps/admin/app/admin/shared.ts
+++ b/apps/admin/app/admin/shared.ts
@@ -167,6 +167,65 @@ export interface OidcOpsOverviewPayload {
   recentAuditEvents: OidcOpsAuditEvent[];
 }
 
+export interface DisclosureOpsEvent {
+  actorType: string;
+  createdAt: string;
+  details: Record<string, unknown>;
+  eventType: string;
+  outcome: string;
+  requestId: string | null;
+}
+
+export interface DisclosureOpsGrantSample {
+  claimCount: number;
+  consentVersion: number;
+  grantedAt: string;
+  policyVersion: string;
+  revokedAt: string | null;
+  scopeCount: number;
+  source: string;
+  status: string;
+}
+
+export interface DisclosureOpsDappSummary {
+  activeGrantCount: number;
+  activeSubjectCount: number;
+  appName: string;
+  dappId: number;
+  lastGrantedAt: string | null;
+  lastRevokedAt: string | null;
+  recentGrants: DisclosureOpsGrantSample[];
+  revokedGrantCount: number;
+  sources: Record<string, number>;
+}
+
+export interface DisclosureOpsOidcClientSummary {
+  activeGrantCount: number;
+  clientId: string;
+  clientName: string;
+  lastGrantedAt: string | null;
+  lastRevokedAt: string | null;
+  recentGrants: DisclosureOpsGrantSample[];
+  revokedGrantCount: number;
+  sources: Record<string, number>;
+}
+
+export interface DisclosureOpsOverviewPayload {
+  dapps: DisclosureOpsDappSummary[];
+  generatedAt: string;
+  oidcClients: DisclosureOpsOidcClientSummary[];
+  recentEvents: DisclosureOpsEvent[];
+  totals: {
+    activeGrants: number;
+    activeSubjects: number;
+    grantsBySource: Record<string, number>;
+    grantsByStatus: Record<string, number>;
+    grantRowsScanned: number;
+    recentGrantEvents7d: number;
+    revokedGrants: number;
+  };
+}
+
 export type RequestedInfoMap = Record<string, RequestedInfoItem>;
 export type RequestedInfoByIndex = Record<number, RequestedInfoMap>;
 

--- a/apps/admin/features/disclosure-ops/api.ts
+++ b/apps/admin/features/disclosure-ops/api.ts
@@ -1,0 +1,11 @@
+import { authedPost } from 'lib/api';
+
+import type { DisclosureOpsOverviewPayload } from '../../app/admin/shared';
+
+export const loadDisclosureOpsOverview = async () => {
+  const response = await authedPost<{ data: DisclosureOpsOverviewPayload }>(
+    '/api/admin/disclosures/operations/overview',
+    {}
+  );
+  return response.data.data;
+};

--- a/apps/admin/lib/server/adminRoutes.test.ts
+++ b/apps/admin/lib/server/adminRoutes.test.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import syncAdminUser from '../../pages/api/admin/auth/sync';
 import metadata from '../../pages/api/admin/metadata';
+import disclosureOpsOverviewRoute from '../../pages/api/admin/disclosures/operations/overview';
 import updateOidcClientOpsRoute from '../../pages/api/admin/oidc/clients/update-ops';
 import rotateKey from '../../pages/api/admin/apps/rotate-key';
 import createWebhook from '../../pages/api/admin/webhooks/create';
@@ -15,6 +16,7 @@ const getOwnedDappIdsMock = jest.fn();
 const getPlatformUserByEmailMock = jest.fn();
 const rotateDappApiKeyMock = jest.fn();
 const updateOidcClientOpsMock = jest.fn();
+const loadDisclosureOpsOverviewMock = jest.fn();
 const normalizeClientOpsUpdateInputMock = jest.fn();
 const encryptWebhookSigningSecretMock = jest.fn();
 
@@ -37,6 +39,11 @@ jest.mock('./oidcOperations', () => ({
   normalizeClientOpsUpdateInput: (...args: unknown[]) =>
     normalizeClientOpsUpdateInputMock(...args),
   updateOidcClientOps: (...args: unknown[]) => updateOidcClientOpsMock(...args),
+}));
+
+jest.mock('./disclosureOperations', () => ({
+  loadDisclosureOpsOverview: (...args: unknown[]) =>
+    loadDisclosureOpsOverviewMock(...args),
 }));
 
 jest.mock('./dappApiKeys', () => ({
@@ -181,6 +188,42 @@ describe('Admin route baseline wiring', () => {
         route: 'admin/oidc/clients/update-ops',
       })
     );
+  });
+
+  it('uses the admin read policy for disclosure operations overview', async () => {
+    prepareAdminApiRequestMock.mockResolvedValue({
+      body: {},
+      context: { supabase: {} },
+      requestId: 'admin_request_disclosure_ops',
+    });
+    loadDisclosureOpsOverviewMock.mockResolvedValue({
+      dapps: [],
+      generatedAt: '2026-05-03T00:00:00.000Z',
+      oidcClients: [],
+      recentEvents: [],
+      totals: {
+        activeGrants: 0,
+        activeSubjects: 0,
+        grantRowsScanned: 0,
+        grantsBySource: {},
+        grantsByStatus: {},
+        recentGrantEvents7d: 0,
+        revokedGrants: 0,
+      },
+    });
+
+    await disclosureOpsOverviewRoute({} as NextApiRequest, createResponse());
+
+    expect(prepareAdminApiRequestMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        actor: 'admin',
+        rateLimitGroup: 'admin_read',
+        route: 'admin/disclosures/operations/overview',
+      })
+    );
+    expect(loadDisclosureOpsOverviewMock).toHaveBeenCalledWith({});
   });
 
   it('creates webhook subscriptions with encrypted one-time signing secrets', async () => {

--- a/apps/admin/lib/server/adminRoutes.test.ts
+++ b/apps/admin/lib/server/adminRoutes.test.ts
@@ -204,10 +204,10 @@ describe('Admin route baseline wiring', () => {
       totals: {
         activeGrants: 0,
         activeSubjects: 0,
-        grantRowsScanned: 0,
         grantsBySource: {},
         grantsByStatus: {},
         recentGrantEvents7d: 0,
+        recentGrantSamples: 0,
         revokedGrants: 0,
       },
     });

--- a/apps/admin/lib/server/disclosureOperations.test.ts
+++ b/apps/admin/lib/server/disclosureOperations.test.ts
@@ -1,0 +1,110 @@
+import { buildDisclosureOpsOverview } from './disclosureOperations';
+
+describe('Disclosure operations helpers', () => {
+  it('builds aggregate disclosure health without exposing raw identifiers', () => {
+    const overview = buildDisclosureOpsOverview({
+      clients: [{ client_id: 'client_tcoin', client_name: 'TCOIN' }],
+      dapps: [{ appname: 'FundLoop', id: 42 }],
+      events: [
+        {
+          actor_identifier: 'user@example.com',
+          actor_type: 'user',
+          created_at: '2026-05-03T12:00:00.000Z',
+          details: {
+            app_scoped_subject_id: 'subject_internal',
+            disclosure_grant_id: 'grant_internal',
+            dapp_user_uuid: 'dapp_user_internal',
+            safe: 'visible',
+          },
+          event_type: 'disclosure.revoked',
+          outcome: 'success',
+          request_id: 'passport_request_1',
+        },
+      ],
+      generatedAt: '2026-05-03T13:00:00.000Z',
+      grants: [
+        {
+          app_scoped_subject_id: 'subject_1',
+          consent_version: 1,
+          created_at: '2026-05-03T10:00:00.000Z',
+          dapp_id: 42,
+          granted_at: '2026-05-03T10:00:00.000Z',
+          granted_claims: [{ claim: 'stamp.email' }],
+          granted_scopes: ['cubid:stamps'],
+          id: 'grant_1',
+          metadata: {},
+          oidc_client_id: null,
+          policy_version: 'allow-page-v1',
+          revoked_at: null,
+          revoked_by: null,
+          source: 'allow_page',
+          status: 'active',
+          updated_at: '2026-05-03T10:00:00.000Z',
+        },
+        {
+          app_scoped_subject_id: 'subject_2',
+          consent_version: 2,
+          created_at: '2026-05-03T11:00:00.000Z',
+          dapp_id: null,
+          granted_at: '2026-05-03T11:00:00.000Z',
+          granted_claims: [{ claim: 'email' }, { claim: 'profile' }],
+          granted_scopes: ['openid', 'email', 'profile'],
+          id: 'grant_2',
+          metadata: {},
+          oidc_client_id: 'client_tcoin',
+          policy_version: 'oidc-v1',
+          revoked_at: '2026-05-03T12:00:00.000Z',
+          revoked_by: 'user',
+          source: 'oidc',
+          status: 'revoked',
+          updated_at: '2026-05-03T12:00:00.000Z',
+        },
+      ],
+      subjects: [
+        {
+          app_identifier: 'dapp:42',
+          dapp_id: 42,
+          id: 'subject_1',
+          status: 'active',
+          subject_type: 'human',
+        },
+        {
+          app_identifier: 'oidc:client_tcoin',
+          dapp_id: null,
+          id: 'subject_2',
+          status: 'active',
+          subject_type: 'human',
+        },
+      ],
+    });
+
+    expect(overview.totals).toMatchObject({
+      activeGrants: 1,
+      activeSubjects: 2,
+      revokedGrants: 1,
+    });
+    expect(overview.totals.grantsBySource).toEqual({
+      allow_page: 1,
+      oidc: 1,
+    });
+    expect(overview.dapps[0]).toMatchObject({
+      activeGrantCount: 1,
+      activeSubjectCount: 1,
+      appName: 'FundLoop',
+      dappId: 42,
+    });
+    expect(overview.oidcClients[0]).toMatchObject({
+      activeGrantCount: 0,
+      clientId: 'client_tcoin',
+      clientName: 'TCOIN',
+      revokedGrantCount: 1,
+    });
+    expect(overview.recentEvents[0].details).toEqual({
+      app_scoped_subject_id: '[redacted]',
+      dapp_user_uuid: '[redacted]',
+      disclosure_grant_id: '[redacted]',
+      safe: 'visible',
+    });
+    expect('actorIdentifier' in overview.recentEvents[0]).toBe(false);
+  });
+});

--- a/apps/admin/lib/server/disclosureOperations.test.ts
+++ b/apps/admin/lib/server/disclosureOperations.test.ts
@@ -3,8 +3,19 @@ import { buildDisclosureOpsOverview } from './disclosureOperations';
 describe('Disclosure operations helpers', () => {
   it('builds aggregate disclosure health without exposing raw identifiers', () => {
     const overview = buildDisclosureOpsOverview({
-      clients: [{ client_id: 'client_tcoin', client_name: 'TCOIN' }],
-      dapps: [{ appname: 'FundLoop', id: 42 }],
+      activeSubjectCount: 2,
+      dappSummaries: [
+        {
+          active_grant_count: '1',
+          active_subject_count: 1,
+          app_name: 'FundLoop',
+          dapp_id: 42,
+          last_granted_at: '2026-05-03T10:00:00.000Z',
+          last_revoked_at: null,
+          revoked_grant_count: 0,
+          sources: { allow_page: '1' },
+        },
+      ],
       events: [
         {
           actor_identifier: 'user@example.com',
@@ -22,7 +33,31 @@ describe('Disclosure operations helpers', () => {
         },
       ],
       generatedAt: '2026-05-03T13:00:00.000Z',
-      grants: [
+      grantTotals: [
+        {
+          grant_count: '1',
+          source: 'allow_page',
+          status: 'active',
+        },
+        {
+          grant_count: 1,
+          source: 'oidc',
+          status: 'revoked',
+        },
+      ],
+      oidcClientSummaries: [
+        {
+          active_grant_count: 0,
+          client_id: 'client_tcoin',
+          client_name: 'TCOIN',
+          last_granted_at: '2026-05-03T11:00:00.000Z',
+          last_revoked_at: '2026-05-03T12:00:00.000Z',
+          revoked_grant_count: '1',
+          sources: { oidc: 1 },
+        },
+      ],
+      recentEventCount: 234,
+      recentGrants: [
         {
           app_scoped_subject_id: 'subject_1',
           consent_version: 1,
@@ -60,27 +95,13 @@ describe('Disclosure operations helpers', () => {
           updated_at: '2026-05-03T12:00:00.000Z',
         },
       ],
-      subjects: [
-        {
-          app_identifier: 'dapp:42',
-          dapp_id: 42,
-          id: 'subject_1',
-          status: 'active',
-          subject_type: 'human',
-        },
-        {
-          app_identifier: 'oidc:client_tcoin',
-          dapp_id: null,
-          id: 'subject_2',
-          status: 'active',
-          subject_type: 'human',
-        },
-      ],
     });
 
     expect(overview.totals).toMatchObject({
       activeGrants: 1,
       activeSubjects: 2,
+      recentGrantEvents7d: 234,
+      recentGrantSamples: 2,
       revokedGrants: 1,
     });
     expect(overview.totals.grantsBySource).toEqual({

--- a/apps/admin/lib/server/disclosureOperations.ts
+++ b/apps/admin/lib/server/disclosureOperations.ts
@@ -1,0 +1,374 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type AdminSupabaseClient = SupabaseClient;
+
+const MAX_GRANT_ROWS = 5000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface DisclosureGrantRow {
+  app_scoped_subject_id: string;
+  consent_version: number;
+  created_at: string;
+  dapp_id: number | null;
+  granted_at: string;
+  granted_claims: unknown;
+  granted_scopes: unknown;
+  id: string;
+  metadata: unknown;
+  oidc_client_id: string | null;
+  policy_version: string;
+  revoked_at: string | null;
+  revoked_by: string | null;
+  source: string;
+  status: string;
+  updated_at: string;
+}
+
+interface AppScopedSubjectRow {
+  app_identifier: string;
+  dapp_id: number | null;
+  id: string;
+  status: string;
+  subject_type: string;
+}
+
+interface DisclosureEventRow {
+  actor_identifier: string | null;
+  actor_type: string;
+  created_at: string;
+  details: unknown;
+  event_type: string;
+  outcome: string;
+  request_id: string | null;
+}
+
+interface DappRow {
+  appname: string;
+  id: number;
+}
+
+interface OidcClientRow {
+  client_id: string;
+  client_name: string;
+}
+
+export interface DisclosureOpsEvent {
+  actorType: string;
+  createdAt: string;
+  details: Record<string, unknown>;
+  eventType: string;
+  outcome: string;
+  requestId: string | null;
+}
+
+export interface DisclosureOpsGrantSample {
+  claimCount: number;
+  consentVersion: number;
+  grantedAt: string;
+  policyVersion: string;
+  revokedAt: string | null;
+  scopeCount: number;
+  source: string;
+  status: string;
+}
+
+export interface DisclosureOpsDappSummary {
+  activeGrantCount: number;
+  activeSubjectCount: number;
+  appName: string;
+  dappId: number;
+  lastGrantedAt: string | null;
+  lastRevokedAt: string | null;
+  recentGrants: DisclosureOpsGrantSample[];
+  revokedGrantCount: number;
+  sources: Record<string, number>;
+}
+
+export interface DisclosureOpsOidcClientSummary {
+  activeGrantCount: number;
+  clientId: string;
+  clientName: string;
+  lastGrantedAt: string | null;
+  lastRevokedAt: string | null;
+  recentGrants: DisclosureOpsGrantSample[];
+  revokedGrantCount: number;
+  sources: Record<string, number>;
+}
+
+export interface DisclosureOpsOverview {
+  dapps: DisclosureOpsDappSummary[];
+  generatedAt: string;
+  oidcClients: DisclosureOpsOidcClientSummary[];
+  recentEvents: DisclosureOpsEvent[];
+  totals: {
+    activeGrants: number;
+    activeSubjects: number;
+    grantsBySource: Record<string, number>;
+    grantsByStatus: Record<string, number>;
+    grantRowsScanned: number;
+    recentGrantEvents7d: number;
+    revokedGrants: number;
+  };
+}
+
+const normalizeDetails = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {};
+  }
+
+  const details = value as Record<string, unknown>;
+  const redacted: Record<string, unknown> = {};
+
+  for (const [key, entry] of Object.entries(details)) {
+    redacted[key] =
+      key === 'human_subject_key' ||
+      key === 'cubid_user_id' ||
+      key === 'app_scoped_subject_id' ||
+      key === 'disclosure_grant_id' ||
+      key === 'dapp_user_uuid'
+        ? '[redacted]'
+        : entry;
+  }
+
+  return redacted;
+};
+
+const normalizeStringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : [];
+
+const normalizeClaimCount = (value: unknown) =>
+  Array.isArray(value) ? value.length : 0;
+
+const increment = (target: Record<string, number>, key: string) => {
+  target[key] = (target[key] ?? 0) + 1;
+};
+
+const maxTimestamp = (current: string | null, next: string | null) => {
+  if (!next) {
+    return current;
+  }
+
+  if (!current) {
+    return next;
+  }
+
+  return next > current ? next : current;
+};
+
+const mapGrantSample = (row: DisclosureGrantRow): DisclosureOpsGrantSample => ({
+  claimCount: normalizeClaimCount(row.granted_claims),
+  consentVersion: row.consent_version,
+  grantedAt: row.granted_at,
+  policyVersion: row.policy_version,
+  revokedAt: row.revoked_at,
+  scopeCount: normalizeStringArray(row.granted_scopes).length,
+  source: row.source,
+  status: row.status,
+});
+
+const mapEvent = (row: DisclosureEventRow): DisclosureOpsEvent => ({
+  actorType: row.actor_type,
+  createdAt: row.created_at,
+  details: normalizeDetails(row.details),
+  eventType: row.event_type,
+  outcome: row.outcome,
+  requestId: row.request_id,
+});
+
+const makeDappSummary = (dapp: DappRow): DisclosureOpsDappSummary => ({
+  activeGrantCount: 0,
+  activeSubjectCount: 0,
+  appName: dapp.appname,
+  dappId: dapp.id,
+  lastGrantedAt: null,
+  lastRevokedAt: null,
+  recentGrants: [],
+  revokedGrantCount: 0,
+  sources: {},
+});
+
+const makeOidcClientSummary = (
+  client: OidcClientRow
+): DisclosureOpsOidcClientSummary => ({
+  activeGrantCount: 0,
+  clientId: client.client_id,
+  clientName: client.client_name,
+  lastGrantedAt: null,
+  lastRevokedAt: null,
+  recentGrants: [],
+  revokedGrantCount: 0,
+  sources: {},
+});
+
+export const buildDisclosureOpsOverview = ({
+  clients,
+  dapps,
+  events,
+  generatedAt,
+  grants,
+  subjects,
+}: {
+  clients: OidcClientRow[];
+  dapps: DappRow[];
+  events: DisclosureEventRow[];
+  generatedAt: string;
+  grants: DisclosureGrantRow[];
+  subjects: AppScopedSubjectRow[];
+}): DisclosureOpsOverview => {
+  const dappsById = new Map(dapps.map((dapp) => [dapp.id, dapp]));
+  const clientsById = new Map(clients.map((client) => [client.client_id, client]));
+  const dappSummaries = new Map<number, DisclosureOpsDappSummary>();
+  const clientSummaries = new Map<string, DisclosureOpsOidcClientSummary>();
+  const activeSubjectIdsByDapp = new Map<number, Set<string>>();
+  const activeSubjects = new Set<string>();
+  const grantsBySource: Record<string, number> = {};
+  const grantsByStatus: Record<string, number> = {};
+
+  for (const subject of subjects) {
+    if (subject.status !== 'active') {
+      continue;
+    }
+
+    activeSubjects.add(subject.id);
+
+    if (subject.dapp_id !== null) {
+      const subjectIds = activeSubjectIdsByDapp.get(subject.dapp_id) ?? new Set();
+      subjectIds.add(subject.id);
+      activeSubjectIdsByDapp.set(subject.dapp_id, subjectIds);
+    }
+  }
+
+  for (const row of grants) {
+    increment(grantsBySource, row.source);
+    increment(grantsByStatus, row.status);
+
+    const sample = mapGrantSample(row);
+    if (row.dapp_id !== null) {
+      const dapp = dappsById.get(row.dapp_id) ?? {
+        appname: `Dapp ${row.dapp_id}`,
+        id: row.dapp_id,
+      };
+      const summary = dappSummaries.get(row.dapp_id) ?? makeDappSummary(dapp);
+
+      if (row.status === 'active') {
+        summary.activeGrantCount += 1;
+      } else if (row.status === 'revoked') {
+        summary.revokedGrantCount += 1;
+      }
+
+      increment(summary.sources, row.source);
+      summary.lastGrantedAt = maxTimestamp(summary.lastGrantedAt, row.granted_at);
+      summary.lastRevokedAt = maxTimestamp(summary.lastRevokedAt, row.revoked_at);
+      if (summary.recentGrants.length < 5) {
+        summary.recentGrants.push(sample);
+      }
+      dappSummaries.set(row.dapp_id, summary);
+    }
+
+    if (row.oidc_client_id) {
+      const client = clientsById.get(row.oidc_client_id) ?? {
+        client_id: row.oidc_client_id,
+        client_name: row.oidc_client_id,
+      };
+      const summary =
+        clientSummaries.get(row.oidc_client_id) ?? makeOidcClientSummary(client);
+
+      if (row.status === 'active') {
+        summary.activeGrantCount += 1;
+      } else if (row.status === 'revoked') {
+        summary.revokedGrantCount += 1;
+      }
+
+      increment(summary.sources, row.source);
+      summary.lastGrantedAt = maxTimestamp(summary.lastGrantedAt, row.granted_at);
+      summary.lastRevokedAt = maxTimestamp(summary.lastRevokedAt, row.revoked_at);
+      if (summary.recentGrants.length < 5) {
+        summary.recentGrants.push(sample);
+      }
+      clientSummaries.set(row.oidc_client_id, summary);
+    }
+  }
+
+  for (const [dappId, summary] of dappSummaries) {
+    summary.activeSubjectCount = activeSubjectIdsByDapp.get(dappId)?.size ?? 0;
+  }
+
+  const since = new Date(
+    new Date(generatedAt).getTime() - SEVEN_DAYS_MS
+  ).toISOString();
+
+  return {
+    dapps: [...dappSummaries.values()].sort(
+      (left, right) => right.activeGrantCount - left.activeGrantCount
+    ),
+    generatedAt,
+    oidcClients: [...clientSummaries.values()].sort(
+      (left, right) => right.activeGrantCount - left.activeGrantCount
+    ),
+    recentEvents: events.map(mapEvent).slice(0, 50),
+    totals: {
+      activeGrants: grantsByStatus.active ?? 0,
+      activeSubjects: activeSubjects.size,
+      grantsBySource,
+      grantsByStatus,
+      grantRowsScanned: grants.length,
+      recentGrantEvents7d: events.filter((event) => event.created_at >= since)
+        .length,
+      revokedGrants: grantsByStatus.revoked ?? 0,
+    },
+  };
+};
+
+export const loadDisclosureOpsOverview = async (
+  supabase: AdminSupabaseClient
+): Promise<DisclosureOpsOverview> => {
+  const generatedAt = new Date().toISOString();
+  const [
+    grantsResponse,
+    subjectsResponse,
+    eventsResponse,
+    dappsResponse,
+    clientsResponse,
+  ] = await Promise.all([
+    supabase
+      .from('selective_disclosure_grants')
+      .select(
+        'id,app_scoped_subject_id,dapp_id,oidc_client_id,source,granted_scopes,granted_claims,policy_version,consent_version,status,granted_at,revoked_at,revoked_by,metadata,created_at,updated_at'
+      )
+      .order('updated_at', { ascending: false })
+      .limit(MAX_GRANT_ROWS),
+    supabase
+      .from('app_scoped_subjects')
+      .select('id,subject_type,app_identifier,dapp_id,status'),
+    supabase
+      .from('selective_disclosure_events')
+      .select('event_type,actor_type,actor_identifier,request_id,outcome,details,created_at')
+      .order('created_at', { ascending: false })
+      .limit(100),
+    supabase.from('dapps').select('id,appname'),
+    supabase.from('oidc_clients').select('client_id,client_name'),
+  ]);
+
+  for (const response of [
+    grantsResponse,
+    subjectsResponse,
+    eventsResponse,
+    dappsResponse,
+    clientsResponse,
+  ]) {
+    if (response.error) {
+      throw response.error;
+    }
+  }
+
+  return buildDisclosureOpsOverview({
+    clients: (clientsResponse.data ?? []) as OidcClientRow[],
+    dapps: (dappsResponse.data ?? []) as DappRow[],
+    events: (eventsResponse.data ?? []) as DisclosureEventRow[],
+    generatedAt,
+    grants: (grantsResponse.data ?? []) as DisclosureGrantRow[],
+    subjects: (subjectsResponse.data ?? []) as AppScopedSubjectRow[],
+  });
+};

--- a/apps/admin/lib/server/disclosureOperations.ts
+++ b/apps/admin/lib/server/disclosureOperations.ts
@@ -2,7 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 
 type AdminSupabaseClient = SupabaseClient;
 
-const MAX_GRANT_ROWS = 5000;
+const MAX_RECENT_GRANT_ROWS = 500;
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 interface DisclosureGrantRow {
@@ -24,14 +24,6 @@ interface DisclosureGrantRow {
   updated_at: string;
 }
 
-interface AppScopedSubjectRow {
-  app_identifier: string;
-  dapp_id: number | null;
-  id: string;
-  status: string;
-  subject_type: string;
-}
-
 interface DisclosureEventRow {
   actor_identifier: string | null;
   actor_type: string;
@@ -42,14 +34,39 @@ interface DisclosureEventRow {
   request_id: string | null;
 }
 
-interface DappRow {
-  appname: string;
-  id: number;
+interface GrantTotalRow {
+  grant_count: number | string | null;
+  source: string;
+  status: string;
 }
 
-interface OidcClientRow {
+interface ActiveSubjectCountRow {
+  active_subject_count: number | string | null;
+}
+
+interface RecentEventCountRow {
+  event_count: number | string | null;
+}
+
+interface DappSummaryRow {
+  active_grant_count: number | string | null;
+  active_subject_count: number | string | null;
+  app_name: string;
+  dapp_id: number | string;
+  last_granted_at: string | null;
+  last_revoked_at: string | null;
+  revoked_grant_count: number | string | null;
+  sources: unknown;
+}
+
+interface OidcClientSummaryRow {
+  active_grant_count: number | string | null;
   client_id: string;
   client_name: string;
+  last_granted_at: string | null;
+  last_revoked_at: string | null;
+  revoked_grant_count: number | string | null;
+  sources: unknown;
 }
 
 export interface DisclosureOpsEvent {
@@ -105,7 +122,7 @@ export interface DisclosureOpsOverview {
     activeSubjects: number;
     grantsBySource: Record<string, number>;
     grantsByStatus: Record<string, number>;
-    grantRowsScanned: number;
+    recentGrantSamples: number;
     recentGrantEvents7d: number;
     revokedGrants: number;
   };
@@ -141,20 +158,30 @@ const normalizeStringArray = (value: unknown): string[] =>
 const normalizeClaimCount = (value: unknown) =>
   Array.isArray(value) ? value.length : 0;
 
-const increment = (target: Record<string, number>, key: string) => {
-  target[key] = (target[key] ?? 0) + 1;
+const normalizeCount = (value: number | string | null | undefined) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
 };
 
-const maxTimestamp = (current: string | null, next: string | null) => {
-  if (!next) {
-    return current;
+const normalizeSourceCounts = (value: unknown): Record<string, number> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {};
   }
 
-  if (!current) {
-    return next;
-  }
-
-  return next > current ? next : current;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([source, count]) => [
+      source,
+      normalizeCount(count as number | string | null | undefined),
+    ])
+  );
 };
 
 const mapGrantSample = (row: DisclosureGrantRow): DisclosureOpsGrantSample => ({
@@ -177,145 +204,90 @@ const mapEvent = (row: DisclosureEventRow): DisclosureOpsEvent => ({
   requestId: row.request_id,
 });
 
-const makeDappSummary = (dapp: DappRow): DisclosureOpsDappSummary => ({
-  activeGrantCount: 0,
-  activeSubjectCount: 0,
-  appName: dapp.appname,
-  dappId: dapp.id,
-  lastGrantedAt: null,
-  lastRevokedAt: null,
-  recentGrants: [],
-  revokedGrantCount: 0,
-  sources: {},
-});
-
-const makeOidcClientSummary = (
-  client: OidcClientRow
-): DisclosureOpsOidcClientSummary => ({
-  activeGrantCount: 0,
-  clientId: client.client_id,
-  clientName: client.client_name,
-  lastGrantedAt: null,
-  lastRevokedAt: null,
-  recentGrants: [],
-  revokedGrantCount: 0,
-  sources: {},
-});
-
 export const buildDisclosureOpsOverview = ({
-  clients,
-  dapps,
+  activeSubjectCount,
+  dappSummaries,
   events,
+  grantTotals,
   generatedAt,
-  grants,
-  subjects,
+  oidcClientSummaries,
+  recentEventCount,
+  recentGrants,
 }: {
-  clients: OidcClientRow[];
-  dapps: DappRow[];
+  activeSubjectCount: number;
+  dappSummaries: DappSummaryRow[];
   events: DisclosureEventRow[];
+  grantTotals: GrantTotalRow[];
   generatedAt: string;
-  grants: DisclosureGrantRow[];
-  subjects: AppScopedSubjectRow[];
+  oidcClientSummaries: OidcClientSummaryRow[];
+  recentEventCount: number;
+  recentGrants: DisclosureGrantRow[];
 }): DisclosureOpsOverview => {
-  const dappsById = new Map(dapps.map((dapp) => [dapp.id, dapp]));
-  const clientsById = new Map(clients.map((client) => [client.client_id, client]));
-  const dappSummaries = new Map<number, DisclosureOpsDappSummary>();
-  const clientSummaries = new Map<string, DisclosureOpsOidcClientSummary>();
-  const activeSubjectIdsByDapp = new Map<number, Set<string>>();
-  const activeSubjects = new Set<string>();
   const grantsBySource: Record<string, number> = {};
   const grantsByStatus: Record<string, number> = {};
+  const recentGrantsByDapp = new Map<number, DisclosureOpsGrantSample[]>();
+  const recentGrantsByClient = new Map<string, DisclosureOpsGrantSample[]>();
 
-  for (const subject of subjects) {
-    if (subject.status !== 'active') {
-      continue;
-    }
-
-    activeSubjects.add(subject.id);
-
-    if (subject.dapp_id !== null) {
-      const subjectIds = activeSubjectIdsByDapp.get(subject.dapp_id) ?? new Set();
-      subjectIds.add(subject.id);
-      activeSubjectIdsByDapp.set(subject.dapp_id, subjectIds);
-    }
+  for (const total of grantTotals) {
+    const count = normalizeCount(total.grant_count);
+    grantsBySource[total.source] = (grantsBySource[total.source] ?? 0) + count;
+    grantsByStatus[total.status] = (grantsByStatus[total.status] ?? 0) + count;
   }
 
-  for (const row of grants) {
-    increment(grantsBySource, row.source);
-    increment(grantsByStatus, row.status);
-
+  for (const row of recentGrants) {
     const sample = mapGrantSample(row);
     if (row.dapp_id !== null) {
-      const dapp = dappsById.get(row.dapp_id) ?? {
-        appname: `Dapp ${row.dapp_id}`,
-        id: row.dapp_id,
-      };
-      const summary = dappSummaries.get(row.dapp_id) ?? makeDappSummary(dapp);
-
-      if (row.status === 'active') {
-        summary.activeGrantCount += 1;
-      } else if (row.status === 'revoked') {
-        summary.revokedGrantCount += 1;
+      const samples = recentGrantsByDapp.get(row.dapp_id) ?? [];
+      if (samples.length < 5) {
+        samples.push(sample);
       }
-
-      increment(summary.sources, row.source);
-      summary.lastGrantedAt = maxTimestamp(summary.lastGrantedAt, row.granted_at);
-      summary.lastRevokedAt = maxTimestamp(summary.lastRevokedAt, row.revoked_at);
-      if (summary.recentGrants.length < 5) {
-        summary.recentGrants.push(sample);
-      }
-      dappSummaries.set(row.dapp_id, summary);
+      recentGrantsByDapp.set(row.dapp_id, samples);
     }
 
     if (row.oidc_client_id) {
-      const client = clientsById.get(row.oidc_client_id) ?? {
-        client_id: row.oidc_client_id,
-        client_name: row.oidc_client_id,
-      };
-      const summary =
-        clientSummaries.get(row.oidc_client_id) ?? makeOidcClientSummary(client);
-
-      if (row.status === 'active') {
-        summary.activeGrantCount += 1;
-      } else if (row.status === 'revoked') {
-        summary.revokedGrantCount += 1;
+      const samples = recentGrantsByClient.get(row.oidc_client_id) ?? [];
+      if (samples.length < 5) {
+        samples.push(sample);
       }
-
-      increment(summary.sources, row.source);
-      summary.lastGrantedAt = maxTimestamp(summary.lastGrantedAt, row.granted_at);
-      summary.lastRevokedAt = maxTimestamp(summary.lastRevokedAt, row.revoked_at);
-      if (summary.recentGrants.length < 5) {
-        summary.recentGrants.push(sample);
-      }
-      clientSummaries.set(row.oidc_client_id, summary);
+      recentGrantsByClient.set(row.oidc_client_id, samples);
     }
   }
 
-  for (const [dappId, summary] of dappSummaries) {
-    summary.activeSubjectCount = activeSubjectIdsByDapp.get(dappId)?.size ?? 0;
-  }
-
-  const since = new Date(
-    new Date(generatedAt).getTime() - SEVEN_DAYS_MS
-  ).toISOString();
-
   return {
-    dapps: [...dappSummaries.values()].sort(
+    dapps: dappSummaries.map((row) => ({
+      activeGrantCount: normalizeCount(row.active_grant_count),
+      activeSubjectCount: normalizeCount(row.active_subject_count),
+      appName: row.app_name,
+      dappId: Number(row.dapp_id),
+      lastGrantedAt: row.last_granted_at,
+      lastRevokedAt: row.last_revoked_at,
+      recentGrants: recentGrantsByDapp.get(Number(row.dapp_id)) ?? [],
+      revokedGrantCount: normalizeCount(row.revoked_grant_count),
+      sources: normalizeSourceCounts(row.sources),
+    })).sort(
       (left, right) => right.activeGrantCount - left.activeGrantCount
     ),
     generatedAt,
-    oidcClients: [...clientSummaries.values()].sort(
+    oidcClients: oidcClientSummaries.map((row) => ({
+      activeGrantCount: normalizeCount(row.active_grant_count),
+      clientId: row.client_id,
+      clientName: row.client_name,
+      lastGrantedAt: row.last_granted_at,
+      lastRevokedAt: row.last_revoked_at,
+      recentGrants: recentGrantsByClient.get(row.client_id) ?? [],
+      revokedGrantCount: normalizeCount(row.revoked_grant_count),
+      sources: normalizeSourceCounts(row.sources),
+    })).sort(
       (left, right) => right.activeGrantCount - left.activeGrantCount
     ),
     recentEvents: events.map(mapEvent).slice(0, 50),
     totals: {
       activeGrants: grantsByStatus.active ?? 0,
-      activeSubjects: activeSubjects.size,
+      activeSubjects: activeSubjectCount,
       grantsBySource,
       grantsByStatus,
-      grantRowsScanned: grants.length,
-      recentGrantEvents7d: events.filter((event) => event.created_at >= since)
-        .length,
+      recentGrantEvents7d: recentEventCount,
+      recentGrantSamples: recentGrants.length,
       revokedGrants: grantsByStatus.revoked ?? 0,
     },
   };
@@ -325,12 +297,17 @@ export const loadDisclosureOpsOverview = async (
   supabase: AdminSupabaseClient
 ): Promise<DisclosureOpsOverview> => {
   const generatedAt = new Date().toISOString();
+  const since = new Date(
+    new Date(generatedAt).getTime() - SEVEN_DAYS_MS
+  ).toISOString();
   const [
-    grantsResponse,
-    subjectsResponse,
+    recentGrantsResponse,
     eventsResponse,
-    dappsResponse,
-    clientsResponse,
+    grantTotalsResponse,
+    activeSubjectCountResponse,
+    recentEventCountResponse,
+    dappSummariesResponse,
+    oidcClientSummariesResponse,
   ] = await Promise.all([
     supabase
       .from('selective_disclosure_grants')
@@ -338,25 +315,27 @@ export const loadDisclosureOpsOverview = async (
         'id,app_scoped_subject_id,dapp_id,oidc_client_id,source,granted_scopes,granted_claims,policy_version,consent_version,status,granted_at,revoked_at,revoked_by,metadata,created_at,updated_at'
       )
       .order('updated_at', { ascending: false })
-      .limit(MAX_GRANT_ROWS),
-    supabase
-      .from('app_scoped_subjects')
-      .select('id,subject_type,app_identifier,dapp_id,status'),
+      .limit(MAX_RECENT_GRANT_ROWS),
     supabase
       .from('selective_disclosure_events')
       .select('event_type,actor_type,actor_identifier,request_id,outcome,details,created_at')
       .order('created_at', { ascending: false })
       .limit(100),
-    supabase.from('dapps').select('id,appname'),
-    supabase.from('oidc_clients').select('client_id,client_name'),
+    supabase.rpc('get_disclosure_ops_grant_totals'),
+    supabase.rpc('get_disclosure_ops_active_subject_count'),
+    supabase.rpc('get_disclosure_ops_recent_event_count', { p_since: since }),
+    supabase.rpc('get_disclosure_ops_dapp_summaries'),
+    supabase.rpc('get_disclosure_ops_oidc_client_summaries'),
   ]);
 
   for (const response of [
-    grantsResponse,
-    subjectsResponse,
+    recentGrantsResponse,
     eventsResponse,
-    dappsResponse,
-    clientsResponse,
+    grantTotalsResponse,
+    activeSubjectCountResponse,
+    recentEventCountResponse,
+    dappSummariesResponse,
+    oidcClientSummariesResponse,
   ]) {
     if (response.error) {
       throw response.error;
@@ -364,11 +343,20 @@ export const loadDisclosureOpsOverview = async (
   }
 
   return buildDisclosureOpsOverview({
-    clients: (clientsResponse.data ?? []) as OidcClientRow[],
-    dapps: (dappsResponse.data ?? []) as DappRow[],
+    activeSubjectCount: normalizeCount(
+      ((activeSubjectCountResponse.data ?? []) as ActiveSubjectCountRow[])[0]
+        ?.active_subject_count
+    ),
+    dappSummaries: (dappSummariesResponse.data ?? []) as DappSummaryRow[],
     events: (eventsResponse.data ?? []) as DisclosureEventRow[],
+    grantTotals: (grantTotalsResponse.data ?? []) as GrantTotalRow[],
     generatedAt,
-    grants: (grantsResponse.data ?? []) as DisclosureGrantRow[],
-    subjects: (subjectsResponse.data ?? []) as AppScopedSubjectRow[],
+    oidcClientSummaries: (oidcClientSummariesResponse.data ??
+      []) as OidcClientSummaryRow[],
+    recentEventCount: normalizeCount(
+      ((recentEventCountResponse.data ?? []) as RecentEventCountRow[])[0]
+        ?.event_count
+    ),
+    recentGrants: (recentGrantsResponse.data ?? []) as DisclosureGrantRow[],
   });
 };

--- a/apps/admin/pages/api/admin/disclosures/operations/overview.ts
+++ b/apps/admin/pages/api/admin/disclosures/operations/overview.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import {
+  prepareAdminApiRequest,
+  sendServerError,
+} from '../../../../../lib/server/adminApi';
+import { adminNoBodySchema } from '../../../../../lib/server/adminSchemas';
+import { loadDisclosureOpsOverview } from '../../../../../lib/server/disclosureOperations';
+
+const overview = async (req: NextApiRequest, res: NextApiResponse) => {
+  const request = await prepareAdminApiRequest(req, res, {
+    actor: 'admin',
+    bodySchema: adminNoBodySchema,
+    rateLimitGroup: 'admin_read',
+    route: 'admin/disclosures/operations/overview',
+  });
+
+  if (!request) {
+    return;
+  }
+
+  try {
+    const data = await loadDisclosureOpsOverview(request.context.supabase);
+    return res.status(200).json({ data });
+  } catch (error) {
+    return sendServerError(
+      res,
+      error,
+      'Failed to load disclosure operations overview'
+    );
+  }
+};
+
+export default overview;

--- a/apps/passport/lib/server/disclosureGrants.ts
+++ b/apps/passport/lib/server/disclosureGrants.ts
@@ -22,18 +22,12 @@ type DappUserGrantLookup = {
   dappUserUuid: string
 }
 
-type LegacyPermissionRow = {
-  dappuser_id?: string | null
-  stamp_id?: number | string | null
-}
-
 export type DappDisclosureGrantSet = {
   appScopedSubject: string | null
   grantedClaims: Set<string>
   grantedScopes: Set<string>
   grantedStampTypes: Set<string>
   hasStampScope: boolean
-  legacyGrantedStampIds: Set<string>
 }
 
 const createEmptyDappDisclosureGrants = (): DappDisclosureGrantSet => ({
@@ -42,7 +36,6 @@ const createEmptyDappDisclosureGrants = (): DappDisclosureGrantSet => ({
   grantedScopes: new Set(),
   grantedStampTypes: new Set(),
   hasStampScope: false,
-  legacyGrantedStampIds: new Set(),
 })
 
 export const DISCLOSURE_CLAIMS = {
@@ -61,19 +54,15 @@ export async function loadDappDisclosureGrants(
   input: {
     dappId: number | string
     dappUserUuid: string
-    legacyStampId?: number | string
   }
 ): Promise<DappDisclosureGrantSet> {
-  const grantsByUser = await loadDappDisclosureGrantsForUsers(supabase, [input], {
-    legacyStampId: input.legacyStampId,
-  })
+  const grantsByUser = await loadDappDisclosureGrantsForUsers(supabase, [input])
   return grantsByUser.get(input.dappUserUuid) ?? createEmptyDappDisclosureGrants()
 }
 
 function mergeGrantRows(
   appScopedSubject: AppScopedSubjectRow | null,
-  grants: SelectiveDisclosureGrantRow[],
-  legacyPermissions: LegacyPermissionRow[] = []
+  grants: SelectiveDisclosureGrantRow[]
 ): DappDisclosureGrantSet {
   const grantedClaims = new Set<string>()
   const grantedScopes = new Set<string>()
@@ -110,12 +99,6 @@ function mergeGrantRows(
     grantedScopes,
     grantedStampTypes,
     hasStampScope,
-    legacyGrantedStampIds: new Set(
-      legacyPermissions
-        .map((row) => row.stamp_id)
-        .filter((value): value is number | string => value !== null && value !== undefined)
-        .map(String)
-    ),
   }
 }
 
@@ -206,11 +189,7 @@ export function sanitizeDisclosedUserProfile<TUser extends Record<string, any>>(
 
 export async function loadDappDisclosureGrantsForUsers(
   supabase: SupabaseClient,
-  users: DappUserGrantLookup[],
-  options: {
-    includeLegacyPermissions?: boolean
-    legacyStampId?: number | string
-  } = {}
+  users: DappUserGrantLookup[]
 ): Promise<Map<string, DappDisclosureGrantSet>> {
   const result = new Map<string, DappDisclosureGrantSet>()
   const uniqueUsers = users.filter(
@@ -276,43 +255,13 @@ export async function loadDappDisclosureGrantsForUsers(
     }
   }
 
-  const legacyPermissionsByUser = new Map<string, LegacyPermissionRow[]>()
-  if (options.includeLegacyPermissions ?? true) {
-    let legacyQuery = supabase
-      .from("stamp_dappuser_permissions")
-      .select("dappuser_id,stamp_id")
-      .in("dappuser_id", dappUserUuids)
-
-    if (options.legacyStampId !== undefined) {
-      legacyQuery = legacyQuery.eq("stamp_id", options.legacyStampId)
-    }
-
-    const { data: legacyPermissions, error: legacyError } = await legacyQuery
-
-    if (legacyError) {
-      throw legacyError
-    }
-
-    for (const permission of (legacyPermissions ?? []) as LegacyPermissionRow[]) {
-      const dappUserUuid = String(permission.dappuser_id ?? "")
-      if (!dappUserUuid) {
-        continue
-      }
-
-      const existing = legacyPermissionsByUser.get(dappUserUuid) ?? []
-      existing.push(permission)
-      legacyPermissionsByUser.set(dappUserUuid, existing)
-    }
-  }
-
   for (const user of uniqueUsers) {
     const subject = subjectsByUser.get(user.dappUserUuid) ?? null
     result.set(
       user.dappUserUuid,
       mergeGrantRows(
         subject,
-        subject ? grantsBySubjectId.get(subject.id) ?? [] : [],
-        legacyPermissionsByUser.get(user.dappUserUuid) ?? []
+        subject ? grantsBySubjectId.get(subject.id) ?? [] : []
       )
     )
   }
@@ -325,10 +274,7 @@ export async function loadDappDisclosureGrantsForStamp(
   users: DappUserGrantLookup[],
   stamp: StampLike | null | undefined
 ): Promise<Map<string, DappDisclosureGrantSet>> {
-  return loadDappDisclosureGrantsForUsers(supabase, users, {
-    legacyStampId:
-      stamp?.id === null || stamp?.id === undefined ? undefined : String(stamp.id),
-  })
+  return loadDappDisclosureGrantsForUsers(supabase, users)
 }
 
 export async function hasActiveSelectiveDisclosureGrants(
@@ -339,7 +285,7 @@ export async function hasActiveSelectiveDisclosureGrants(
   }
 ): Promise<boolean> {
   const grants = await loadDappDisclosureGrants(supabase, input)
-  return grants.hasStampScope || grants.legacyGrantedStampIds.size > 0
+  return grants.hasStampScope
 }
 
 export function isStampTypeDisclosed(
@@ -363,10 +309,6 @@ export function isStampDisclosed(
 ): boolean {
   if (!grants || !stamp) {
     return false
-  }
-
-  if (grants.legacyGrantedStampIds.has(String(stamp.id ?? ""))) {
-    return true
   }
 
   const stampTypeId = Number(stamp.stamptype)

--- a/apps/passport/lib/server/passportData.ts
+++ b/apps/passport/lib/server/passportData.ts
@@ -191,7 +191,7 @@ const persistAllowPageDisclosureGrant = async (input: {
   return disclosureGrant
 }
 
-const persistAllowPageDisclosureForStampPermission = async (input: {
+export const persistAllowPageDisclosureForStampPermission = async (input: {
   dappUserId: string
   stampId: number | string
 }) => {

--- a/apps/passport/package.json
+++ b/apps/passport/package.json
@@ -10,6 +10,7 @@
     "lint": "pnpm exec next lint",
     "lint:fix": "pnpm exec next lint --fix",
     "preview": "pnpm exec next build && pnpm exec next start",
+    "backfill:disclosure-grants": "pnpm exec tsx scripts/backfill-selective-disclosure-grants.ts",
     "typecheck": "pnpm exec tsc --noEmit -p tsconfig.typecheck.json",
     "test": "pnpm exec tsx --test tests/*.test.ts",
     "format": "pnpm exec prettier --check \"**/*.{ts,tsx,mdx}\" --cache",

--- a/apps/passport/scripts/backfill-selective-disclosure-grants.ts
+++ b/apps/passport/scripts/backfill-selective-disclosure-grants.ts
@@ -5,6 +5,7 @@ import { getPassportSupabase } from "../lib/server/supabase"
 
 type LegacyStampPermissionRow = {
   dappuser_id: string | null
+  id: number | string
   stamp_id: number | string | null
 }
 
@@ -19,6 +20,7 @@ type StampRow = {
 }
 
 const isDryRun = process.argv.includes("--dry-run")
+const PAGE_SIZE = 500
 
 const getLimit = () => {
   const limitArg = process.argv.find((arg) => arg.startsWith("--limit="))
@@ -42,92 +44,127 @@ const uniqueStrings = (values: Array<number | string | null | undefined>) => [
   ),
 ]
 
+const fetchDappUsers = async (
+  supabase: ReturnType<typeof getPassportSupabase>,
+  dappUserIds: string[]
+) => {
+  if (dappUserIds.length === 0) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from("dapp_users")
+    .select("uuid,dapp_id")
+    .in("uuid", dappUserIds)
+
+  if (error) {
+    throw error
+  }
+
+  return (data ?? []) as DappUserRow[]
+}
+
+const fetchStamps = async (
+  supabase: ReturnType<typeof getPassportSupabase>,
+  stampIds: string[]
+) => {
+  if (stampIds.length === 0) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from("stamps")
+    .select("id,stamptype")
+    .in("id", stampIds)
+
+  if (error) {
+    throw error
+  }
+
+  return (data ?? []) as StampRow[]
+}
+
 const main = async () => {
   const limit = getLimit()
   const supabase = getPassportSupabase()
-  let query = supabase
-    .from("stamp_dappuser_permissions")
-    .select("dappuser_id,stamp_id")
-
-  if (limit) {
-    query = query.limit(limit)
-  }
-
-  const { data: permissionRows, error: permissionError } = await query
-
-  if (permissionError) {
-    throw permissionError
-  }
-
-  const permissions = (permissionRows ?? []) as LegacyStampPermissionRow[]
-  const dappUserIds = uniqueStrings(permissions.map((row) => row.dappuser_id))
-  const stampIds = uniqueStrings(permissions.map((row) => row.stamp_id))
-
-  const [
-    { data: dappUsers, error: dappUsersError },
-    { data: stamps, error: stampsError },
-  ] = await Promise.all([
-    dappUserIds.length
-      ? supabase.from("dapp_users").select("uuid,dapp_id").in("uuid", dappUserIds)
-      : Promise.resolve({ data: [], error: null }),
-    stampIds.length
-      ? supabase.from("stamps").select("id,stamptype").in("id", stampIds)
-      : Promise.resolve({ data: [], error: null }),
-  ])
-
-  if (dappUsersError) {
-    throw dappUsersError
-  }
-
-  if (stampsError) {
-    throw stampsError
-  }
-
-  const dappUsersById = new Map(
-    ((dappUsers ?? []) as DappUserRow[]).map((row) => [String(row.uuid), row])
-  )
-  const stampsById = new Map(
-    ((stamps ?? []) as StampRow[]).map((row) => [String(row.id), row])
-  )
   const summaryByDapp = new Map<string, number>()
   const summaryByStampType = new Map<string, number>()
   let backfilledCount = 0
+  let scannedCount = 0
   let skippedCount = 0
+  let offset = 0
 
-  for (const permission of permissions) {
-    const dappUserId = String(permission.dappuser_id ?? "")
-    const stampId = String(permission.stamp_id ?? "")
-    const dappUser = dappUsersById.get(dappUserId)
-    const stamp = stampsById.get(stampId)
+  while (limit === null || scannedCount < limit) {
+    const remaining = limit === null ? PAGE_SIZE : Math.min(PAGE_SIZE, limit - scannedCount)
+    const { data: permissionRows, error: permissionError } = await supabase
+      .from("stamp_dappuser_permissions")
+      .select("id,dappuser_id,stamp_id")
+      .order("id", { ascending: true })
+      .range(offset, offset + remaining - 1)
 
-    if (!dappUser?.dapp_id || !stamp?.stamptype) {
-      skippedCount += 1
-      continue
+    if (permissionError) {
+      throw permissionError
     }
 
-    const dappId = String(dappUser.dapp_id)
-    const stampTypeName = getStampTypeName(Number(stamp.stamptype))
-    summaryByDapp.set(dappId, (summaryByDapp.get(dappId) ?? 0) + 1)
-    summaryByStampType.set(
-      stampTypeName,
-      (summaryByStampType.get(stampTypeName) ?? 0) + 1
+    const permissions = (permissionRows ?? []) as LegacyStampPermissionRow[]
+    if (permissions.length === 0) {
+      break
+    }
+
+    scannedCount += permissions.length
+    offset += permissions.length
+
+    const dappUserIds = uniqueStrings(permissions.map((row) => row.dappuser_id))
+    const stampIds = uniqueStrings(permissions.map((row) => row.stamp_id))
+    const [dappUsers, stamps] = await Promise.all([
+      fetchDappUsers(supabase, dappUserIds),
+      fetchStamps(supabase, stampIds),
+    ])
+    const dappUsersById = new Map(
+      dappUsers.map((row) => [String(row.uuid), row])
     )
+    const stampsById = new Map(stamps.map((row) => [String(row.id), row]))
 
-    if (!isDryRun) {
-      await persistAllowPageDisclosureForStampPermission({
-        dappUserId,
-        stampId,
-      })
+    for (const permission of permissions) {
+      const dappUserId = String(permission.dappuser_id ?? "")
+      const stampId = String(permission.stamp_id ?? "")
+      const dappUser = dappUsersById.get(dappUserId)
+      const stamp = stampsById.get(stampId)
+
+      if (!dappUser?.dapp_id || !stamp?.stamptype) {
+        skippedCount += 1
+        continue
+      }
+
+      const dappId = String(dappUser.dapp_id)
+      const stampTypeName = getStampTypeName(Number(stamp.stamptype))
+      summaryByDapp.set(dappId, (summaryByDapp.get(dappId) ?? 0) + 1)
+      summaryByStampType.set(
+        stampTypeName,
+        (summaryByStampType.get(stampTypeName) ?? 0) + 1
+      )
+
+      if (!isDryRun) {
+        await persistAllowPageDisclosureForStampPermission({
+          dappUserId,
+          stampId,
+        })
+      }
+
+      backfilledCount += 1
     }
 
-    backfilledCount += 1
+    if (permissions.length < remaining) {
+      break
+    }
   }
 
   process.stdout.write(
     [
-      `legacy stamp permissions scanned: ${permissions.length}`,
+      `legacy stamp permissions scanned: ${scannedCount}`,
       `selective disclosure grants ${isDryRun ? "would backfill" : "backfilled"}: ${backfilledCount}`,
       `legacy rows skipped: ${skippedCount}`,
+      `page size: ${PAGE_SIZE}`,
       `by dapp: ${JSON.stringify(Object.fromEntries([...summaryByDapp.entries()].sort()))}`,
       `by stamp type: ${JSON.stringify(Object.fromEntries([...summaryByStampType.entries()].sort()))}`,
       "",

--- a/apps/passport/scripts/backfill-selective-disclosure-grants.ts
+++ b/apps/passport/scripts/backfill-selective-disclosure-grants.ts
@@ -1,0 +1,143 @@
+import { getStampTypeName } from "@cubid/stamps"
+
+import { persistAllowPageDisclosureForStampPermission } from "../lib/server/passportData"
+import { getPassportSupabase } from "../lib/server/supabase"
+
+type LegacyStampPermissionRow = {
+  dappuser_id: string | null
+  stamp_id: number | string | null
+}
+
+type DappUserRow = {
+  dapp_id: number | string | null
+  uuid: string
+}
+
+type StampRow = {
+  id: number | string
+  stamptype: number | string | null
+}
+
+const isDryRun = process.argv.includes("--dry-run")
+
+const getLimit = () => {
+  const limitArg = process.argv.find((arg) => arg.startsWith("--limit="))
+  if (!limitArg) {
+    return null
+  }
+
+  const value = Number(limitArg.slice("--limit=".length))
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error("--limit must be a positive integer")
+  }
+
+  return value
+}
+
+const uniqueStrings = (values: Array<number | string | null | undefined>) => [
+  ...new Set(
+    values
+      .filter((value): value is number | string => value !== null && value !== undefined)
+      .map(String)
+  ),
+]
+
+const main = async () => {
+  const limit = getLimit()
+  const supabase = getPassportSupabase()
+  let query = supabase
+    .from("stamp_dappuser_permissions")
+    .select("dappuser_id,stamp_id")
+
+  if (limit) {
+    query = query.limit(limit)
+  }
+
+  const { data: permissionRows, error: permissionError } = await query
+
+  if (permissionError) {
+    throw permissionError
+  }
+
+  const permissions = (permissionRows ?? []) as LegacyStampPermissionRow[]
+  const dappUserIds = uniqueStrings(permissions.map((row) => row.dappuser_id))
+  const stampIds = uniqueStrings(permissions.map((row) => row.stamp_id))
+
+  const [
+    { data: dappUsers, error: dappUsersError },
+    { data: stamps, error: stampsError },
+  ] = await Promise.all([
+    dappUserIds.length
+      ? supabase.from("dapp_users").select("uuid,dapp_id").in("uuid", dappUserIds)
+      : Promise.resolve({ data: [], error: null }),
+    stampIds.length
+      ? supabase.from("stamps").select("id,stamptype").in("id", stampIds)
+      : Promise.resolve({ data: [], error: null }),
+  ])
+
+  if (dappUsersError) {
+    throw dappUsersError
+  }
+
+  if (stampsError) {
+    throw stampsError
+  }
+
+  const dappUsersById = new Map(
+    ((dappUsers ?? []) as DappUserRow[]).map((row) => [String(row.uuid), row])
+  )
+  const stampsById = new Map(
+    ((stamps ?? []) as StampRow[]).map((row) => [String(row.id), row])
+  )
+  const summaryByDapp = new Map<string, number>()
+  const summaryByStampType = new Map<string, number>()
+  let backfilledCount = 0
+  let skippedCount = 0
+
+  for (const permission of permissions) {
+    const dappUserId = String(permission.dappuser_id ?? "")
+    const stampId = String(permission.stamp_id ?? "")
+    const dappUser = dappUsersById.get(dappUserId)
+    const stamp = stampsById.get(stampId)
+
+    if (!dappUser?.dapp_id || !stamp?.stamptype) {
+      skippedCount += 1
+      continue
+    }
+
+    const dappId = String(dappUser.dapp_id)
+    const stampTypeName = getStampTypeName(Number(stamp.stamptype))
+    summaryByDapp.set(dappId, (summaryByDapp.get(dappId) ?? 0) + 1)
+    summaryByStampType.set(
+      stampTypeName,
+      (summaryByStampType.get(stampTypeName) ?? 0) + 1
+    )
+
+    if (!isDryRun) {
+      await persistAllowPageDisclosureForStampPermission({
+        dappUserId,
+        stampId,
+      })
+    }
+
+    backfilledCount += 1
+  }
+
+  process.stdout.write(
+    [
+      `legacy stamp permissions scanned: ${permissions.length}`,
+      `selective disclosure grants ${isDryRun ? "would backfill" : "backfilled"}: ${backfilledCount}`,
+      `legacy rows skipped: ${skippedCount}`,
+      `by dapp: ${JSON.stringify(Object.fromEntries([...summaryByDapp.entries()].sort()))}`,
+      `by stamp type: ${JSON.stringify(Object.fromEntries([...summaryByStampType.entries()].sort()))}`,
+      "",
+    ].join("\n")
+  )
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    error instanceof Error ? `${error.message}\n` : `${String(error)}\n`
+  )
+  process.exitCode = 1
+})

--- a/apps/passport/tests/disclosureGrants.test.ts
+++ b/apps/passport/tests/disclosureGrants.test.ts
@@ -82,7 +82,7 @@ test("loadDappDisclosureGrants denies by default without an app-scoped subject",
   assert.equal(isStampDisclosed(grants, { stamptype: 13 }), false)
 })
 
-test("loadDappDisclosureGrants preserves legacy stamp permissions during rollout", async () => {
+test("loadDappDisclosureGrants ignores legacy stamp permissions after backfill cutoff", async () => {
   const supabase = new MockPassportSupabase()
   supabase.stampPermissions.push({
     dappuser_id: "legacy_user",
@@ -94,7 +94,7 @@ test("loadDappDisclosureGrants preserves legacy stamp permissions during rollout
     dappUserUuid: "legacy_user",
   })
 
-  assert.equal(isStampDisclosed(grants, { id: 99, stamptype: 13 }), true)
+  assert.equal(isStampDisclosed(grants, { id: 99, stamptype: 13 }), false)
   assert.equal(isStampDisclosed(grants, { id: 100, stamptype: 13 }), false)
 })
 
@@ -148,7 +148,6 @@ test("sanitizeDisclosedUserProfile removes non-granted profile and location fiel
     grantedScopes: new Set(["cubid:profile", "cubid:location", "cubid:stamps"]),
     grantedStampTypes: new Set(["email"]),
     hasStampScope: true,
-    legacyGrantedStampIds: new Set<string>(),
   }
 
   assert.deepEqual(

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -1409,9 +1409,28 @@ test("Passport API v3 webhook trigger sends signed disclosure-filtered payloads"
     id: 610,
     stamptype: 13,
   })
-  supabase.stampPermissions.push({
-    dappuser_id: dappUserUuid,
-    stamp_id: 610,
+  supabase.appScopedSubjects.push({
+    app_identifier: "dapp:42",
+    app_scoped_subject: "app_subject_610",
+    dapp_id: 42,
+    dapp_user_uuid: dappUserUuid,
+    id: "subject_610",
+    status: "active",
+  })
+  supabase.selectiveDisclosureGrants.push({
+    app_scoped_subject_id: "subject_610",
+    dapp_id: 42,
+    granted_claims: [
+      {
+        claim: "stamp:email",
+        dataClass: "identity",
+        purpose: "Allow Page stamp sharing",
+        required: false,
+      },
+    ],
+    granted_scopes: ["cubid:stamps"],
+    id: "grant_610",
+    status: "active",
   })
   supabase.setWebhookSubscription({
     dapp: 42,
@@ -1526,9 +1545,28 @@ test("Passport API v3 webhook trigger records failed delivery attempts and retry
     id: 630,
     stamptype: 13,
   })
-  supabase.stampPermissions.push({
-    dappuser_id: dappUserUuid,
-    stamp_id: 630,
+  supabase.appScopedSubjects.push({
+    app_identifier: "dapp:42",
+    app_scoped_subject: "app_subject_630",
+    dapp_id: 42,
+    dapp_user_uuid: dappUserUuid,
+    id: "subject_630",
+    status: "active",
+  })
+  supabase.selectiveDisclosureGrants.push({
+    app_scoped_subject_id: "subject_630",
+    dapp_id: 42,
+    granted_claims: [
+      {
+        claim: "stamp:email",
+        dataClass: "identity",
+        purpose: "Allow Page stamp sharing",
+        required: false,
+      },
+    ],
+    granted_scopes: ["cubid:stamps"],
+    id: "grant_630",
+    status: "active",
   })
   supabase.setWebhookSubscription({
     dapp: 42,

--- a/docs/engineering/app-scoped-identity-selective-disclosure.md
+++ b/docs/engineering/app-scoped-identity-selective-disclosure.md
@@ -1,7 +1,7 @@
 # App-Scoped Identity and Selective Disclosure
 
-Last updated: 2026-04-30
-Status: E01 foundation
+Last updated: 2026-05-03
+Status: E01 implemented; rollout follow-ups tracked in E01.1 and E01.2
 
 ## Purpose
 
@@ -148,21 +148,27 @@ Internal identifiers are never valid disclosure claims. If a downstream app
 needs a stable ID, it receives the app-scoped subject or OIDC pairwise `sub`,
 not raw Cubid storage identifiers.
 
-## Runtime Adoption Sequence
+## Runtime Adoption Status
 
-E01 does not rewrite every route in one pass. Current and remaining adoption
-sequence is:
+E01 is complete as a first-class platform foundation:
 
-1. Use `@cubid/identity` disclosure helpers in new API and webhook code.
-2. Route Allow Page stamp permissions through `selective_disclosure_grants`.
-3. Mirror OIDC consent records into disclosure grants or make OIDC consume the
-   disclosure grant service directly.
-4. Update SDK-facing identity routes to return only app-scoped subject and
-   granted claims.
-5. Use disclosure grants to filter webhook payloads.
-6. Extend the grant taxonomy beyond stamps to profile and location claims.
-7. Add user-facing disclosure history and revocation views that cover both OIDC
-   and non-OIDC app grants.
+1. `@cubid/identity` owns the shared app-scoped subject and disclosure-grant
+   domain helpers.
+2. Allow Page stamp permissions persist source `allow_page` disclosure grants.
+3. OIDC consent approval and revocation mirror into the shared disclosure-grant
+   contract.
+4. SDK-facing Passport identity, stamp, score, profile, and location routes
+   consult disclosure grants before releasing values.
+5. API v3 webhook delivery is disclosure-gated and does not send undisclosed
+   stamp events.
+6. The grant taxonomy now includes stamp, profile, and location claims.
+7. Passport Profile exposes OIDC consent management and separate non-OIDC app
+   disclosure grant history/revocation.
+
+The remaining work is rollout and operations cleanup, not core E01
+implementation. `E01.1` owns production backfill and retirement of the temporary
+legacy `stamp_dappuser_permissions` fallback. `E01.2` owns Admin/Ops visibility
+for app-scoped subjects, disclosure grants, and grant/revoke events.
 
 ## Non-Goals In This Slice
 

--- a/docs/engineering/app-scoped-identity-selective-disclosure.md
+++ b/docs/engineering/app-scoped-identity-selective-disclosure.md
@@ -166,11 +166,31 @@ E01 is complete as a first-class platform foundation:
 6. The grant taxonomy now includes stamp, profile, and location claims.
 7. Passport Profile exposes OIDC consent management and separate non-OIDC app
    disclosure grant history/revocation.
+8. Admin exposes read-only disclosure operations visibility for aggregate grant
+   health, source splits, dapp/client summaries, and redacted grant events.
 
-The remaining work is operations visibility, not core E01 implementation.
 `E01.1` added the production backfill script and removed runtime fallback reads
-from `stamp_dappuser_permissions`. `E01.2` owns Admin/Ops visibility for
-app-scoped subjects, disclosure grants, and grant/revoke events.
+from `stamp_dappuser_permissions`. `E01.2` added the Admin read-only
+Disclosure Ops panel and overview API for app-scoped subjects, disclosure
+grants, dapp/OIDC-client health, and grant/revoke events.
+
+## Admin Disclosure Ops
+
+Admin's `Disclosure Ops` tab is intentionally read-only. It loads through
+`POST /api/admin/disclosures/operations/overview`, requires the shared Admin
+API security baseline, and returns:
+
+- total active and revoked disclosure grants
+- active app-scoped subject count
+- grant source and status splits
+- dapp-level active/revoked grant counts and recent grant samples
+- OIDC-client-level active/revoked grant counts and recent grant samples
+- recent disclosure events with raw subject IDs, grant IDs, Cubid user IDs, and
+  dapp user UUIDs redacted from event details
+
+Operator-driven revocation, repair, or data backfill from Admin is out of scope
+until there is a separate authorization design. Production backfills should use
+the Passport server script and normal deployment controls, not a browser UI.
 
 ## Non-Goals In This Slice
 

--- a/docs/engineering/app-scoped-identity-selective-disclosure.md
+++ b/docs/engineering/app-scoped-identity-selective-disclosure.md
@@ -59,11 +59,12 @@ disclosure grants before returning stamp values to a dapp. Legacy response
 shapes are preserved where practical, but undisclosed stamps are removed from
 the result set and email/phone fields are nulled unless the matching stamp claim
 was granted. This is intentionally stricter than the old table-permission
-behavior: `stamp_dappuser_permissions` remains a legacy compatibility table, but
-new grants are evaluated through the selective-disclosure contract. During the
-rollout period, routes retain a compatibility fallback to existing
-`stamp_dappuser_permissions` rows so pre-migration grants are not silently
-revoked before a production backfill has run.
+behavior: `stamp_dappuser_permissions` remains a legacy write-side table for
+older flows, but it is no longer a runtime authorization fallback for
+app-facing identity, score, location, or webhook release decisions. The
+`backfill:disclosure-grants` script should be run in dry-run mode before
+deployment and in write mode during rollout so legacy permission rows are
+represented in `selective_disclosure_grants`.
 Score and score-detail endpoints also calculate only from disclosed stamps so a
 dapp cannot infer undisclosed credentials from score contributions.
 
@@ -99,7 +100,8 @@ classifications, and grant timestamps, and revoke active Allow Page grants. The
 revocation route updates `selective_disclosure_grants`, writes a
 `selective_disclosure_events` audit event, and removes matching legacy
 `stamp_dappuser_permissions` rows for stamp claims in the revoked grant so the
-temporary compatibility fallback does not preserve access after revocation.
+legacy write-side permission table stays aligned with the disclosure-grant
+source of truth.
 
 Passport requires `PASSPORT_APP_SCOPED_SUBJECT_SECRET` for Allow Page subject
 derivation. OIDC currently derives its broader app-scoped subject from the same
@@ -165,10 +167,10 @@ E01 is complete as a first-class platform foundation:
 7. Passport Profile exposes OIDC consent management and separate non-OIDC app
    disclosure grant history/revocation.
 
-The remaining work is rollout and operations cleanup, not core E01
-implementation. `E01.1` owns production backfill and retirement of the temporary
-legacy `stamp_dappuser_permissions` fallback. `E01.2` owns Admin/Ops visibility
-for app-scoped subjects, disclosure grants, and grant/revoke events.
+The remaining work is operations visibility, not core E01 implementation.
+`E01.1` added the production backfill script and removed runtime fallback reads
+from `stamp_dappuser_permissions`. `E01.2` owns Admin/Ops visibility for
+app-scoped subjects, disclosure grants, and grant/revoke events.
 
 ## Non-Goals In This Slice
 

--- a/docs/engineering/app-scoped-identity-selective-disclosure.md
+++ b/docs/engineering/app-scoped-identity-selective-disclosure.md
@@ -188,6 +188,11 @@ API security baseline, and returns:
 - recent disclosure events with raw subject IDs, grant IDs, Cubid user IDs, and
   dapp user UUIDs redacted from event details
 
+The overview uses service-role SQL aggregate functions for totals, per-dapp
+summaries, per-OIDC-client summaries, active subject count, and 7-day event
+count. The API only samples recent grant rows for compact UI detail cards, so
+operator totals do not depend on capped PostgREST result windows.
+
 Operator-driven revocation, repair, or data backfill from Admin is out of scope
 until there is a separate authorization design. Production backfills should use
 the Passport server script and normal deployment controls, not a browser UI.

--- a/supabase/migrations/20260503204500_disclosure_ops_aggregates.sql
+++ b/supabase/migrations/20260503204500_disclosure_ops_aggregates.sql
@@ -1,0 +1,206 @@
+create index if not exists selective_disclosure_grants_status_source_idx
+  on public.selective_disclosure_grants (status, source);
+
+create index if not exists selective_disclosure_grants_dapp_updated_idx
+  on public.selective_disclosure_grants (dapp_id, updated_at desc)
+  where dapp_id is not null;
+
+create index if not exists selective_disclosure_grants_oidc_client_updated_idx
+  on public.selective_disclosure_grants (oidc_client_id, updated_at desc)
+  where oidc_client_id is not null;
+
+create index if not exists selective_disclosure_events_created_idx
+  on public.selective_disclosure_events (created_at desc);
+
+create or replace function public.get_disclosure_ops_grant_totals()
+returns table (
+  source text,
+  status text,
+  grant_count bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    grants.source,
+    grants.status,
+    count(*)::bigint as grant_count
+  from public.selective_disclosure_grants grants
+  group by grants.source, grants.status;
+$$;
+
+revoke all on function public.get_disclosure_ops_grant_totals() from public;
+grant execute on function public.get_disclosure_ops_grant_totals() to service_role;
+
+create or replace function public.get_disclosure_ops_active_subject_count()
+returns table (
+  active_subject_count bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select count(*)::bigint as active_subject_count
+  from public.app_scoped_subjects subjects
+  where subjects.status = 'active';
+$$;
+
+revoke all on function public.get_disclosure_ops_active_subject_count() from public;
+grant execute on function public.get_disclosure_ops_active_subject_count() to service_role;
+
+create or replace function public.get_disclosure_ops_recent_event_count(
+  p_since timestamptz
+)
+returns table (
+  event_count bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select count(*)::bigint as event_count
+  from public.selective_disclosure_events events
+  where events.created_at >= p_since;
+$$;
+
+revoke all on function public.get_disclosure_ops_recent_event_count(timestamptz) from public;
+grant execute on function public.get_disclosure_ops_recent_event_count(timestamptz) to service_role;
+
+create or replace function public.get_disclosure_ops_dapp_summaries()
+returns table (
+  dapp_id bigint,
+  app_name text,
+  active_grant_count bigint,
+  revoked_grant_count bigint,
+  active_subject_count bigint,
+  last_granted_at timestamptz,
+  last_revoked_at timestamptz,
+  sources jsonb
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with grant_counts as (
+    select
+      grants.dapp_id,
+      count(*) filter (where grants.status = 'active')::bigint as active_grant_count,
+      count(*) filter (where grants.status = 'revoked')::bigint as revoked_grant_count,
+      max(grants.granted_at) as last_granted_at,
+      max(grants.revoked_at) as last_revoked_at
+    from public.selective_disclosure_grants grants
+    where grants.dapp_id is not null
+    group by grants.dapp_id
+  ),
+  source_counts as (
+    select
+      grants.dapp_id,
+      grants.source,
+      count(*)::bigint as source_count
+    from public.selective_disclosure_grants grants
+    where grants.dapp_id is not null
+    group by grants.dapp_id, grants.source
+  ),
+  source_json as (
+    select
+      source_counts.dapp_id,
+      jsonb_object_agg(source_counts.source, source_counts.source_count) as sources
+    from source_counts
+    group by source_counts.dapp_id
+  ),
+  subject_counts as (
+    select
+      subjects.dapp_id,
+      count(distinct subjects.id)::bigint as active_subject_count
+    from public.app_scoped_subjects subjects
+    where subjects.dapp_id is not null
+      and subjects.status = 'active'
+    group by subjects.dapp_id
+  )
+  select
+    grant_counts.dapp_id,
+    coalesce(dapps.appname, ('Dapp ' || grant_counts.dapp_id::text)) as app_name,
+    grant_counts.active_grant_count,
+    grant_counts.revoked_grant_count,
+    coalesce(subject_counts.active_subject_count, 0)::bigint as active_subject_count,
+    grant_counts.last_granted_at,
+    grant_counts.last_revoked_at,
+    coalesce(source_json.sources, '{}'::jsonb) as sources
+  from grant_counts
+  left join public.dapps dapps
+    on dapps.id = grant_counts.dapp_id
+  left join subject_counts
+    on subject_counts.dapp_id = grant_counts.dapp_id
+  left join source_json
+    on source_json.dapp_id = grant_counts.dapp_id
+  order by grant_counts.active_grant_count desc, grant_counts.revoked_grant_count desc;
+$$;
+
+revoke all on function public.get_disclosure_ops_dapp_summaries() from public;
+grant execute on function public.get_disclosure_ops_dapp_summaries() to service_role;
+
+create or replace function public.get_disclosure_ops_oidc_client_summaries()
+returns table (
+  client_id text,
+  client_name text,
+  active_grant_count bigint,
+  revoked_grant_count bigint,
+  last_granted_at timestamptz,
+  last_revoked_at timestamptz,
+  sources jsonb
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with grant_counts as (
+    select
+      grants.oidc_client_id,
+      count(*) filter (where grants.status = 'active')::bigint as active_grant_count,
+      count(*) filter (where grants.status = 'revoked')::bigint as revoked_grant_count,
+      max(grants.granted_at) as last_granted_at,
+      max(grants.revoked_at) as last_revoked_at
+    from public.selective_disclosure_grants grants
+    where grants.oidc_client_id is not null
+    group by grants.oidc_client_id
+  ),
+  source_counts as (
+    select
+      grants.oidc_client_id,
+      grants.source,
+      count(*)::bigint as source_count
+    from public.selective_disclosure_grants grants
+    where grants.oidc_client_id is not null
+    group by grants.oidc_client_id, grants.source
+  ),
+  source_json as (
+    select
+      source_counts.oidc_client_id,
+      jsonb_object_agg(source_counts.source, source_counts.source_count) as sources
+    from source_counts
+    group by source_counts.oidc_client_id
+  )
+  select
+    grant_counts.oidc_client_id as client_id,
+    coalesce(clients.client_name, grant_counts.oidc_client_id) as client_name,
+    grant_counts.active_grant_count,
+    grant_counts.revoked_grant_count,
+    grant_counts.last_granted_at,
+    grant_counts.last_revoked_at,
+    coalesce(source_json.sources, '{}'::jsonb) as sources
+  from grant_counts
+  left join public.oidc_clients clients
+    on clients.client_id = grant_counts.oidc_client_id
+  left join source_json
+    on source_json.oidc_client_id = grant_counts.oidc_client_id
+  order by grant_counts.active_grant_count desc, grant_counts.revoked_grant_count desc;
+$$;
+
+revoke all on function public.get_disclosure_ops_oidc_client_summaries() from public;
+grant execute on function public.get_disclosure_ops_oidc_client_summaries() to service_role;


### PR DESCRIPTION
## Summary
- Closes the E01 disclosure foundation and splits the remaining rollout tail into precise follow-ups.
- Adds a production backfill path from legacy stamp permissions into selective-disclosure grants.
- Retires runtime fallback reads from `stamp_dappuser_permissions` so app-facing disclosure is grant-backed only.
- Adds read-only Admin Disclosure Ops visibility for grant health, source splits, dapp/OIDC summaries, and redacted events.

## Objective
Make app-scoped identity and selective disclosure a completed platform foundation while leaving the remaining rollout and operator visibility work explicit, reviewable, and safe.

## Changes
- Updated E01 roadmap/session metadata and the selective-disclosure engineering doc.
- Added `pnpm --filter @cubid/passport backfill:disclosure-grants` for dry-run/write backfill from legacy permissions.
- Removed legacy stamp-permission fallback checks from Passport disclosure helpers and updated Passport route tests.
- Added `POST /api/admin/disclosures/operations/overview` under the Admin API security baseline.
- Added Admin `Disclosure Ops` tab with read-only aggregate and per-app/client views.
- Added Admin tests for disclosure ops aggregation/redaction and route wiring.

## Validation
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
- `pnpm --filter @cubid/passport typecheck`
- `pnpm --filter @cubid/passport build`
- `pnpm --filter @cubid/admin test`
- `pnpm --filter @cubid/admin typecheck`
- `pnpm --filter @cubid/admin build`
- `git diff --check`

## Reviewer Notes
- Review the docs/todo reconciliation first, then the Passport fallback retirement, then the Admin Disclosure Ops slice.
- The Admin panel is intentionally read-only; operator revocation/repair controls are deferred pending a separate authorization design.
- The legacy `stamp_dappuser_permissions` table is not dropped or destructively migrated here.
- Local validation still reports the known Node 24 engine warning when run from this shell on Node 25, plus pre-existing frontend lint warnings during builds.

## Follow-ups
- Run the disclosure backfill script in production dry-run mode before write mode.
- Decide whether to add operator-driven disclosure repair/revocation in a future, separately authorized Admin slice.
