### PR TITLE
[codex] add Sui v3 custody and quarantine legacy secrets

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4408,3 +4408,28 @@ Complete `C05.2.1` by adding Sui to the v3 custodial blockchain account surface 
 #### Follow-up
 
 - yeet the C05.2.1 branch for review, then continue with `C05.1.1` public dapp-user-secret legacy table quarantine or the next API v3 custody hardening slice
+
+### session: v154
+
+- timestamp: 2026-05-03T21:21:47Z
+- agent: **OpenAI Codex**
+- branch: **codex/c05-2-1-sui-v3-custody**
+- head: **`07417d1`**
+- session name: **Close C05.2.1 metadata**
+
+#### Objective
+
+Record the implementation commit for `C05.2.1` after the Sui v3 custody slice landed and passed validation.
+
+#### Actions Taken
+
+- updated `agent-context/todo.md` so `C05.2.1` references implementation commit `07417d1`
+- kept the follow-up SDK handoff note in the public SDK repo message queue for SDK agents to consume
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- yeet the C05.2.1 branch for review, then continue with `C05.1.1` or the next API v3 custody hardening slice

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4463,3 +4463,28 @@ Complete `C05.1.1` by quarantining legacy public plaintext dapp-user-secret stor
 #### Follow-up
 
 - physically remove the legacy public table only after production backfill, audit, and retention/export decisions are complete
+
+### session: v156
+
+- timestamp: 2026-05-03T21:27:46Z
+- agent: **OpenAI Codex**
+- branch: **codex/c05-2-1-sui-v3-custody**
+- head: **`99e8c4e`**
+- session name: **Close C05.1.1 metadata**
+
+#### Objective
+
+Record the implementation commit for `C05.1.1` after the legacy public dapp-user-secret quarantine landed and passed validation.
+
+#### Actions Taken
+
+- updated `agent-context/todo.md` so `C05.1.1` references implementation commit `99e8c4e`
+- kept the physical table-removal follow-up deferred until production backfill, audit, and retention/export decisions are complete
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- yeet the C05 custody branch for review, or continue with a narrow post-backfill physical-removal todo once production verification is available

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4433,3 +4433,33 @@ Record the implementation commit for `C05.2.1` after the Sui v3 custody slice la
 #### Follow-up
 
 - yeet the C05.2.1 branch for review, then continue with `C05.1.1` or the next API v3 custody hardening slice
+
+### session: v155
+
+- timestamp: 2026-05-03T21:26:52Z
+- agent: **OpenAI Codex**
+- branch: **codex/c05-2-1-sui-v3-custody**
+- head: **`07f9378`**
+- session name: **Quarantine legacy dapp user secret plaintext storage**
+
+#### Objective
+
+Complete `C05.1.1` by quarantining legacy public plaintext dapp-user-secret storage without dropping historical rows that may still need production backfill or audit review.
+
+#### Actions Taken
+
+- changed `/api/v2/save_secret` to return `410 endpoint_removed` instead of writing plaintext rows to `public.dapp_user_secrets`
+- added a Supabase migration that revokes broad access to `public.dapp_user_secrets`, keeps `service_role` read-only access, and rejects new inserts, updates, and deletes
+- updated Passport route tests to prove the v2 endpoint no longer writes plaintext and v3 remains the encrypted write path
+- updated custody/security docs and created a public SDK handoff note because legacy v2 secret writes are no longer supported
+
+#### Verification
+
+- `pnpm --filter @cubid/passport typecheck`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- physically remove the legacy public table only after production backfill, audit, and retention/export decisions are complete

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4517,3 +4517,32 @@ Address Codex review feedback on PR 158 so the removed `/api/v2/save_secret` end
 #### Follow-up
 
 - commit and push the review fix, reply to and resolve the Codex thread, then re-check CI
+
+### session: v158
+
+- timestamp: 2026-05-03T21:45:21Z
+- agent: **OpenAI Codex**
+- branch: **codex/c05-2-1-sui-v3-custody**
+- head: **`df02adb`**
+- session name: **Address PR 158 Copilot custody comments**
+
+#### Objective
+
+Address the remaining Copilot review comments on PR 158 after the first removed-endpoint CORS fix was pushed.
+
+#### Actions Taken
+
+- adjusted the public dapp-user-secret quarantine trigger to reject inserts and updates without blocking cascaded cleanup deletes
+- updated custody docs to clarify that deletes remain available for `ON DELETE CASCADE` cleanup
+- added a Sui list/filter regression test for API v3 generated account listing
+
+#### Verification
+
+- `pnpm --filter @cubid/passport typecheck`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- commit and push the Copilot fixes, reply to and resolve all review threads, then re-check CI

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4378,3 +4378,33 @@ Address Copilot and Codex review comments on PR 157 before completing the yeet r
 #### Follow-up
 
 - push the review fixes, confirm CI is green again, reply to and resolve the Copilot and Codex review threads
+
+### session: v153
+
+- timestamp: 2026-05-03T21:21:07Z
+- agent: **OpenAI Codex**
+- branch: **codex/c05-2-1-sui-v3-custody**
+- head: **`77b7290`**
+- session name: **Add Sui v3 blockchain custody support**
+
+#### Objective
+
+Complete `C05.2.1` by adding Sui to the v3 custodial blockchain account surface while preserving the C05 envelope-encryption and non-exposure rules.
+
+#### Actions Taken
+
+- added `@mysten/sui` to the Passport workspace and wired Sui Ed25519 account generation into the shared v3 blockchain custody helper
+- added Sui to the v3 account generate/list validation schemas and the supported-chain metadata migration path
+- updated helper, route, and docs coverage so Sui private keys remain encrypted-only and public addresses are normalized as lowercase `0x` values
+- created a handoff note for the public SDK agents because `chain: "sui"` is an additive API v3 SDK-facing capability
+
+#### Verification
+
+- `pnpm --filter @cubid/passport typecheck`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- yeet the C05.2.1 branch for review, then continue with `C05.1.1` public dapp-user-secret legacy table quarantine or the next API v3 custody hardening slice

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4488,3 +4488,32 @@ Record the implementation commit for `C05.1.1` after the legacy public dapp-user
 #### Follow-up
 
 - yeet the C05 custody branch for review, or continue with a narrow post-backfill physical-removal todo once production verification is available
+
+### session: v157
+
+- timestamp: 2026-05-03T21:43:18Z
+- agent: **OpenAI Codex**
+- branch: **codex/c05-2-1-sui-v3-custody**
+- head: **`67ee15a`**
+- session name: **Address PR 158 removed endpoint review**
+
+#### Objective
+
+Address Codex review feedback on PR 158 so the removed `/api/v2/save_secret` endpoint still participates in the shared Passport route baseline.
+
+#### Actions Taken
+
+- routed the removed v2 secret endpoint through `handlePassportRoute` with an anonymous actor and explicit `POST` method contract
+- preserved the `410 endpoint_removed` response while restoring CORS and `OPTIONS` preflight handling for browser callers
+- added regression coverage for the removed endpoint's allowed-origin preflight response
+
+#### Verification
+
+- `pnpm --filter @cubid/passport typecheck`
+- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- commit and push the review fix, reply to and resolve the Codex thread, then re-check CI

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -438,8 +438,8 @@ Migrate dapp user secret custody away from plaintext storage using the C05 Supab
 - Timestamp started: 2026-05-03T21:25:01Z
 - Timestamp completed: 2026-05-03T21:26:52Z
 - Feature branch: codex/c05-2-1-sui-v3-custody
-- Head: 07f9378
-- Session-log reference(s): session: v155
+- Head: 99e8c4e
+- Session-log reference(s): session: v155, session: v156
 
 Permanently quarantine the legacy `public.dapp_user_secrets` plaintext table while preserving already-existing rows as service-role-only backfill/audit input. `/api/v2/save_secret` must no longer write plaintext rows and should return a clear removed-endpoint response that points callers at `/api/v3/save_secret`. The database should revoke broad public, anon, and authenticated grants, leave only the minimum `service_role` read access needed by the backfill script, and reject all new inserts, updates, or deletes against the public table. Keep physical table removal deferred until production confirms all historical rows have been backfilled into `private.dapp_user_secrets` and legacy retention/export needs are resolved.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -456,12 +456,12 @@ Remove ambiguous plaintext custody for blockchain private keys across EVM, NEAR,
 
 ### C05.2.1 Add Sui support to v3 blockchain account custody
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-05-03T21:18:25Z
+- Timestamp completed: 2026-05-03T21:21:07Z
+- Feature branch: codex/c05-2-1-sui-v3-custody
+- Head: 77b7290
+- Session-log reference(s): session: v153
 
 Add Sui to the v3 blockchain account custody surface after selecting and validating the repo-supported Sui SDK. Extend `public.ref_chains` with Sui metadata, add the Sui keypair generator, normalize Sui public-address handling, and add route/helper tests proving `/api/v3/accounts/generate` and `/api/v3/accounts/list` work without returning private-key material. Keep the same C05 Vault envelope-encryption model and `private.private_keys` storage contract used for EVM, NEAR, and Solana. This follow-up should not alter legacy v2 wallet APIs; it should only expand the v3 route surface once the Sui dependency and address format are intentionally locked.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -430,18 +430,18 @@ Create the retrievable-secret custody track for values Cubid must later recover 
 - Head: f3e8b02
 - Session-log reference(s): session: v79, session: v86, session: v87
 
-Migrate dapp user secret custody away from plaintext storage using the C05 Supabase Vault envelope-encryption helper. Preserve the legacy `/api/v2/save_secret` behavior and `public.dapp_user_secrets` table for compatibility, and introduce `/api/v3/save_secret` as the encrypted replacement backed by `private.dapp_user_secrets`. The v3 route must authenticate the dapp, validate that `user_id` belongs to that dapp, encrypt the submitted secret before writing the private-schema table, and store only a non-secret sentinel in the private legacy `secret` column. Provide a careful migration path that reads existing public plaintext rows and inserts encrypted private copies without logging raw values. No public decrypt endpoint should be added in this slice; decryption helpers are server-only for future explicit internal workflows.
+Migrate dapp user secret custody away from plaintext storage using the C05 Supabase Vault envelope-encryption helper. Introduce `/api/v3/save_secret` as the encrypted replacement backed by `private.dapp_user_secrets`; the earlier `/api/v2/save_secret` compatibility path has since been removed by `C05.1.1` so new plaintext rows are not written to `public.dapp_user_secrets`. The v3 route must authenticate the dapp, validate that `user_id` belongs to that dapp, encrypt the submitted secret before writing the private-schema table, and store only a non-secret sentinel in the private legacy `secret` column. Provide a careful migration path that reads existing public plaintext rows and inserts encrypted private copies without logging raw values. No public decrypt endpoint should be added in this slice; decryption helpers are server-only for future explicit internal workflows.
 
 ### C05.1.1 Remove legacy dapp user secret plaintext column
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Completed
+- Timestamp started: 2026-05-03T21:25:01Z
+- Timestamp completed: 2026-05-03T21:26:52Z
+- Feature branch: codex/c05-2-1-sui-v3-custody
+- Head: 07f9378
+- Session-log reference(s): session: v155
 
-After C05.1 is deployed, Supabase Vault is provisioned, and the backfill script has inserted encrypted private copies for all legacy public rows in production, remove or permanently quarantine the legacy `public.dapp_user_secrets` plaintext table. First smoke-test that `/api/v3/save_secret` writes encrypted rows to `private.dapp_user_secrets`, that the backfill reports zero unmigrated public rows, and that no active caller depends on `/api/v2/save_secret` or public plaintext reads. Then add the physical cleanup migration, update docs and generated schema expectations, and add a regression check preventing new code from selecting or inserting raw `secret` values on the public table. This follow-up must not run before production verification because existing rows need a safe migration window.
+Permanently quarantine the legacy `public.dapp_user_secrets` plaintext table while preserving already-existing rows as service-role-only backfill/audit input. `/api/v2/save_secret` must no longer write plaintext rows and should return a clear removed-endpoint response that points callers at `/api/v3/save_secret`. The database should revoke broad public, anon, and authenticated grants, leave only the minimum `service_role` read access needed by the backfill script, and reject all new inserts, updates, or deletes against the public table. Keep physical table removal deferred until production confirms all historical rows have been backfilled into `private.dapp_user_secrets` and legacy retention/export needs are resolved.
 
 ### C05.2 Redesign blockchain private-key custody
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -460,8 +460,8 @@ Remove ambiguous plaintext custody for blockchain private keys across EVM, NEAR,
 - Timestamp started: 2026-05-03T21:18:25Z
 - Timestamp completed: 2026-05-03T21:21:07Z
 - Feature branch: codex/c05-2-1-sui-v3-custody
-- Head: 77b7290
-- Session-log reference(s): session: v153
+- Head: 07417d1
+- Session-log reference(s): session: v153, session: v154
 
 Add Sui to the v3 blockchain account custody surface after selecting and validating the repo-supported Sui SDK. Extend `public.ref_chains` with Sui metadata, add the Sui keypair generator, normalize Sui public-address handling, and add route/helper tests proving `/api/v3/accounts/generate` and `/api/v3/accounts/list` work without returning private-key material. Keep the same C05 Vault envelope-encryption model and `private.private_keys` storage contract used for EVM, NEAR, and Solana. This follow-up should not alter legacy v2 wallet APIs; it should only expand the v3 route surface once the Sui dependency and address format are intentionally locked.
 

--- a/apps/passport/lib/server/blockchainAccounts.ts
+++ b/apps/passport/lib/server/blockchainAccounts.ts
@@ -9,6 +9,7 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { ethers } from "ethers"
 import { KeyPair } from "near-api-js"
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519"
 import { Keypair } from "@solana/web3.js"
 
 export const BLOCKCHAIN_PRIVATE_KEY_ALGORITHM =
@@ -18,7 +19,7 @@ export const BLOCKCHAIN_PRIVATE_KEY_ID =
 export const BLOCKCHAIN_PRIVATE_KEY_VERSION = 1
 export const BLOCKCHAIN_PRIVATE_KEY_PURPOSE = "blockchain_private_key" as const
 
-export const SUPPORTED_GENERATED_CHAINS = ["evm", "near", "solana"] as const
+export const SUPPORTED_GENERATED_CHAINS = ["evm", "near", "solana", "sui"] as const
 
 export type SupportedGeneratedChain = (typeof SUPPORTED_GENERATED_CHAINS)[number]
 
@@ -64,7 +65,7 @@ export const normalizePublicAddress = (
 ) => {
   const trimmed = publicAddress.trim()
 
-  if (chainKey === "evm" || chainKey === "near") {
+  if (chainKey === "evm" || chainKey === "near" || chainKey === "sui") {
     return trimmed.toLowerCase()
   }
 
@@ -89,6 +90,15 @@ export const generateBlockchainAccount = (
       chainKey,
       privateKey: keyPair.toString(),
       publicAddress: keyPair.getPublicKey().toString(),
+    }
+  }
+
+  if (chainKey === "sui") {
+    const keypair = Ed25519Keypair.generate()
+    return {
+      chainKey,
+      privateKey: keypair.getSecretKey(),
+      publicAddress: keypair.getPublicKey().toSuiAddress(),
     }
   }
 

--- a/apps/passport/package.json
+++ b/apps/passport/package.json
@@ -34,6 +34,7 @@
     "@heroicons/react": "^2.1.3",
     "@lens-protocol/react-web": "^2.3.1",
     "@lens-protocol/wagmi": "^4.1.4",
+    "@mysten/sui": "^2.16.0",
     "@near-js/transactions": "^1.1.0",
     "@near-wallet-selector/coin98-wallet": "^8.5.3",
     "@near-wallet-selector/core": "^8.5.3",

--- a/apps/passport/pages/api/v2/save_secret.ts
+++ b/apps/passport/pages/api/v2/save_secret.ts
@@ -1,52 +1,25 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 
+import { ApiSecurityError } from "@cubid/auth/server"
 import {
-  handlePassportRoute,
-  passportSchemas,
+  getPassportRequestId,
+  sendPassportApiError,
 } from "@/lib/server/passportApi"
-import { getPassportSupabase } from "@/lib/server/supabase"
-
-const schema = passportSchemas.z.object({
-  api_key: passportSchemas.z.string().min(1).optional(),
-  secret: passportSchemas.z.string().min(1),
-  user_id: passportSchemas.z.string().min(1),
-})
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  return handlePassportRoute(
+  res.setHeader("X-Request-Id", getPassportRequestId(req))
+  return sendPassportApiError(
     req,
     res,
-    {
-      actor: "dapp",
-      bodySchema: schema,
-      rateLimitGroup: "passport_dapp_mutation",
-      route: "v2.save_secret",
-    },
-    async ({ body }) => {
-      const supabase = getPassportSupabase()
-      const { data: existingRows, error: existingError } = await supabase
-        .from("dapp_user_secrets")
-        .select("*")
-        .eq("dapp_user_uuid", body.user_id)
-
-      if (existingError) {
-        throw existingError
-      }
-
-      const { error } = await supabase.from("dapp_user_secrets").insert({
-        dapp_user_uuid: body.user_id,
-        secret: body.secret,
-        secret_sequential_id: (existingRows ?? []).length + 1,
-      })
-
-      if (error) {
-        throw error
-      }
-
-      return res.status(200).json({ success: true })
-    }
+    new ApiSecurityError(
+      410,
+      "endpoint_removed",
+      "Legacy plaintext dapp user secret writes have been removed. Use /api/v3/save_secret."
+    ),
+    "Legacy plaintext dapp user secret writes have been removed. Use /api/v3/save_secret.",
+    "v2.save_secret"
   )
 }

--- a/apps/passport/pages/api/v2/save_secret.ts
+++ b/apps/passport/pages/api/v2/save_secret.ts
@@ -2,24 +2,28 @@ import type { NextApiRequest, NextApiResponse } from "next"
 
 import { ApiSecurityError } from "@cubid/auth/server"
 import {
-  getPassportRequestId,
-  sendPassportApiError,
+  handlePassportRoute,
 } from "@/lib/server/passportApi"
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  res.setHeader("X-Request-Id", getPassportRequestId(req))
-  return sendPassportApiError(
+  return handlePassportRoute(
     req,
     res,
-    new ApiSecurityError(
-      410,
-      "endpoint_removed",
-      "Legacy plaintext dapp user secret writes have been removed. Use /api/v3/save_secret."
-    ),
-    "Legacy plaintext dapp user secret writes have been removed. Use /api/v3/save_secret.",
-    "v2.save_secret"
+    {
+      actor: "anonymous",
+      allowedMethods: ["POST"],
+      rateLimitGroup: "passport_dapp_mutation",
+      route: "v2.save_secret",
+    },
+    async () => {
+      throw new ApiSecurityError(
+        410,
+        "endpoint_removed",
+        "Legacy plaintext dapp user secret writes have been removed. Use /api/v3/save_secret."
+      )
+    }
   )
 }

--- a/apps/passport/pages/api/v3/accounts/generate.ts
+++ b/apps/passport/pages/api/v3/accounts/generate.ts
@@ -15,7 +15,7 @@ import { getPassportSupabase } from "@/lib/server/supabase"
 const schema = passportSchemas.z.object({
   api_key: passportSchemas.z.string().min(1).optional(),
   apikey: passportSchemas.z.string().min(1).optional(),
-  chain: passportSchemas.z.enum(["evm", "near", "solana"]),
+  chain: passportSchemas.z.enum(["evm", "near", "solana", "sui"]),
   dapp_id: passportSchemas.z.union([
     passportSchemas.z.number().int().positive(),
     passportSchemas.z.string().min(1),

--- a/apps/passport/pages/api/v3/accounts/list.ts
+++ b/apps/passport/pages/api/v3/accounts/list.ts
@@ -10,7 +10,7 @@ import { getPassportSupabase } from "@/lib/server/supabase"
 const schema = passportSchemas.z.object({
   api_key: passportSchemas.z.string().min(1).optional(),
   apikey: passportSchemas.z.string().min(1).optional(),
-  chain: passportSchemas.z.enum(["evm", "near", "solana"]).optional(),
+  chain: passportSchemas.z.enum(["evm", "near", "solana", "sui"]).optional(),
   dapp_id: passportSchemas.z.union([
     passportSchemas.z.number().int().positive(),
     passportSchemas.z.string().min(1),

--- a/apps/passport/tests/blockchainAccounts.test.ts
+++ b/apps/passport/tests/blockchainAccounts.test.ts
@@ -88,13 +88,18 @@ test("blockchain private-key envelope rejects the wrong wrapping key", () => {
   )
 })
 
-test("generated blockchain accounts support evm near and solana without exposing empty keys", () => {
-  for (const chain of ["evm", "near", "solana"] as const) {
+test("generated blockchain accounts support evm near solana and sui without exposing empty keys", () => {
+  for (const chain of ["evm", "near", "solana", "sui"] as const) {
     const account = generateBlockchainAccount(chain)
 
     assert.equal(account.chainKey, chain)
     assert.ok(account.publicAddress.length > 10)
     assert.ok(account.privateKey.length > 10)
+
+    if (chain === "sui") {
+      assert.equal(account.publicAddress.startsWith("0x"), true)
+      assert.equal(account.privateKey.startsWith("suiprivkey"), true)
+    }
   }
 })
 
@@ -102,4 +107,5 @@ test("public address normalization preserves case-sensitive Solana addresses", (
   assert.equal(normalizePublicAddress("evm", "0xABC"), "0xabc")
   assert.equal(normalizePublicAddress("near", "ED25519:ABC"), "ed25519:abc")
   assert.equal(normalizePublicAddress("solana", "SoLaNaAbC"), "SoLaNaAbC")
+  assert.equal(normalizePublicAddress("sui", "0xABC"), "0xabc")
 })

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -1377,11 +1377,11 @@ test("Passport v3 account list validates auth, payloads, ownership, and chain fi
     createApiRequest({
       body: {
         api_key: apiKey,
-        chain: "solana",
+        chain: "sui",
         dapp_user_uuid: dappUserUuid,
       },
       headers: {
-        "idempotency-key": "generate-solana-for-filter",
+        "idempotency-key": "generate-sui-for-filter",
         origin: "https://passport.cubid.me",
       },
       url: "/api/v3/accounts/generate",
@@ -1394,7 +1394,7 @@ test("Passport v3 account list validates auth, payloads, ownership, and chain fi
     createApiRequest({
       body: {
         api_key: apiKey,
-        chain: "evm",
+        chain: "sui",
         dapp_user_uuid: dappUserUuid,
       },
       headers: {
@@ -1409,7 +1409,9 @@ test("Passport v3 account list validates auth, payloads, ownership, and chain fi
   assert.equal(filteredRes.statusCode, 200)
   assert.equal(filteredRes.headers["x-request-id"], "passport_v3_list_filter")
   assert.equal(accounts.length, 1)
-  assert.equal(accounts[0].chain, "evm")
+  assert.equal(accounts[0].chain, "sui")
+  assert.equal(String(accounts[0].publicAddress).startsWith("0x"), true)
+  assert.equal(JSON.stringify(filteredRes.body).includes("private"), false)
 })
 
 test("Passport internal webhook trigger rejects missing internal bearer tokens", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -1054,7 +1054,7 @@ test("Passport v3 account generation rejects dapp users outside the authenticate
   assert.equal(supabase.dappUserAccounts.length, 0)
 })
 
-test("Passport v3 account generation rejects unsupported Sui requests", async () => {
+test("Passport v3 account generation supports Sui without exposing private keys", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000054"
@@ -1077,9 +1077,18 @@ test("Passport v3 account generation rejects unsupported Sui requests", async ()
 
   await generateAccountV3Handler(req, res)
 
-  assert.equal(res.statusCode, 400)
-  assert.equal((res.body as { error: { code: string } }).error.code, "invalid_request")
-  assert.equal(supabase.userAccounts.length, 0)
+  assert.equal(res.statusCode, 200)
+  const body = res.body as DataResponse<Record<string, unknown>>
+  assert.equal(body.data.chain, "sui")
+  assert.equal(String(body.data.publicAddress).startsWith("0x"), true)
+  assert.equal(JSON.stringify(res.body).includes("suiprivkey"), false)
+  assert.equal(JSON.stringify(res.body).includes("ciphertext"), false)
+  assert.equal(JSON.stringify(res.body).includes("private"), false)
+  assert.equal(supabase.userAccounts.length, 1)
+  assert.equal(supabase.userAccounts[0]?.chain_key, "sui")
+  assert.equal(supabase.privateKeys.length, 1)
+  assert.equal(supabase.privateKeys[0]?.chain_key, "sui")
+  assert.equal(supabase.dappUserAccounts.length, 1)
 })
 
 test("Passport v3 account generation replays Idempotency-Key writes without creating duplicate accounts", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -599,7 +599,7 @@ test("Passport v2 create_user rejects malformed dapp payloads before execution",
   )
 })
 
-test("Passport v2 save_secret keeps legacy public-table behavior", async () => {
+test("Passport v2 save_secret is removed and never writes plaintext secrets", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const userId = "00000000-0000-4000-8000-000000000041"
@@ -613,6 +613,7 @@ test("Passport v2 save_secret keeps legacy public-table behavior", async () => {
     },
     headers: {
       origin: "https://passport.cubid.me",
+      "x-request-id": "passport_v2_secret_removed",
     },
     url: "/api/v2/save_secret",
   })
@@ -620,12 +621,18 @@ test("Passport v2 save_secret keeps legacy public-table behavior", async () => {
 
   await saveSecretV2Handler(req, res)
 
-  assert.equal(res.statusCode, 200)
-  assert.deepEqual(res.body, { success: true })
-  assert.equal(supabase.dappUserSecrets.length, 1)
+  assert.equal(res.statusCode, 410)
+  assert.equal(res.headers["x-request-id"], "passport_v2_secret_removed")
+  assert.deepEqual(res.body, {
+    error: {
+      code: "endpoint_removed",
+      message:
+        "Legacy plaintext dapp user secret writes have been removed. Use /api/v3/save_secret.",
+      requestId: "passport_v2_secret_removed",
+    },
+  })
+  assert.equal(supabase.dappUserSecrets.length, 0)
   assert.equal(supabase.privateDappUserSecrets.length, 0)
-  assert.equal(supabase.dappUserSecrets[0].secret, "legacy plaintext dapp user secret")
-  assert.equal(supabase.dappUserSecrets[0].secret_sequential_id, 1)
 })
 
 test("Passport v3 save_secret stores only encrypted dapp user secrets", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -633,6 +633,25 @@ test("Passport v2 save_secret is removed and never writes plaintext secrets", as
   })
   assert.equal(supabase.dappUserSecrets.length, 0)
   assert.equal(supabase.privateDappUserSecrets.length, 0)
+
+  const optionsReq = createApiRequest({
+    headers: {
+      origin: "https://passport.cubid.me",
+      "x-request-id": "passport_v2_secret_options",
+    },
+    method: "OPTIONS",
+    url: "/api/v2/save_secret",
+  })
+  const optionsRes = createApiResponse()
+
+  await saveSecretV2Handler(optionsReq, optionsRes)
+
+  assert.equal(optionsRes.statusCode, 200)
+  assert.equal(optionsRes.headers["x-request-id"], "passport_v2_secret_options")
+  assert.equal(
+    optionsRes.headers["access-control-allow-origin"],
+    "https://passport.cubid.me"
+  )
 })
 
 test("Passport v3 save_secret stores only encrypted dapp user secrets", async () => {

--- a/apps/passport/types/mysten-sui.d.ts
+++ b/apps/passport/types/mysten-sui.d.ts
@@ -1,0 +1,9 @@
+declare module "@mysten/sui/keypairs/ed25519" {
+  export class Ed25519Keypair {
+    static generate(): Ed25519Keypair
+    getPublicKey(): {
+      toSuiAddress(): string
+    }
+    getSecretKey(): string
+  }
+}

--- a/docs/engineering/api-security-operations.md
+++ b/docs/engineering/api-security-operations.md
@@ -227,9 +227,10 @@ encryption model. `/api/v3/save_secret` encrypts submissions into
 `private.dapp_user_secrets` using a per-row data key wrapped by the Supabase
 Vault secret `passport_dapp_user_secret_wrapping_key_v1`. Provision this Vault
 secret before enabling v3 writes or running the legacy backfill script. The
-legacy `/api/v2/save_secret` route is preserved for compatibility and continues
-to use `public.dapp_user_secrets`; v3 is the encrypted private-schema custody
-contract.
+legacy `/api/v2/save_secret` route is removed and returns `410 endpoint_removed`.
+The legacy `public.dapp_user_secrets` table is quarantined as service-role
+read-only backfill/audit input; new writes must use v3 encrypted private-schema
+custody.
 
 Webhook signing secrets use the same C05 envelope model because Passport must
 recover them to sign outbound webhook deliveries. Admin-created subscriptions

--- a/docs/engineering/api-security-operations.md
+++ b/docs/engineering/api-security-operations.md
@@ -230,7 +230,8 @@ secret before enabling v3 writes or running the legacy backfill script. The
 legacy `/api/v2/save_secret` route is removed and returns `410 endpoint_removed`.
 The legacy `public.dapp_user_secrets` table is quarantined as service-role
 read-only backfill/audit input; new writes must use v3 encrypted private-schema
-custody.
+custody. The quarantine blocks inserts and updates but preserves cascaded
+cleanup deletes from owning dapp-user records.
 
 Webhook signing secrets use the same C05 envelope model because Passport must
 recover them to sign outbound webhook deliveries. Admin-created subscriptions

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -54,6 +54,9 @@ Purpose: store a retrievable dapp-user secret using the v3 encrypted custody
 model. This is the encrypted replacement for legacy `/api/v2/save_secret`; it
 does not add a public retrieval endpoint.
 
+Legacy `/api/v2/save_secret` is removed and returns `410 endpoint_removed`.
+Callers that need to store dapp-user secrets must migrate to this v3 route.
+
 Request body:
 
 ```json

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -105,8 +105,7 @@ Rules:
 
 - `Idempotency-Key` is required.
 - `dapp_user_uuid` must belong to the authenticated dapp.
-- Supported generated chains are currently `evm`, `near`, and `solana`. Sui is
-  explicitly deferred to `C05.2.1`.
+- Supported generated chains are currently `evm`, `near`, `solana`, and `sui`.
 - The route creates `public.user_accounts`, encrypted `private.private_keys`,
   and one `public.dapp_user_accounts` link for the triggering dapp user.
 - If private-key or link creation fails, the route performs compensating cleanup
@@ -152,7 +151,7 @@ Request body:
 Rules:
 
 - `dapp_user_uuid` must belong to the authenticated dapp.
-- `chain` is optional and filters to `evm`, `near`, or `solana` when present.
+- `chain` is optional and filters to `evm`, `near`, `solana`, or `sui` when present.
 - Only active dapp-user account links and active user accounts are returned.
 
 Success response shape:

--- a/docs/engineering/encrypted-database-secrets.md
+++ b/docs/engineering/encrypted-database-secrets.md
@@ -52,9 +52,12 @@ blockchain account, purpose, or key fails.
 - stores `__cubid_encrypted_dapp_user_secret__` in the legacy `secret` column
 - writes a security event without raw secret material
 
-`public.dapp_user_secrets` remains the legacy v2 table. It is intentionally
-left intact while v2 is supported, and new encrypted v3 work must not add
-encrypted columns or new custody behavior to the public table.
+`public.dapp_user_secrets` is a quarantined legacy table retained only so
+already-created plaintext rows can be audited/backfilled into private encrypted
+custody. `/api/v2/save_secret` is removed and must not write new plaintext
+rows. The quarantine migration revokes broad public grants, leaves
+`service_role` with read-only access for backfill/audit, and installs a trigger
+that rejects new inserts, updates, and deletes on the public table.
 
 The required Vault secret is `passport_dapp_user_secret_wrapping_key_v1`. It
 must be a base64 or base64url encoded 32-byte value and must be provisioned
@@ -73,13 +76,14 @@ pnpm --filter @cubid/passport exec tsx scripts/encrypt-dapp-user-secrets.ts --dr
 pnpm --filter @cubid/passport exec tsx scripts/encrypt-dapp-user-secrets.ts
 ```
 
-The script reads plaintext rows from `public.dapp_user_secrets` and inserts
-encrypted copies into `private.dapp_user_secrets`. It reports counts only,
-must never log raw secret values, and does not mutate the legacy public table.
+The script reads plaintext rows from quarantined `public.dapp_user_secrets` and
+inserts encrypted copies into `private.dapp_user_secrets`. It reports counts
+only, must never log raw secret values, and does not mutate the legacy public
+table.
 
-Physical removal or final quarantine of the legacy public table is deferred
-until production smoke confirms current rows are encrypted privately and no
-callers depend on the v2 plaintext table.
+Physical removal of the legacy public table is still deferred until production
+smoke confirms current rows are encrypted privately and retention/export needs
+for legacy rows are resolved.
 
 ## Webhook Signing Secrets
 

--- a/docs/engineering/encrypted-database-secrets.md
+++ b/docs/engineering/encrypted-database-secrets.md
@@ -57,7 +57,9 @@ already-created plaintext rows can be audited/backfilled into private encrypted
 custody. `/api/v2/save_secret` is removed and must not write new plaintext
 rows. The quarantine migration revokes broad public grants, leaves
 `service_role` with read-only access for backfill/audit, and installs a trigger
-that rejects new inserts, updates, and deletes on the public table.
+that rejects new inserts and updates on the public table. Deletes are not
+blocked so existing `ON DELETE CASCADE` cleanup from `public.dapp_users` can
+still remove legacy rows.
 
 The required Vault secret is `passport_dapp_user_secret_wrapping_key_v1`. It
 must be a base64 or base64url encoded 32-byte value and must be provisioned

--- a/docs/engineering/encrypted-database-secrets.md
+++ b/docs/engineering/encrypted-database-secrets.md
@@ -127,8 +127,10 @@ account metadata separately from encrypted private-key material:
 The `private` schema is service-role-only. Browser, Admin list, and dapp
 responses must never return raw private keys, ciphertext, wrapped data keys,
 IVs, authentication tags, or Vault material. V3 account generation currently
-supports EVM, NEAR, and Solana. Sui is deferred until a Sui SDK and address
-normalization contract are selected.
+supports EVM, NEAR, Solana, and Sui. Sui accounts use Ed25519 keypairs from
+`@mysten/sui`, store the SDK `suiprivkey` value only inside the encrypted
+`private.private_keys` envelope, and normalize public Sui addresses as
+lowercase `0x` values.
 
 The required Vault secret is
 `passport_blockchain_private_key_wrapping_key_v1`. It must be a base64 or

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,7 @@ importers:
         version: 2.6.6
       '@gooddollar/web3sdk-v2':
         specifier: ^0.1.121
-        version: 0.1.121(048116ad0ad28a0e2334f4a0c6c9e419)
+        version: 0.1.121(8d1a3ab3160d9ffbba825de02026783e)
       '@headlessui/react':
         specifier: ^1.7.18
         version: 1.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -231,6 +231,9 @@ importers:
       '@lens-protocol/wagmi':
         specifier: ^4.1.4
         version: 4.1.4(@lens-protocol/react-web@2.3.1(@types/react@18.2.48)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10))(@tanstack/react-query@5.59.13(react@18.3.1))(bufferutil@4.0.8)(utf-8-validate@5.0.10)(viem@2.21.25(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.12.17(@react-native-async-storage/async-storage@1.21.0(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.59.13)(@tanstack/react-query@5.59.13(react@18.3.1))(@types/react@18.2.48)(bufferutil@4.0.8)(encoding@0.1.13)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.2.2)(utf-8-validate@5.0.10)(viem@2.21.25(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))
+      '@mysten/sui':
+        specifier: ^2.16.0
+        version: 2.16.0(typescript@5.2.2)
       '@near-js/transactions':
         specifier: ^1.1.0
         version: 1.1.0
@@ -748,6 +751,20 @@ importers:
         version: 5.2.2
 
 packages:
+
+  '@0no-co/graphql.web@1.2.0':
+    resolution: {integrity: sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+
+  '@0no-co/graphqlsp@1.15.4':
+    resolution: {integrity: sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
@@ -2832,6 +2849,26 @@ packages:
     resolution: {integrity: sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==}
     engines: {node: '>=14'}
 
+  '@gql.tada/cli-utils@1.7.3':
+    resolution: {integrity: sha512-3iQY5E/jvv3Lnh6D1Mh7zr+Bb9C/TGk1DHkm+lbIjQBnZAu2m+BcTcr1e3spUt6Aa6HG/xAN2XxpbWw9oZALEg==}
+    peerDependencies:
+      '@0no-co/graphqlsp': ^1.12.13
+      '@gql.tada/svelte-support': 1.0.2
+      '@gql.tada/vue-support': 1.0.2
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      '@gql.tada/svelte-support':
+        optional: true
+      '@gql.tada/vue-support':
+        optional: true
+
+  '@gql.tada/internal@1.0.9':
+    resolution: {integrity: sha512-Bp8yi+kLrzIJ3l5Dfxhz48H4OCH2LCX+pShaPcJgh+oiBt6clrjUKDYNDD3Z78aDQ3+Tyrxe4dd0MfLgpSLPPg==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0
+
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
@@ -3326,6 +3363,16 @@ packages:
   '@multiformats/base-x@4.0.1':
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
 
+  '@mysten/bcs@2.0.3':
+    resolution: {integrity: sha512-dwcaL4HNAsEGpU3hKUAsXgCZp9l6++e2A3THpzoYZ8e7bsy4XH1V0dXD5dIzgNcVZiZfb6ZnDMG+gdF6+1WOQA==}
+
+  '@mysten/sui@2.16.0':
+    resolution: {integrity: sha512-xnf3e3uIuJGzIVEBLEl372Xk51CB45CP2ZlXXLSnWHH1MI0xIpko10JSQ44ohde9XhxygAy1jz26rkrlCgDGXQ==}
+    engines: {node: '>=22'}
+
+  '@mysten/utils@0.3.1':
+    resolution: {integrity: sha512-36KhxG284uhDdSnlkyNaS6fzKTX9FpP2WQWOwUKIRsqQFFIm2ooCf2TP1IuqrtMpkairwpiWkAS0eg7cpemVzg==}
+
   '@near-js/crypto@1.2.0':
     resolution: {integrity: sha512-iYpiynirW1cB9kNttSsbNhlN4LFR1Esq08aIFyFB/qGNy8DjLYYoe2g923YBxDbVMI6Ljk6AX3G+KDnG3S9lqg==}
 
@@ -3593,6 +3640,10 @@ packages:
     resolution: {integrity: sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/hashes@1.1.5':
     resolution: {integrity: sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==}
 
@@ -3618,6 +3669,10 @@ packages:
   '@noble/hashes@1.7.2':
     resolution: {integrity: sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@noble/secp256k1@1.7.1':
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
@@ -3931,6 +3986,15 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.5.0
+
+  '@protobuf-ts/grpcweb-transport@2.11.1':
+    resolution: {integrity: sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==}
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    resolution: {integrity: sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==}
+
+  '@protobuf-ts/runtime@2.11.1':
+    resolution: {integrity: sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4423,6 +4487,9 @@ packages:
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
+
   '@scure/bip32@1.1.5':
     resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
 
@@ -4434,6 +4501,9 @@ packages:
 
   '@scure/bip32@1.5.0':
     resolution: {integrity: sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==}
+
+  '@scure/bip32@2.2.0':
+    resolution: {integrity: sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==}
 
   '@scure/bip39@1.1.0':
     resolution: {integrity: sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==}
@@ -4449,6 +4519,9 @@ packages:
 
   '@scure/bip39@1.4.0':
     resolution: {integrity: sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==}
+
+  '@scure/bip39@2.2.0':
+    resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
 
   '@sentry/browser@7.16.0':
     resolution: {integrity: sha512-tJ063zvoF8Raw7mzQEXupOFPSN6v36WIbsDVGeFdToPCwViaBuATaxvWCrudGzsnBkMyItmTLJkzn9SEIXUOiw==}
@@ -9240,6 +9313,12 @@ packages:
     resolution: {integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==}
     engines: {node: '>=8.6'}
 
+  gql.tada@1.9.2:
+    resolution: {integrity: sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0 || ^6.0.0
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -9259,6 +9338,10 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   graphql@16.9.0:
     resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
@@ -11894,6 +11977,9 @@ packages:
     resolution: {integrity: sha512-3IKLNXclQgkU++2fSi93sQ6BznFuxSLB11HdvZQ6JW/spahf/P1pAHBQEahr20rs0htZW0UDkM1HmA+nZkXKsw==}
     engines: {node: '>=12.0.0'}
 
+  poseidon-lite@0.2.1:
+    resolution: {integrity: sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==}
+
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
@@ -14129,6 +14215,14 @@ packages:
     resolution: {integrity: sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==}
     engines: {node: '>=10.12.0'}
 
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   valid-url@1.0.9:
     resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
 
@@ -14942,6 +15036,16 @@ packages:
 
 snapshots:
 
+  '@0no-co/graphql.web@1.2.0(graphql@16.13.2)':
+    optionalDependencies:
+      graphql: 16.13.2
+
+  '@0no-co/graphqlsp@1.15.4(graphql@16.13.2)(typescript@5.2.2)':
+    dependencies:
+      '@gql.tada/internal': 1.0.9(graphql@16.13.2)(typescript@5.2.2)
+      graphql: 16.13.2
+      typescript: 5.2.2
+
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
   '@adobe/css-tools@4.4.4': {}
@@ -15027,14 +15131,14 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@apollo/client@3.11.8(@types/react@18.2.48)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@apollo/client@3.11.8(@types/react@18.2.48)(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
       '@wry/caches': 1.0.1
       '@wry/equality': 0.5.7
       '@wry/trie': 0.5.0
-      graphql: 16.9.0
-      graphql-tag: 2.12.6(graphql@16.9.0)
+      graphql: 16.13.2
+      graphql-tag: 2.12.6(graphql@16.13.2)
       hoist-non-react-statics: 3.3.2
       optimism: 0.18.0
       prop-types: 15.8.1
@@ -16284,8 +16388,8 @@ snapshots:
   '@didtools/pkh-ethereum@0.4.1':
     dependencies:
       '@didtools/cacao': 2.1.0
-      '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@stablelib/random': 1.0.2
       caip: 1.1.0
 
@@ -16300,7 +16404,7 @@ snapshots:
   '@didtools/pkh-solana@0.1.1':
     dependencies:
       '@didtools/cacao': 2.1.0
-      '@noble/curves': 1.6.0
+      '@noble/curves': 1.8.2
       '@stablelib/random': 1.0.2
       caip: 1.1.0
       uint8arrays: 4.0.10
@@ -16327,8 +16431,8 @@ snapshots:
   '@didtools/pkh-tezos@0.2.2':
     dependencies:
       '@didtools/cacao': 2.1.0
-      '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@stablelib/random': 1.0.2
       caip: 1.1.0
       uint8arrays: 4.0.10
@@ -18073,7 +18177,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@gooddollar/goodprotocol@2.0.24(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(graphql@16.9.0)(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2)(utf-8-validate@5.0.10)':
+  '@gooddollar/goodprotocol@2.0.24(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(graphql@16.13.2)(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@gooddollar/goodcontracts': 2.6.6
       '@jsier/retrier': 1.2.4
@@ -18081,7 +18185,7 @@ snapshots:
       '@openzeppelin/contracts-upgradeable': 4.9.5
       '@openzeppelin/hardhat-upgrades': 1.28.0(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10))
       '@superfluid-finance/ethereum-contracts': 1.8.1(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
-      '@superfluid-finance/sdk-core': 0.5.9(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(graphql@16.9.0)(typescript@5.2.2)(utf-8-validate@5.0.10)
+      '@superfluid-finance/sdk-core': 0.5.9(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(graphql@16.13.2)(typescript@5.2.2)(utf-8-validate@5.0.10)
       '@typechain/hardhat': 6.1.6(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2))(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))
       async-promise-pool: 1.0.6
       openzeppelin-solidity: 4.8.1
@@ -18108,7 +18212,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@gooddollar/web3sdk-v2@0.1.121(048116ad0ad28a0e2334f4a0c6c9e419)':
+  '@gooddollar/web3sdk-v2@0.1.121(8d1a3ab3160d9ffbba825de02026783e)':
     dependencies:
       '@amplitude/analytics-browser': 1.13.4
       '@amplitude/analytics-react-native': 0.7.2(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)
@@ -18116,7 +18220,7 @@ snapshots:
       '@ceramicnetwork/stream-tile': 2.35.0(encoding@0.1.13)
       '@gooddollar/bridge-app': 1.5.11(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@gooddollar/bridge-contracts': 1.0.17
-      '@gooddollar/goodprotocol': 2.0.24(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(graphql@16.9.0)(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2)(utf-8-validate@5.0.10)
+      '@gooddollar/goodprotocol': 2.0.24(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10)))(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(graphql@16.13.2)(hardhat@2.28.6(bufferutil@4.0.8)(typescript@5.2.2)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.2.2))(typescript@5.2.2)(utf-8-validate@5.0.10)
       '@orbisclub/orbis-sdk': 0.4.89(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@react-native-async-storage/async-storage': 1.21.0(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))
       '@react-native-firebase/analytics': 16.7.0(@react-native-firebase/app@16.7.0(react-native@0.85.1(@babel/core@7.26.0)(@types/react@18.2.48)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1))
@@ -18245,9 +18349,22 @@ snapshots:
       - supports-color
     optional: true
 
-  '@graphql-typed-document-node/core@3.2.0(graphql@16.9.0)':
+  '@gql.tada/cli-utils@1.7.3(@0no-co/graphqlsp@1.15.4(graphql@16.13.2)(typescript@5.2.2))(graphql@16.13.2)(typescript@5.2.2)':
     dependencies:
-      graphql: 16.9.0
+      '@0no-co/graphqlsp': 1.15.4(graphql@16.13.2)(typescript@5.2.2)
+      '@gql.tada/internal': 1.0.9(graphql@16.13.2)(typescript@5.2.2)
+      graphql: 16.13.2
+      typescript: 5.2.2
+
+  '@gql.tada/internal@1.0.9(graphql@16.13.2)(typescript@5.2.2)':
+    dependencies:
+      '@0no-co/graphql.web': 1.2.0(graphql@16.13.2)
+      graphql: 16.13.2
+      typescript: 5.2.2
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.13.2)':
+    dependencies:
+      graphql: 16.13.2
 
   '@grpc/grpc-js@1.14.3':
     dependencies:
@@ -18673,7 +18790,7 @@ snapshots:
 
   '@lens-protocol/api-bindings@0.12.3(@apollo/client@3.11.8(@types/react@18.2.48)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@apollo/client': 3.11.8(@types/react@18.2.48)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.11.8(@types/react@18.2.48)(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lens-protocol/domain': 0.12.0
       '@lens-protocol/shared-kernel': 0.12.0
       graphql: 16.9.0
@@ -18740,7 +18857,7 @@ snapshots:
 
   '@lens-protocol/react@2.3.1(@types/react@18.2.48)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10)':
     dependencies:
-      '@apollo/client': 3.11.8(@types/react@18.2.48)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.11.8(@types/react@18.2.48)(graphql@16.13.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ethersproject/abstract-signer': 5.7.0
       '@ethersproject/address': 5.7.0
       '@ethersproject/bignumber': 5.7.0
@@ -19100,6 +19217,37 @@ snapshots:
 
   '@multiformats/base-x@4.0.1': {}
 
+  '@mysten/bcs@2.0.3':
+    dependencies:
+      '@mysten/utils': 0.3.1
+      '@scure/base': 2.2.0
+
+  '@mysten/sui@2.16.0(typescript@5.2.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@mysten/bcs': 2.0.3
+      '@mysten/utils': 0.3.1
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@protobuf-ts/grpcweb-transport': 2.11.1
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      '@scure/base': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      gql.tada: 1.9.2(graphql@16.13.2)(typescript@5.2.2)
+      graphql: 16.13.2
+      poseidon-lite: 0.2.1
+      valibot: 1.3.1(typescript@5.2.2)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+
+  '@mysten/utils@0.3.1':
+    dependencies:
+      '@scure/base': 2.2.0
+
   '@near-js/crypto@1.2.0':
     dependencies:
       '@near-js/types': 0.0.4
@@ -19414,6 +19562,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.7.2
 
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
   '@noble/hashes@1.1.5': {}
 
   '@noble/hashes@1.2.0': {}
@@ -19427,6 +19579,8 @@ snapshots:
   '@noble/hashes@1.5.0': {}
 
   '@noble/hashes@1.7.2': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -19834,6 +19988,17 @@ snapshots:
       '@solana/web3.js': 1.95.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       bs58: 4.0.1
       eventemitter3: 4.0.7
+
+  '@protobuf-ts/grpcweb-transport@2.11.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+
+  '@protobuf-ts/runtime@2.11.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -20399,6 +20564,8 @@ snapshots:
 
   '@scure/base@1.2.6': {}
 
+  '@scure/base@2.2.0': {}
+
   '@scure/bip32@1.1.5':
     dependencies:
       '@noble/hashes': 1.2.0
@@ -20422,6 +20589,12 @@ snapshots:
       '@noble/curves': 1.6.0
       '@noble/hashes': 1.5.0
       '@scure/base': 1.1.9
+
+  '@scure/bip32@2.2.0':
+    dependencies:
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@scure/bip39@1.1.0':
     dependencies:
@@ -20447,6 +20620,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.5.0
       '@scure/base': 1.1.9
+
+  '@scure/bip39@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@sentry/browser@7.16.0':
     dependencies:
@@ -21076,7 +21254,7 @@ snapshots:
 
   '@solana/wallet-standard-util@1.1.1':
     dependencies:
-      '@noble/curves': 1.6.0
+      '@noble/curves': 1.8.2
       '@solana/wallet-standard-chains': 1.1.0
       '@solana/wallet-standard-features': 1.2.0
 
@@ -21199,7 +21377,7 @@ snapshots:
 
   '@spruceid/siwe-parser@2.1.2':
     dependencies:
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.7.2
       apg-js: 4.3.0
       uri-js: 4.4.1
       valid-url: 1.0.9
@@ -21465,14 +21643,14 @@ snapshots:
 
   '@superfluid-finance/metadata@https://codeload.github.com/superfluid-finance/metadata/tar.gz/bdcccf7d484e09efc1ac17adf4bdf2068404103d': {}
 
-  '@superfluid-finance/sdk-core@0.5.9(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(graphql@16.9.0)(typescript@5.2.2)(utf-8-validate@5.0.10)':
+  '@superfluid-finance/sdk-core@0.5.9(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(encoding@0.1.13)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(graphql@16.13.2)(typescript@5.2.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@superfluid-finance/ethereum-contracts': 1.4.3(@openzeppelin/test-helpers@0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@superfluid-finance/metadata': https://codeload.github.com/superfluid-finance/metadata/tar.gz/bdcccf7d484e09efc1ac17adf4bdf2068404103d
       browserify: 17.0.0
       ethers: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      graphql: 16.9.0
-      graphql-request: 4.3.0(encoding@0.1.13)(graphql@16.9.0)
+      graphql: 16.13.2
+      graphql-request: 4.3.0(encoding@0.1.13)(graphql@16.13.2)
       lodash: 4.17.21
       tsify: 5.0.4(browserify@17.0.0)(typescript@5.2.2)
     transitivePeerDependencies:
@@ -24908,7 +25086,7 @@ snapshots:
 
   bs58check@4.0.0:
     dependencies:
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.7.2
       bs58: 6.0.0
 
   bser@2.1.1:
@@ -24967,7 +25145,7 @@ snapshots:
 
   c32check@2.0.0:
     dependencies:
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.7.2
       base-x: 4.0.0
 
   cacheable-lookup@5.0.4: {}
@@ -25947,9 +26125,9 @@ snapshots:
   did-jwt@7.4.7:
     dependencies:
       '@noble/ciphers': 0.4.1
-      '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
-      '@scure/base': 1.1.9
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
+      '@scure/base': 1.2.6
       canonicalize: 2.0.0
       did-resolver: 4.1.0
       multibase: 4.0.6
@@ -27981,25 +28159,44 @@ snapshots:
       to-readable-stream: 1.0.0
       url-parse-lax: 3.0.0
 
+  gql.tada@1.9.2(graphql@16.13.2)(typescript@5.2.2):
+    dependencies:
+      '@0no-co/graphql.web': 1.2.0(graphql@16.13.2)
+      '@0no-co/graphqlsp': 1.15.4(graphql@16.13.2)(typescript@5.2.2)
+      '@gql.tada/cli-utils': 1.7.3(@0no-co/graphqlsp@1.15.4(graphql@16.13.2)(typescript@5.2.2))(graphql@16.13.2)(typescript@5.2.2)
+      '@gql.tada/internal': 1.0.9(graphql@16.13.2)(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - graphql
+
   graceful-fs@4.2.11: {}
 
   grapheme-splitter@1.0.4: {}
 
   graphemer@1.4.0: {}
 
-  graphql-request@4.3.0(encoding@0.1.13)(graphql@16.9.0):
+  graphql-request@4.3.0(encoding@0.1.13)(graphql@16.13.2):
     dependencies:
       cross-fetch: 3.1.8(encoding@0.1.13)
       extract-files: 9.0.0
       form-data: 3.0.1
-      graphql: 16.9.0
+      graphql: 16.13.2
     transitivePeerDependencies:
       - encoding
+
+  graphql-tag@2.12.6(graphql@16.13.2):
+    dependencies:
+      graphql: 16.13.2
+      tslib: 2.8.1
 
   graphql-tag@2.12.6(graphql@16.9.0):
     dependencies:
       graphql: 16.9.0
       tslib: 2.8.1
+
+  graphql@16.13.2: {}
 
   graphql@16.9.0: {}
 
@@ -29342,7 +29539,7 @@ snapshots:
 
   jsontokens@4.0.1:
     dependencies:
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.7.2
       '@noble/secp256k1': 1.7.1
       base64-js: 1.5.1
 
@@ -30466,7 +30663,7 @@ snapshots:
 
   multihashes-sync@1.1.3:
     dependencies:
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.7.2
       multiformats: 11.0.2
 
   multihashes@0.4.21:
@@ -31212,6 +31409,8 @@ snapshots:
   pngjs@5.0.0: {}
 
   pony-cause@2.1.10: {}
+
+  poseidon-lite@0.2.1: {}
 
   possible-typed-array-names@1.0.0: {}
 
@@ -33807,6 +34006,10 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 1.9.0
       source-map: 0.7.4
+
+  valibot@1.3.1(typescript@5.2.2):
+    optionalDependencies:
+      typescript: 5.2.2
 
   valid-url@1.0.9: {}
 

--- a/supabase/migrations/20260503212000_add_sui_ref_chain.sql
+++ b/supabase/migrations/20260503212000_add_sui_ref_chain.sql
@@ -1,0 +1,29 @@
+insert into public.ref_chains (
+  chain_key,
+  display_name,
+  chain_family,
+  native_asset_symbol,
+  public_address_label,
+  address_case_sensitive,
+  supports_custodial_generation,
+  metadata
+) values (
+  'sui',
+  'Sui',
+  'sui',
+  'SUI',
+  'address',
+  false,
+  true,
+  '{"keyType":"ed25519","addressFormat":"hex","privateKeyFormat":"suiprivkey"}'::jsonb
+)
+on conflict (chain_key) do update
+set
+  display_name = excluded.display_name,
+  chain_family = excluded.chain_family,
+  native_asset_symbol = excluded.native_asset_symbol,
+  public_address_label = excluded.public_address_label,
+  address_case_sensitive = excluded.address_case_sensitive,
+  supports_custodial_generation = excluded.supports_custodial_generation,
+  metadata = excluded.metadata,
+  updated_at = now();

--- a/supabase/migrations/20260503212500_quarantine_public_dapp_user_secrets.sql
+++ b/supabase/migrations/20260503212500_quarantine_public_dapp_user_secrets.sql
@@ -1,0 +1,31 @@
+revoke all on table public.dapp_user_secrets from public;
+revoke all on table public.dapp_user_secrets from anon;
+revoke all on table public.dapp_user_secrets from authenticated;
+revoke all on sequence public.dapp_user_secrets_id_seq from public;
+revoke all on sequence public.dapp_user_secrets_id_seq from anon;
+revoke all on sequence public.dapp_user_secrets_id_seq from authenticated;
+
+revoke all on table public.dapp_user_secrets from service_role;
+grant select on table public.dapp_user_secrets to service_role;
+
+revoke all on sequence public.dapp_user_secrets_id_seq from service_role;
+
+create or replace function public.reject_public_dapp_user_secrets_writes()
+returns trigger
+language plpgsql
+as $$
+begin
+  raise exception 'public.dapp_user_secrets is quarantined; use private.dapp_user_secrets via /api/v3/save_secret'
+    using errcode = '42501';
+end;
+$$;
+
+drop trigger if exists reject_public_dapp_user_secrets_writes
+  on public.dapp_user_secrets;
+
+create trigger reject_public_dapp_user_secrets_writes
+before insert or update or delete on public.dapp_user_secrets
+for each row execute function public.reject_public_dapp_user_secrets_writes();
+
+comment on table public.dapp_user_secrets is
+  'Quarantined legacy plaintext dapp-user-secret table. Retained only for service-role backfill/audit reads; new writes must use private.dapp_user_secrets through API v3.';

--- a/supabase/migrations/20260503212500_quarantine_public_dapp_user_secrets.sql
+++ b/supabase/migrations/20260503212500_quarantine_public_dapp_user_secrets.sql
@@ -10,7 +10,7 @@ grant select on table public.dapp_user_secrets to service_role;
 
 revoke all on sequence public.dapp_user_secrets_id_seq from service_role;
 
-create or replace function public.reject_public_dapp_user_secrets_writes()
+create or replace function public.reject_public_dapp_user_secrets_mutations()
 returns trigger
 language plpgsql
 as $$
@@ -22,10 +22,12 @@ $$;
 
 drop trigger if exists reject_public_dapp_user_secrets_writes
   on public.dapp_user_secrets;
+drop trigger if exists reject_public_dapp_user_secrets_mutations
+  on public.dapp_user_secrets;
 
-create trigger reject_public_dapp_user_secrets_writes
-before insert or update or delete on public.dapp_user_secrets
-for each row execute function public.reject_public_dapp_user_secrets_writes();
+create trigger reject_public_dapp_user_secrets_mutations
+before insert or update on public.dapp_user_secrets
+for each row execute function public.reject_public_dapp_user_secrets_mutations();
 
 comment on table public.dapp_user_secrets is
-  'Quarantined legacy plaintext dapp-user-secret table. Retained only for service-role backfill/audit reads; new writes must use private.dapp_user_secrets through API v3.';
+  'Quarantined legacy plaintext dapp-user-secret table. Retained only for service-role backfill/audit reads and cascaded cleanup deletes; new writes must use private.dapp_user_secrets through API v3.';


### PR DESCRIPTION
## Summary
- Adds Sui support to API v3 custodial blockchain account generation and listing.
- Quarantines the legacy plaintext dapp-user-secret write path so new secret writes must use encrypted API v3 custody.
- Updates Passport tests, Supabase migrations, custody docs, and roadmap/session metadata.
- Leaves SDK implementation out of this repo and creates handoff notes for the public SDK agents.

## Objective
Finish the remaining C05 custody follow-ups by expanding v3 blockchain custody to Sui while reducing plaintext dapp-user-secret risk in the legacy public table.

## Changes
- Added `@mysten/sui` to Passport and wired Sui Ed25519 keypair generation into v3 account custody.
- Added Sui `ref_chains` metadata and v3 route schema support for `chain: "sui"`.
- Changed `/api/v2/save_secret` to return `410 endpoint_removed` rather than writing plaintext rows.
- Added a migration that revokes broad access to `public.dapp_user_secrets`, keeps service-role read-only access for backfill/audit, and rejects future public-table writes.
- Updated docs and tests for Sui custody, v3-only secret writes, and non-exposure of private keys/secrets.

## Validation
- `pnpm --filter @cubid/passport typecheck`
- `npx -p node@24 -c 'node --version && pnpm --filter @cubid/passport test'`
- `pnpm --filter @cubid/passport build`
- `git diff --check`

## Reviewer Notes
- Review the migrations first, especially the public dapp-user-secret quarantine trigger and Sui `ref_chains` metadata.
- The `/api/v2/save_secret` behavior change is intentionally breaking for legacy plaintext secret-write callers.
- `public.dapp_user_secrets` is not dropped in this PR; historical rows remain for service-role backfill/audit reads.
- `@mysten/sui` is added only to the Passport backend workspace, not to public SDK packages in this repo.

## Follow-ups
- Public SDK agents need to consume the handoff notes for Sui custody and the v2 save-secret removal.
- Physically remove the legacy public table only after production backfill, audit, and retention/export decisions are complete.
