### PR TITLE
[codex] Add SIWC custody and signing foundation

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4992,3 +4992,30 @@ Create the production-readiness runbook for operating SIWC app-scoped custody an
 #### Follow-up
 
 - close `SIWC08` metadata with the implementation commit SHA and reconcile the parent SIWC roadmap status
+
+### session: v175
+
+- timestamp: 2026-05-06T11:49:35Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`969385a`**
+- session name: **Close SIWC08 and SIWC roadmap**
+
+#### Objective
+
+Close the completed SIWC production-readiness runbook todo and reconcile the parent SIWC roadmap status.
+
+#### Actions Taken
+
+- marked `SIWC08` completed in both the main roadmap and SIWC side roadmap
+- recorded implementation head `969385a` for the SIWC custody and signing runbook
+- marked the parent `SIWC` roadmap completed now that SIWC01 through SIWC08 are closed
+- updated the SIWC side-roadmap truth statement so it reflects the delivered signing foundation and deferred transaction/smart-account work
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- yeet the SIWC roadmap branch for review, or start a new follow-up track for transaction signing readiness after review

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4713,3 +4713,29 @@ Add Passport user-facing visibility for app-scoped custody accounts without expo
 #### Follow-up
 
 - close `SIWC03` metadata with the implementation commit SHA, then immediately start `SIWC04`
+
+### session: v165
+
+- timestamp: 2026-05-06T08:31:22Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`774cd64`**
+- session name: **Close SIWC03 and start SIWC04**
+
+#### Objective
+
+Close the completed SIWC Passport account-visibility todo and immediately start the v3 signing request lifecycle todo.
+
+#### Actions Taken
+
+- marked `SIWC03` completed in both the main roadmap and SIWC side roadmap
+- recorded implementation head `774cd64` for `SIWC03`
+- marked `SIWC04` started on `codex/siwc-roadmap-cleanup`
+
+#### Verification
+
+- planned docs-only validation with `git diff --check`
+
+#### Follow-up
+
+- implement `SIWC04` by adding the backend signing request lifecycle guarded by Admin policy and Passport approval

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4966,3 +4966,29 @@ Close the completed SIWC smart-account roadmap evaluation and immediately start 
 #### Follow-up
 
 - implement `SIWC08` by building the production-readiness runbook for SIWC custody and signing
+
+### session: v174
+
+- timestamp: 2026-05-06T11:47:17Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`88203ac`**
+- session name: **Implement SIWC08 custody signing runbook**
+
+#### Objective
+
+Create the production-readiness runbook for operating SIWC app-scoped custody and signing safely.
+
+#### Actions Taken
+
+- added a dedicated SIWC custody and signing production runbook
+- documented custody exposure boundaries, Vault prerequisites, migration readiness, Admin policy operations, signing request triage, webhook operations, smoke tests, abuse monitoring, incident response, user support, and launch blockers
+- updated the SIWC architecture status to point at the runbook closeout state
+
+#### Verification
+
+- planned docs-only validation with `git diff --check`
+
+#### Follow-up
+
+- close `SIWC08` metadata with the implementation commit SHA and reconcile the parent SIWC roadmap status

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4626,3 +4626,34 @@ Close the completed SIWC signing-architecture todo and immediately start the nex
 #### Follow-up
 
 - implement `SIWC02` by designing and adding Admin policy controls for app-scoped custody and signing
+
+### session: v162
+
+- timestamp: 2026-05-05T23:41:16Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`4f9fb04`**
+- session name: **Implement SIWC02 Admin policy controls**
+
+#### Objective
+
+Implement the Admin control-plane slice for app-scoped custody and signing policies without adding signing execution.
+
+#### Actions Taken
+
+- added the `siwc_signing_policies` migration with fail-closed defaults and service-role-only access
+- added Admin SIWC policy list/upsert APIs using the shared Admin API baseline
+- added Admin SIWC policy repository helpers, schemas, tests, and audit-event writing
+- added the `SIWC Policy` Admin tab for custody/signing policy visibility and editing
+- documented the concrete SIWC02 policy contract in the signing architecture doc
+
+#### Verification
+
+- `pnpm --filter @cubid/admin test`
+- `pnpm --filter @cubid/admin typecheck`
+- `pnpm --filter @cubid/admin build`
+- `git diff --check`
+
+#### Follow-up
+
+- close `SIWC02` metadata with the implementation commit SHA, then immediately start `SIWC03`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4600,3 +4600,29 @@ Promote `SIWC01` from the SIWC side-roadmap into the main roadmap and define the
 #### Follow-up
 
 - close `SIWC01` metadata with the implementation commit SHA, then immediately start `SIWC02`
+
+### session: v161
+
+- timestamp: 2026-05-05T01:23:41Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`008934d`**
+- session name: **Close SIWC01 and start SIWC02**
+
+#### Objective
+
+Close the completed SIWC signing-architecture todo and immediately start the next SIWC policy-control todo.
+
+#### Actions Taken
+
+- marked `SIWC01` completed in both the main roadmap and the SIWC side roadmap
+- recorded implementation head `008934d` for `SIWC01`
+- marked `SIWC02` started on `codex/siwc-roadmap-cleanup`
+
+#### Verification
+
+- planned docs-only validation with `git diff --check`
+
+#### Follow-up
+
+- implement `SIWC02` by designing and adding Admin policy controls for app-scoped custody and signing

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4683,3 +4683,33 @@ Close the completed SIWC Admin policy-control todo and immediately start the nex
 #### Follow-up
 
 - implement `SIWC03` by adding Passport user-facing visibility for app-scoped custody accounts without exposing private or encrypted custody material
+
+### session: v164
+
+- timestamp: 2026-05-06T08:30:48Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`4203c6c`**
+- session name: **Implement SIWC03 Passport account visibility**
+
+#### Objective
+
+Add Passport user-facing visibility for app-scoped custody accounts without exposing private or encrypted custody material.
+
+#### Actions Taken
+
+- added an authenticated Passport SIWC account visibility helper and `POST /api/siwc/accounts/list`
+- added a Profile `App-scoped accounts` card showing app, chain, public address, custody/signing policy status, and timestamps
+- extended Passport tests and mocks for user-owned account visibility, policy metadata, empty state, auth failure, and secret redaction
+- documented the SIWC03 visibility contract in `docs/engineering/siwc-v3-signing-architecture.md`
+
+#### Verification
+
+- `npx -y -p node@24 -p pnpm@10.33.0 pnpm --filter @cubid/passport test`
+- `npx -y -p node@24 -p pnpm@10.33.0 pnpm --filter @cubid/passport typecheck`
+- `npx -y -p node@24 -p pnpm@10.33.0 pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- close `SIWC03` metadata with the implementation commit SHA, then immediately start `SIWC04`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4657,3 +4657,29 @@ Implement the Admin control-plane slice for app-scoped custody and signing polic
 #### Follow-up
 
 - close `SIWC02` metadata with the implementation commit SHA, then immediately start `SIWC03`
+
+### session: v163
+
+- timestamp: 2026-05-05T23:41:40Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`a968016`**
+- session name: **Close SIWC02 and start SIWC03**
+
+#### Objective
+
+Close the completed SIWC Admin policy-control todo and immediately start the next Passport account-visibility todo.
+
+#### Actions Taken
+
+- marked `SIWC02` completed in both the main roadmap and SIWC side roadmap
+- recorded implementation head `a968016` for `SIWC02`
+- marked `SIWC03` started on `codex/siwc-roadmap-cleanup`
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- implement `SIWC03` by adding Passport user-facing visibility for app-scoped custody accounts without exposing private or encrypted custody material

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -5047,3 +5047,31 @@ Address the automated review finding that SIWC policy listing exposed all dapps 
 #### Follow-up
 
 - push the review fix, comment on and resolve the PR review thread, then re-check CI
+
+### session: v177
+
+- timestamp: 2026-05-06T12:04:27Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`84c3969`**
+- session name: **Address PR 159 Copilot wording comments**
+
+#### Objective
+
+Address Copilot review feedback about stale SIWC architecture and Profile copy.
+
+#### Actions Taken
+
+- updated the SIWC architecture intro to reflect that signing routes and Admin policy controls now exist
+- changed the API surface section from future/candidate language to implemented route language
+- removed the stale `pending_policy` state from the documented state machine
+- updated Profile copy so users are not told signing requests are unavailable while the signing request card is live
+
+#### Verification
+
+- planned docs/UI copy validation with `git diff --check`
+- planned focused validation with `pnpm --filter @cubid/passport typecheck`
+
+#### Follow-up
+
+- push the wording fix, reply to and resolve Copilot threads, then re-check CI

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4771,3 +4771,29 @@ Implement the first API v3 signing request lifecycle with Admin policy checks, P
 #### Follow-up
 
 - close `SIWC04` metadata with the implementation commit SHA, then immediately start `SIWC05`
+
+### session: v167
+
+- timestamp: 2026-05-06T08:57:01Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`a41f6ee`**
+- session name: **Close SIWC04 and start SIWC05**
+
+#### Objective
+
+Close the completed SIWC signing request lifecycle todo and immediately start the transaction-risk and policy-hardening follow-up.
+
+#### Actions Taken
+
+- marked `SIWC04` completed in both the main roadmap and SIWC side roadmap
+- recorded implementation head `a41f6ee` for `SIWC04`
+- marked `SIWC05` started on `codex/siwc-roadmap-cleanup`
+
+#### Verification
+
+- planned docs-only validation with `git diff --check`
+
+#### Follow-up
+
+- implement `SIWC05` by adding transaction risk summaries, stricter policy evaluation, and passkey step-up hardening before enabling transaction signing

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4860,7 +4860,7 @@ Close the completed SIWC transaction-risk todo and immediately start the signing
 - timestamp: 2026-05-06T10:24:29Z
 - agent: **OpenAI Codex**
 - branch: **codex/siwc-roadmap-cleanup**
-- head: **`55fb0ca`**
+- head: **`82fcdd6`**
 - session name: **Implement SIWC06 signing webhook contracts**
 
 #### Objective
@@ -4886,3 +4886,29 @@ Extend the API v3 webhook contract to cover app-scoped custody and SIWC signing 
 #### Follow-up
 
 - close `SIWC06` metadata with the implementation commit SHA, then start `SIWC07`
+
+### session: v171
+
+- timestamp: 2026-05-06T10:25:43Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`82fcdd6`**
+- session name: **Close SIWC06 and start SIWC07**
+
+#### Objective
+
+Close the SIWC webhook contract todo after validation and immediately start the smart-account/session-key/paymaster roadmap follow-up.
+
+#### Actions Taken
+
+- marked `SIWC06` completed in both the main roadmap and SIWC side roadmap
+- recorded implementation head `82fcdd6` for the wallet/signing webhook contract work
+- marked `SIWC07` started on `codex/siwc-roadmap-cleanup`
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- implement `SIWC07` by evaluating smart accounts, session keys, and paymaster/gas sponsorship against Cubid's app-scoped custody model

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -5075,3 +5075,30 @@ Address Copilot review feedback about stale SIWC architecture and Profile copy.
 #### Follow-up
 
 - push the wording fix, reply to and resolve Copilot threads, then re-check CI
+
+### session: v178
+
+- timestamp: 2026-05-06T12:07:38Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`855eebd`**
+- session name: **Fix PR 159 Admin route test after SIWC policy scoping**
+
+#### Objective
+
+Fix the CI failure caused by the Admin route wiring test still expecting the old SIWC policy list helper signature.
+
+#### Actions Taken
+
+- updated the SIWC policy list route test to provide and expect the Admin request context
+- kept the ownership-scoped runtime behavior introduced for the review fix
+
+#### Verification
+
+- planned focused validation with `pnpm --filter @cubid/admin test -- adminRoutes`
+- planned follow-up validation with `pnpm --filter @cubid/admin typecheck`
+- `git diff --check`
+
+#### Follow-up
+
+- push the CI fix and confirm PR checks return green

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4546,3 +4546,30 @@ Address the remaining Copilot review comments on PR 158 after the first removed-
 #### Follow-up
 
 - commit and push the Copilot fixes, reply to and resolve all review threads, then re-check CI
+
+### session: v159
+
+- timestamp: 2026-05-05T01:18:01Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`2bb7eda`**
+- session name: **Specialize SIWC roadmap**
+
+#### Objective
+
+Keep the SIWC side-roadmap while replacing generic competitive guidance with repo-specific, metadata-backed todos.
+
+#### Actions Taken
+
+- rewrote `agent-context/siwc-todo.md` around current OIDC, passkey, disclosure, API v3 custody, and SDK-boundary reality
+- added SIWC01-SIWC08 open todos with standard metadata blocks
+- preserved the product positioning while marking implemented, different, and deferred work clearly
+
+#### Verification
+
+- `git diff --check`
+- `git status --short`
+
+#### Follow-up
+
+- yeet the docs branch for review, then consider metadata-normalizing `C02` in `agent-context/todo.md`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4940,3 +4940,29 @@ Evaluate smart accounts, scoped session keys, and paymaster/gas sponsorship agai
 #### Follow-up
 
 - close `SIWC07` metadata with the implementation commit SHA, then start `SIWC08`
+
+### session: v173
+
+- timestamp: 2026-05-06T10:40:40Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`e3fec1a`**
+- session name: **Close SIWC07 and start SIWC08**
+
+#### Objective
+
+Close the completed SIWC smart-account roadmap evaluation and immediately start the production-readiness runbook follow-up.
+
+#### Actions Taken
+
+- marked `SIWC07` completed in both the main roadmap and SIWC side roadmap
+- recorded implementation head `e3fec1a` for the smart-account/session-key/paymaster recommendation
+- marked `SIWC08` started on `codex/siwc-roadmap-cleanup`
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- implement `SIWC08` by building the production-readiness runbook for SIWC custody and signing

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4797,3 +4797,34 @@ Close the completed SIWC signing request lifecycle todo and immediately start th
 #### Follow-up
 
 - implement `SIWC05` by adding transaction risk summaries, stricter policy evaluation, and passkey step-up hardening before enabling transaction signing
+
+### session: v168
+
+- timestamp: 2026-05-06T09:22:05Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`12f2d3f`**
+- session name: **Implement SIWC05 transaction risk controls**
+
+#### Objective
+
+Add transaction risk summaries, stricter policy evidence, and fresh passkey step-up checks before any SIWC transaction signing is enabled.
+
+#### Actions Taken
+
+- added service-role-only signing request risk metadata for risk level, risk reasons, policy decision, transaction recipient/contract/value, and step-up requirement
+- added conservative transaction risk evaluation for EVM transaction payloads and fail-closed unsupported-chain handling for NEAR, Solana, and Sui transactions
+- enforced transaction value limits and contract allowlists in policy denial details while keeping all transaction signing disabled
+- hardened Passport signing approval so passkey ACR sessions must be fresh and step-up failures are audited
+- updated Profile signing-request visibility, SIWC/API v3 docs, Passport tests, and the public SDK handoff note
+
+#### Verification
+
+- `npx -p node@24 node $(which pnpm) --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `npx -p node@24 node $(which pnpm) --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- close `SIWC05` metadata with the implementation commit SHA, then start `SIWC06`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4854,3 +4854,35 @@ Close the completed SIWC transaction-risk todo and immediately start the signing
 #### Follow-up
 
 - implement `SIWC06` by standardizing signing and wallet webhook contracts with SDK handoff notes
+
+### session: v170
+
+- timestamp: 2026-05-06T10:24:29Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`55fb0ca`**
+- session name: **Implement SIWC06 signing webhook contracts**
+
+#### Objective
+
+Extend the API v3 webhook contract to cover app-scoped custody and SIWC signing lifecycle events without enabling transaction signing.
+
+#### Actions Taken
+
+- added canonical SIWC wallet webhook event names and seeded them into `webhook_types`
+- added a shared SIWC webhook delivery helper that reuses v3 payloads, signatures, delivery attempts, encrypted webhook secrets, and best-effort failure handling
+- emitted wallet/signing webhooks from account generation, signing request creation, policy denial, approval, rejection, cancellation, step-up failure, and signature completion/failure paths
+- updated Admin SIWC policy event choices, API v3/SIWC docs, Passport route tests, and the public SDK handoff note
+
+#### Verification
+
+- `npx -p node@24 node $(which pnpm) --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/admin typecheck`
+- `npx -p node@24 node $(which pnpm) --filter @cubid/passport build`
+- `npx -p node@24 node $(which pnpm) --filter @cubid/admin build`
+- `git diff --check`
+
+#### Follow-up
+
+- close `SIWC06` metadata with the implementation commit SHA, then start `SIWC07`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4828,3 +4828,29 @@ Add transaction risk summaries, stricter policy evidence, and fresh passkey step
 #### Follow-up
 
 - close `SIWC05` metadata with the implementation commit SHA, then start `SIWC06`
+
+### session: v169
+
+- timestamp: 2026-05-06T09:22:33Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`313f4a5`**
+- session name: **Close SIWC05 and start SIWC06**
+
+#### Objective
+
+Close the completed SIWC transaction-risk todo and immediately start the signing/webhook contract follow-up.
+
+#### Actions Taken
+
+- marked `SIWC05` completed in both the main roadmap and SIWC side roadmap
+- recorded implementation head `313f4a5` for `SIWC05`
+- marked `SIWC06` started on `codex/siwc-roadmap-cleanup`
+
+#### Verification
+
+- planned docs-only validation with `git diff --check`
+
+#### Follow-up
+
+- implement `SIWC06` by standardizing signing and wallet webhook contracts with SDK handoff notes

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4573,3 +4573,30 @@ Keep the SIWC side-roadmap while replacing generic competitive guidance with rep
 #### Follow-up
 
 - yeet the docs branch for review, then consider metadata-normalizing `C02` in `agent-context/todo.md`
+
+### session: v160
+
+- timestamp: 2026-05-05T01:21:18Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`f4fb0c1`**
+- session name: **Promote and implement SIWC01 signing architecture**
+
+#### Objective
+
+Promote `SIWC01` from the SIWC side-roadmap into the main roadmap and define the first target architecture for API v3 signing and transaction authorization.
+
+#### Actions Taken
+
+- added the SIWC execution track and `SIWC01`-`SIWC08` child todos to `agent-context/todo.md`
+- marked `SIWC01` started in both the main roadmap and side roadmap
+- created `docs/engineering/siwc-v3-signing-architecture.md` as the signing and transaction authorization target-state source of truth
+- locked the first implementation direction as phased server-side custodial signing backed by existing Vault-encrypted API v3 private-key custody
+
+#### Verification
+
+- planned docs-only validation with `git diff --check`
+
+#### Follow-up
+
+- close `SIWC01` metadata with the implementation commit SHA, then immediately start `SIWC02`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4912,3 +4912,31 @@ Close the SIWC webhook contract todo after validation and immediately start the 
 #### Follow-up
 
 - implement `SIWC07` by evaluating smart accounts, session keys, and paymaster/gas sponsorship against Cubid's app-scoped custody model
+
+### session: v172
+
+- timestamp: 2026-05-06T10:39:53Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`338d035`**
+- session name: **Implement SIWC07 smart-account roadmap evaluation**
+
+#### Objective
+
+Evaluate smart accounts, scoped session keys, and paymaster/gas sponsorship against Cubid's app-scoped custody model without changing runtime behavior.
+
+#### Actions Taken
+
+- documented that app-scoped generated custody accounts remain the near-term default account mode
+- recommended smart accounts as a future optional EVM-first custody mode rather than a replacement for generated accounts
+- defined session keys as future scoped, revocable child capabilities of app-scoped accounts
+- defined paymasters as a later policy and billing product gated by transaction signing readiness and abuse controls
+- created a public SDK handoff note explaining that future SDK support should use capability discovery
+
+#### Verification
+
+- planned docs-only validation with `git diff --check`
+
+#### Follow-up
+
+- close `SIWC07` metadata with the implementation commit SHA, then start `SIWC08`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -5019,3 +5019,31 @@ Close the completed SIWC production-readiness runbook todo and reconcile the par
 #### Follow-up
 
 - yeet the SIWC roadmap branch for review, or start a new follow-up track for transaction signing readiness after review
+
+### session: v176
+
+- timestamp: 2026-05-06T12:03:10Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`eba25d1`**
+- session name: **Address PR 159 SIWC policy scope review**
+
+#### Objective
+
+Address the automated review finding that SIWC policy listing exposed all dapps instead of scoping to the authenticated admin.
+
+#### Actions Taken
+
+- changed `listSiwcPolicies` to accept the Admin request context and filter `dapps` by `admin_uid`
+- updated the Admin SIWC policy list route to pass the authenticated context
+- added a regression test proving another admin receives no policies for unrelated dapps
+
+#### Verification
+
+- `pnpm --filter @cubid/admin test -- siwcPolicies`
+- planned follow-up validation with `pnpm --filter @cubid/admin typecheck`
+- `git diff --check`
+
+#### Follow-up
+
+- push the review fix, comment on and resolve the PR review thread, then re-check CI

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -4739,3 +4739,35 @@ Close the completed SIWC Passport account-visibility todo and immediately start 
 #### Follow-up
 
 - implement `SIWC04` by adding the backend signing request lifecycle guarded by Admin policy and Passport approval
+
+### session: v166
+
+- timestamp: 2026-05-06T08:56:28Z
+- agent: **OpenAI Codex**
+- branch: **codex/siwc-roadmap-cleanup**
+- head: **`a58b735`**
+- session name: **Implement SIWC04 signing request lifecycle**
+
+#### Objective
+
+Implement the first API v3 signing request lifecycle with Admin policy checks, Passport user approval, passkey ACR enforcement, and safe server-side signing for supported message flows.
+
+#### Actions Taken
+
+- added the `siwc_signing_requests` migration and service-role-only storage contract
+- added dapp-facing API v3 signing request create/get/list/cancel routes with idempotent creation
+- added Passport user-facing signing request list/approve/reject routes and Profile approval visibility
+- implemented policy evaluation, passkey-backed OIDC session step-up checks, encrypted private-key decrypt, and EVM/NEAR/Solana/Sui message signing plus EVM typed-data signing
+- kept transaction signing policy-denied until SIWC05 risk controls
+- updated API v3 and SIWC architecture docs and wrote the public SDK handoff note
+
+#### Verification
+
+- `npx -y -p node@24 -p pnpm@10.33.0 pnpm --filter @cubid/passport test`
+- `npx -y -p node@24 -p pnpm@10.33.0 pnpm --filter @cubid/passport typecheck`
+- `npx -y -p node@24 -p pnpm@10.33.0 pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- close `SIWC04` metadata with the implementation commit SHA, then immediately start `SIWC05`

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -89,23 +89,23 @@ Extend the API v3 webhook contract for app-scoped custody and signing events. Ca
 
 ### SIWC07. Evaluate smart-account, session-key, and paymaster roadmap
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T10:25:43Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T10:40:40Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: 82fcdd6
-- Session-log reference(s): session: v171
+- Head: e3fec1a
+- Session-log reference(s): session: v171, session: v172
 
 Evaluate whether Cubid should support smart accounts, scoped session keys, and paymaster/gas sponsorship after the basic signing lifecycle is secure. This should be a design and sequencing task, not an implementation shortcut. Compare the app-scoped privacy model against user expectations for portable wallets, recovery, gasless onboarding, and asset fragmentation. Decide whether smart accounts should wrap existing app-scoped custodial keys, replace generated EOAs for some chains, or remain a later optional custody mode. Define what would need to change in Admin policy, Passport approval UX, API v3 signing routes, webhook events, and SDK contracts. The output should be a recommendation with explicit "not yet" criteria if the platform is not ready.
 
 ### SIWC08. Build production readiness runbook for SIWC custody and signing
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T10:40:40Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/siwc-roadmap-cleanup
+- Head: e3fec1a
+- Session-log reference(s): session: v173
 
 Create the operator runbook for SIWC custody and signing before exposing signing broadly. The runbook should cover Vault key ownership and rotation, generated-account custody boundaries, migration rollback, audit-log inspection, signing request triage, webhook replay, incident response, abuse monitoring, emergency app suspension, user support, and privacy review for app-scoped account visibility. It should explicitly document what is safe to expose to users and dapps, what is Admin-only, what is service-role-only, and what must never leave server memory. Include local/staging/prod environment requirements, smoke tests, and launch blockers. This todo should close the gap between a technically working signer and an operable platform surface.
 

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -67,23 +67,23 @@ Implement the backend lifecycle for signing requests after SIWC01 chooses the ar
 
 ### SIWC05. Add transaction risk, policy evaluation, and passkey step-up
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T08:57:01Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T09:22:33Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v167
+- Head: 313f4a5
+- Session-log reference(s): session: v167, session: v168
 
 Add the first transaction-policy and risk layer before broad transaction signing is considered production-ready. The initial version can be conservative: human-readable request summaries, chain/account matching, requested operation type, recipient or contract metadata where available, amount thresholds, contract allowlist checks, and mandatory passkey step-up for high-risk requests. The goal is not full transaction simulation across every chain in v1; it is to prevent blind signing from becoming the default. Passport approval screens should make the app, chain, public account, action, and risk posture clear. Admin should be able to configure policy strictness. Failed policy checks, rejected approvals, and passkey step-up failures should be auditable and webhook-eligible.
 
 ### SIWC06. Add signing and wallet webhook contracts plus SDK handoff notes
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T09:22:33Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/siwc-roadmap-cleanup
+- Head: 313f4a5
+- Session-log reference(s): session: v169
 
 Extend the API v3 webhook contract for app-scoped custody and signing events. Candidate events include `wallet.created`, `wallet.signing_request.created`, `wallet.signing_request.approved`, `wallet.signing_request.rejected`, `wallet.signature.completed`, `wallet.transaction.submitted`, `wallet.transaction.failed`, and `wallet.policy.denied`. Payloads must follow the existing API v3 webhook direction: stable event IDs, timestamps, HMAC signatures, replay-safe delivery semantics, retry metadata, and disclosure-safe payloads that do not leak cross-app identifiers or custody secrets. Because these events affect developer-facing SDK behavior, each implemented contract change must create a handoff note in the public SDK repo. Do not add SDK implementation code to `cubid-passport`.
 

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -78,23 +78,23 @@ Add the first transaction-policy and risk layer before broad transaction signing
 
 ### SIWC06. Add signing and wallet webhook contracts plus SDK handoff notes
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T09:22:33Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T10:25:43Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: 313f4a5
-- Session-log reference(s): session: v169
+- Head: 82fcdd6
+- Session-log reference(s): session: v169, session: v170
 
 Extend the API v3 webhook contract for app-scoped custody and signing events. Candidate events include `wallet.created`, `wallet.signing_request.created`, `wallet.signing_request.approved`, `wallet.signing_request.rejected`, `wallet.signature.completed`, `wallet.transaction.submitted`, `wallet.transaction.failed`, and `wallet.policy.denied`. Payloads must follow the existing API v3 webhook direction: stable event IDs, timestamps, HMAC signatures, replay-safe delivery semantics, retry metadata, and disclosure-safe payloads that do not leak cross-app identifiers or custody secrets. Because these events affect developer-facing SDK behavior, each implemented contract change must create a handoff note in the public SDK repo. Do not add SDK implementation code to `cubid-passport`.
 
 ### SIWC07. Evaluate smart-account, session-key, and paymaster roadmap
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T10:25:43Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/siwc-roadmap-cleanup
+- Head: 82fcdd6
+- Session-log reference(s): session: v171
 
 Evaluate whether Cubid should support smart accounts, scoped session keys, and paymaster/gas sponsorship after the basic signing lifecycle is secure. This should be a design and sequencing task, not an implementation shortcut. Compare the app-scoped privacy model against user expectations for portable wallets, recovery, gasless onboarding, and asset fragmentation. Decide whether smart accounts should wrap existing app-scoped custodial keys, replace generated EOAs for some chains, or remain a later optional custody mode. Define what would need to change in Admin policy, Passport approval UX, API v3 signing routes, webhook events, and SDK contracts. The output should be a recommendation with explicit "not yet" criteria if the platform is not ready.
 

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -45,23 +45,23 @@ Add Admin-side controls that let operators configure whether an app may request 
 
 ### SIWC03. Add Passport user-facing app account visibility
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-05T23:41:40Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T08:31:22Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v163
+- Head: 774cd64
+- Session-log reference(s): session: v163, session: v164
 
 Add user-facing visibility for app-scoped custody accounts in Passport, likely inside the existing Profile and disclosure-management surface. Users should be able to see which apps have generated accounts for them, which chain each account belongs to, public addresses, labels, creation dates, custody status, and whether signing is enabled for that app. The UI should reinforce the privacy model: these accounts are scoped to individual apps, and other apps should not be able to correlate them. This slice should not add private-key export, signing, or cross-app wallet portability. It should only make the already-created v3 account metadata understandable and auditable for the human user, with no exposure of private or encrypted custody fields.
 
 ### SIWC04. Implement v3 signing request lifecycle
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T08:31:22Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v165
 
 Implement the backend lifecycle for signing requests after SIWC01 chooses the architecture. Add API v3 routes for creating a signing request, reading request status, approving or rejecting through Passport, and returning the resulting signature or transaction hash when complete. Requests must be app-scoped, dapp-authenticated, idempotent where appropriate, bound to a specific `dapp_user_uuid` and `user_account_id`, and checked against Admin signing policy before user approval. Approval should be hosted in Passport and require passkey step-up when policy or ACR requires it. Responses must never return private keys, raw decrypted material, Vault wrapping keys, or internal human subject keys. All state changes should write audit/security events and be safe to retry.
 

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -23,12 +23,12 @@ The generic recommendation to build new `/api/v2/wallets/*` routes should be rep
 
 ### SIWC01. Define the v3 signing and transaction authorization architecture
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-05T01:21:18Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v160
 
 Design the first decision-complete signing architecture for app-scoped custody accounts. The architecture should decide whether v3 signing starts as server-side custodial signing with Supabase Vault-backed private keys, smart-account signing, a future external signer, or a phased hybrid. It must preserve the separation between authentication credentials and blockchain signing keys: passkeys authorize user intent, while wallet private keys or smart-account signer keys perform blockchain signing. Define the signing request lifecycle, approval state machine, actor model, replay/idempotency requirements, audit events, and which chains are included in the first slice. The design should explicitly say that generated accounts are not enough for SIWC wallet parity until users can safely approve signatures or transactions.
 

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -23,23 +23,23 @@ The generic recommendation to build new `/api/v2/wallets/*` routes should be rep
 
 ### SIWC01. Define the v3 signing and transaction authorization architecture
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-05T01:21:18Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-05T01:23:41Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v160
+- Head: 008934d
+- Session-log reference(s): session: v160, session: v161
 
 Design the first decision-complete signing architecture for app-scoped custody accounts. The architecture should decide whether v3 signing starts as server-side custodial signing with Supabase Vault-backed private keys, smart-account signing, a future external signer, or a phased hybrid. It must preserve the separation between authentication credentials and blockchain signing keys: passkeys authorize user intent, while wallet private keys or smart-account signer keys perform blockchain signing. Define the signing request lifecycle, approval state machine, actor model, replay/idempotency requirements, audit events, and which chains are included in the first slice. The design should explicitly say that generated accounts are not enough for SIWC wallet parity until users can safely approve signatures or transactions.
 
 ### SIWC02. Add Admin policy controls for app-scoped account custody and signing
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-05T01:23:41Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v161
 
 Add Admin-side controls that let operators configure whether an app may request generated accounts, which chains are enabled, whether signing is enabled, and which approval rules apply. This should extend the existing Admin control-plane pattern rather than creating a separate wallet dashboard. Include fields for allowed chains, custody mode, signing status, allowed signature types, transaction limits, optional contract allowlists, required passkey ACR, webhook event subscriptions, and sandbox/production behavior. Admin list/detail views must not expose private keys, ciphertext, wrapped data keys, Vault key material, or cross-app user identifiers. This todo should also decide how policy names and versions are surfaced to API v3 responses and audit logs.
 

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -34,23 +34,23 @@ Design the first decision-complete signing architecture for app-scoped custody a
 
 ### SIWC02. Add Admin policy controls for app-scoped account custody and signing
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-05T01:23:41Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-05T23:41:40Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v161
+- Head: a968016
+- Session-log reference(s): session: v161, session: v162, session: v163
 
 Add Admin-side controls that let operators configure whether an app may request generated accounts, which chains are enabled, whether signing is enabled, and which approval rules apply. This should extend the existing Admin control-plane pattern rather than creating a separate wallet dashboard. Include fields for allowed chains, custody mode, signing status, allowed signature types, transaction limits, optional contract allowlists, required passkey ACR, webhook event subscriptions, and sandbox/production behavior. Admin list/detail views must not expose private keys, ciphertext, wrapped data keys, Vault key material, or cross-app user identifiers. This todo should also decide how policy names and versions are surfaced to API v3 responses and audit logs.
 
 ### SIWC03. Add Passport user-facing app account visibility
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-05T23:41:40Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v163
 
 Add user-facing visibility for app-scoped custody accounts in Passport, likely inside the existing Profile and disclosure-management surface. Users should be able to see which apps have generated accounts for them, which chain each account belongs to, public addresses, labels, creation dates, custody status, and whether signing is enabled for that app. The UI should reinforce the privacy model: these accounts are scoped to individual apps, and other apps should not be able to correlate them. This slice should not add private-key export, signing, or cross-app wallet portability. It should only make the already-created v3 account metadata understandable and auditable for the human user, with no exposure of private or encrypted custody fields.
 

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -10,7 +10,7 @@ Source note: this file replaces a generic competitor-research implementation gui
 - Passkey work is already substantially implemented: Passport login UX, fallback/recovery framing, passkey registration, device lifecycle, rename/revoke, Profile visibility, Admin read-only passkey ops, and passkey-required ACR semantics exist.
 - App-scoped identity and selective disclosure are now first-class backend concepts: app-scoped subjects, disclosure grants, Allow Page persistence, OIDC consent persistence, SDK-facing route filtering, webhook filtering, non-OIDC disclosure history/revocation, and Admin disclosure ops exist.
 - API v3 custody exists for encrypted dapp-user secrets and generated app-scoped blockchain accounts across EVM, NEAR, Solana, and Sui. Private material is stored through Supabase Vault-backed envelope encryption and is not returned to dapps, browsers, or Admin list views.
-- The important SIWC product gap is signing. Generated app-scoped accounts can be created and listed, but Cubid does not yet expose message signing, transaction approval, signing policy evaluation, signer recovery, transaction simulation, or smart-account/session-key flows.
+- The SIWC backend foundation now includes app-scoped account generation/listing, Admin signing policy controls, Passport account visibility, message and typed-data signing requests, passkey step-up, transaction-risk denial evidence, signed wallet webhooks, and an operator runbook. Transaction signing, signer recovery, transaction simulation, smart accounts, session keys, and paymasters remain deferred.
 - Public SDK and UI package implementation belongs in `Cubid-Me/cubid-sdk`, not this repo. This repo owns backend behavior, migrations, Passport/Admin/OIDC runtime, API/webhook contracts, and handoff notes for SDK agents.
 
 ## Recommended Direction
@@ -100,12 +100,12 @@ Evaluate whether Cubid should support smart accounts, scoped session keys, and p
 
 ### SIWC08. Build production readiness runbook for SIWC custody and signing
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T10:40:40Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T11:49:35Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: e3fec1a
-- Session-log reference(s): session: v173
+- Head: 969385a
+- Session-log reference(s): session: v173, session: v174
 
 Create the operator runbook for SIWC custody and signing before exposing signing broadly. The runbook should cover Vault key ownership and rotation, generated-account custody boundaries, migration rollback, audit-log inspection, signing request triage, webhook replay, incident response, abuse monitoring, emergency app suspension, user support, and privacy review for app-scoped account visibility. It should explicitly document what is safe to expose to users and dapps, what is Admin-only, what is service-role-only, and what must never leave server memory. Include local/staging/prod environment requirements, smoke tests, and launch blockers. This todo should close the gap between a technically working signer and an operable platform surface.
 

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -1,0 +1,126 @@
+# SIWC Roadmap: Sign In With Cubid
+
+Sign In With Cubid is the passkey-first, privacy-preserving, app-scoped identity and wallet-adjacent platform layer for Cubid. The product should combine OIDC login, hosted Passport UX, Admin policy controls, app-scoped identity, selective disclosure, proof-of-personhood signals, and optional app-scoped custody accounts without becoming a generic embedded-wallet clone.
+
+Source note: this file replaces a generic competitor-research implementation guide with a repo-grounded side roadmap. It should stay separate from `agent-context/todo.md` until the team chooses which SIWC work to promote into the main execution backlog.
+
+## Current Repo Truth
+
+- OIDC issuer work is already substantially implemented: dynamic registration, Authorization Code + PKCE, `/token`, `/userinfo`, JWKS, revoke/logout, pairwise subjects, passkey ACR, TCOIN-oriented seed/config artifacts, and issuer operations views exist in the monorepo.
+- Passkey work is already substantially implemented: Passport login UX, fallback/recovery framing, passkey registration, device lifecycle, rename/revoke, Profile visibility, Admin read-only passkey ops, and passkey-required ACR semantics exist.
+- App-scoped identity and selective disclosure are now first-class backend concepts: app-scoped subjects, disclosure grants, Allow Page persistence, OIDC consent persistence, SDK-facing route filtering, webhook filtering, non-OIDC disclosure history/revocation, and Admin disclosure ops exist.
+- API v3 custody exists for encrypted dapp-user secrets and generated app-scoped blockchain accounts across EVM, NEAR, Solana, and Sui. Private material is stored through Supabase Vault-backed envelope encryption and is not returned to dapps, browsers, or Admin list views.
+- The important SIWC product gap is signing. Generated app-scoped accounts can be created and listed, but Cubid does not yet expose message signing, transaction approval, signing policy evaluation, signer recovery, transaction simulation, or smart-account/session-key flows.
+- Public SDK and UI package implementation belongs in `Cubid-Me/cubid-sdk`, not this repo. This repo owns backend behavior, migrations, Passport/Admin/OIDC runtime, API/webhook contracts, and handoff notes for SDK agents.
+
+## Recommended Direction
+
+Keep Login with Cubid centered on standards and privacy: OIDC for sign-in, Passport for hosted human auth and consent UX, Admin for policy and client control, and API v3 for backend app integration. Treat wallets/accounts as app-scoped custody accounts by default, not universal identities. The strongest Cubid positioning is not "Privy or Magic with different branding"; it is app-scoped identity, passkey-first authentication, proof-of-personhood signals, selective disclosure, and optional app-scoped account custody that avoids cross-app correlation.
+
+The generic recommendation to build new `/api/v2/wallets/*` routes should be replaced with API v3 contracts. Any SDK-visible changes must be coordinated through `Cubid-Me/cubid-sdk` by writing a handoff note in that repo; no new public SDK implementation should be added here.
+
+## Open Todos
+
+### SIWC01. Define the v3 signing and transaction authorization architecture
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Design the first decision-complete signing architecture for app-scoped custody accounts. The architecture should decide whether v3 signing starts as server-side custodial signing with Supabase Vault-backed private keys, smart-account signing, a future external signer, or a phased hybrid. It must preserve the separation between authentication credentials and blockchain signing keys: passkeys authorize user intent, while wallet private keys or smart-account signer keys perform blockchain signing. Define the signing request lifecycle, approval state machine, actor model, replay/idempotency requirements, audit events, and which chains are included in the first slice. The design should explicitly say that generated accounts are not enough for SIWC wallet parity until users can safely approve signatures or transactions.
+
+### SIWC02. Add Admin policy controls for app-scoped account custody and signing
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add Admin-side controls that let operators configure whether an app may request generated accounts, which chains are enabled, whether signing is enabled, and which approval rules apply. This should extend the existing Admin control-plane pattern rather than creating a separate wallet dashboard. Include fields for allowed chains, custody mode, signing status, allowed signature types, transaction limits, optional contract allowlists, required passkey ACR, webhook event subscriptions, and sandbox/production behavior. Admin list/detail views must not expose private keys, ciphertext, wrapped data keys, Vault key material, or cross-app user identifiers. This todo should also decide how policy names and versions are surfaced to API v3 responses and audit logs.
+
+### SIWC03. Add Passport user-facing app account visibility
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add user-facing visibility for app-scoped custody accounts in Passport, likely inside the existing Profile and disclosure-management surface. Users should be able to see which apps have generated accounts for them, which chain each account belongs to, public addresses, labels, creation dates, custody status, and whether signing is enabled for that app. The UI should reinforce the privacy model: these accounts are scoped to individual apps, and other apps should not be able to correlate them. This slice should not add private-key export, signing, or cross-app wallet portability. It should only make the already-created v3 account metadata understandable and auditable for the human user, with no exposure of private or encrypted custody fields.
+
+### SIWC04. Implement v3 signing request lifecycle
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Implement the backend lifecycle for signing requests after SIWC01 chooses the architecture. Add API v3 routes for creating a signing request, reading request status, approving or rejecting through Passport, and returning the resulting signature or transaction hash when complete. Requests must be app-scoped, dapp-authenticated, idempotent where appropriate, bound to a specific `dapp_user_uuid` and `user_account_id`, and checked against Admin signing policy before user approval. Approval should be hosted in Passport and require passkey step-up when policy or ACR requires it. Responses must never return private keys, raw decrypted material, Vault wrapping keys, or internal human subject keys. All state changes should write audit/security events and be safe to retry.
+
+### SIWC05. Add transaction risk, policy evaluation, and passkey step-up
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add the first transaction-policy and risk layer before broad transaction signing is considered production-ready. The initial version can be conservative: human-readable request summaries, chain/account matching, requested operation type, recipient or contract metadata where available, amount thresholds, contract allowlist checks, and mandatory passkey step-up for high-risk requests. The goal is not full transaction simulation across every chain in v1; it is to prevent blind signing from becoming the default. Passport approval screens should make the app, chain, public account, action, and risk posture clear. Admin should be able to configure policy strictness. Failed policy checks, rejected approvals, and passkey step-up failures should be auditable and webhook-eligible.
+
+### SIWC06. Add signing and wallet webhook contracts plus SDK handoff notes
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Extend the API v3 webhook contract for app-scoped custody and signing events. Candidate events include `wallet.created`, `wallet.signing_request.created`, `wallet.signing_request.approved`, `wallet.signing_request.rejected`, `wallet.signature.completed`, `wallet.transaction.submitted`, `wallet.transaction.failed`, and `wallet.policy.denied`. Payloads must follow the existing API v3 webhook direction: stable event IDs, timestamps, HMAC signatures, replay-safe delivery semantics, retry metadata, and disclosure-safe payloads that do not leak cross-app identifiers or custody secrets. Because these events affect developer-facing SDK behavior, each implemented contract change must create a handoff note in the public SDK repo. Do not add SDK implementation code to `cubid-passport`.
+
+### SIWC07. Evaluate smart-account, session-key, and paymaster roadmap
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Evaluate whether Cubid should support smart accounts, scoped session keys, and paymaster/gas sponsorship after the basic signing lifecycle is secure. This should be a design and sequencing task, not an implementation shortcut. Compare the app-scoped privacy model against user expectations for portable wallets, recovery, gasless onboarding, and asset fragmentation. Decide whether smart accounts should wrap existing app-scoped custodial keys, replace generated EOAs for some chains, or remain a later optional custody mode. Define what would need to change in Admin policy, Passport approval UX, API v3 signing routes, webhook events, and SDK contracts. The output should be a recommendation with explicit "not yet" criteria if the platform is not ready.
+
+### SIWC08. Build production readiness runbook for SIWC custody and signing
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Create the operator runbook for SIWC custody and signing before exposing signing broadly. The runbook should cover Vault key ownership and rotation, generated-account custody boundaries, migration rollback, audit-log inspection, signing request triage, webhook replay, incident response, abuse monitoring, emergency app suspension, user support, and privacy review for app-scoped account visibility. It should explicitly document what is safe to expose to users and dapps, what is Admin-only, what is service-role-only, and what must never leave server memory. Include local/staging/prod environment requirements, smoke tests, and launch blockers. This todo should close the gap between a technically working signer and an operable platform surface.
+
+## Implemented Differently Than Generic Recommendation
+
+- API v3 is the forward path for developer-facing backend surfaces. Do not add new `/api/v2/wallets/*` routes for SIWC.
+- Public SDK and UI work belongs in `Cubid-Me/cubid-sdk`; this repo should only define backend contracts, runtime behavior, migrations, and SDK handoff notes.
+- OIDC pairwise subjects and app-scoped disclosure grants are preferred over a custom token shape that embeds broad wallet, score, or PII claims.
+- Supabase Vault-backed envelope encryption is the current retrievable-secret custody pattern for dapp-user secrets, webhook signing secrets, and blockchain private keys.
+- Legacy `/api/v2/save_secret` plaintext writes have been removed; new dapp-user secret writes must use encrypted API v3 custody.
+- Generated app-scoped accounts are not the same thing as an embedded wallet product until signing, approval, and policy controls exist.
+
+## Deferred / Not In This Repo
+
+- Public React components, drop-in SIWC buttons, Deno/Supabase Edge examples, and package publication belong in `Cubid-Me/cubid-sdk`.
+- Competitor references are useful inspiration but should not drive repo-local implementation details unless translated into Cubid-specific OIDC, Passport, Admin, API v3, or webhook work.
+- Generic embedded-wallet features such as universal wallets, key export, social-login-first onboarding, broad cross-app portability, swaps, onramps, and paymasters are deferred unless explicitly reconciled with Cubid's app-scoped privacy model.
+- No new public SDK implementation code should be added under `packages/` in this repo.

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -56,23 +56,23 @@ Add user-facing visibility for app-scoped custody accounts in Passport, likely i
 
 ### SIWC04. Implement v3 signing request lifecycle
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T08:31:22Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T08:57:01Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v165
+- Head: a41f6ee
+- Session-log reference(s): session: v165, session: v166
 
 Implement the backend lifecycle for signing requests after SIWC01 chooses the architecture. Add API v3 routes for creating a signing request, reading request status, approving or rejecting through Passport, and returning the resulting signature or transaction hash when complete. Requests must be app-scoped, dapp-authenticated, idempotent where appropriate, bound to a specific `dapp_user_uuid` and `user_account_id`, and checked against Admin signing policy before user approval. Approval should be hosted in Passport and require passkey step-up when policy or ACR requires it. Responses must never return private keys, raw decrypted material, Vault wrapping keys, or internal human subject keys. All state changes should write audit/security events and be safe to retry.
 
 ### SIWC05. Add transaction risk, policy evaluation, and passkey step-up
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T08:57:01Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v167
 
 Add the first transaction-policy and risk layer before broad transaction signing is considered production-ready. The initial version can be conservative: human-readable request summaries, chain/account matching, requested operation type, recipient or contract metadata where available, amount thresholds, contract allowlist checks, and mandatory passkey step-up for high-risk requests. The goal is not full transaction simulation across every chain in v1; it is to prevent blind signing from becoming the default. Passport approval screens should make the app, chain, public account, action, and risk posture clear. Admin should be able to configure policy strictness. Failed policy checks, rejected approvals, and passkey step-up failures should be auditable and webhook-eligible.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -731,23 +731,23 @@ Promote the SIWC side-roadmap into the main execution backlog as the next wallet
 
 ### SIWC01. Define the v3 signing and transaction authorization architecture
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-05T01:21:18Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-05T01:23:41Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v160
+- Head: 008934d
+- Session-log reference(s): session: v160, session: v161
 
 Design the first decision-complete signing architecture for app-scoped custody accounts in `docs/engineering/siwc-v3-signing-architecture.md`. The architecture should decide whether v3 signing starts as server-side custodial signing with Supabase Vault-backed private keys, smart-account signing, a future external signer, or a phased hybrid. It must preserve the separation between authentication credentials and blockchain signing keys: passkeys authorize user intent, while wallet private keys or smart-account signer keys perform blockchain signing. Define the signing request lifecycle, approval state machine, actor model, replay/idempotency requirements, audit events, and which chains are included in the first slice. The design should explicitly say that generated accounts are not enough for SIWC wallet parity until users can safely approve signatures or transactions.
 
 ### SIWC02. Add Admin policy controls for app-scoped account custody and signing
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-05T01:23:41Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v161
 
 Add Admin-side controls that let operators configure whether an app may request generated accounts, which chains are enabled, whether signing is enabled, and which approval rules apply. This should extend the existing Admin control-plane pattern rather than creating a separate wallet dashboard. Include fields for allowed chains, custody mode, signing status, allowed signature types, transaction limits, optional contract allowlists, required passkey ACR, webhook event subscriptions, and sandbox/production behavior. Admin list/detail views must not expose private keys, ciphertext, wrapped data keys, Vault key material, or cross-app user identifiers. This todo should also decide how policy names and versions are surfaced to API v3 responses and audit logs, and should treat policy changes as SDK-impacting only when they alter public route or webhook semantics.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -786,23 +786,23 @@ Add the first transaction-policy and risk layer before broad transaction signing
 
 ### SIWC06. Add signing and wallet webhook contracts plus SDK handoff notes
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T09:22:33Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T10:25:43Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: 313f4a5
-- Session-log reference(s): session: v169
+- Head: 82fcdd6
+- Session-log reference(s): session: v169, session: v170
 
 Extend the API v3 webhook contract for app-scoped custody and signing events. Candidate events include `wallet.created`, `wallet.signing_request.created`, `wallet.signing_request.approved`, `wallet.signing_request.rejected`, `wallet.signature.completed`, `wallet.transaction.submitted`, `wallet.transaction.failed`, and `wallet.policy.denied`. Payloads must follow the existing API v3 webhook direction: stable event IDs, timestamps, HMAC signatures, replay-safe delivery semantics, retry metadata, and disclosure-safe payloads that do not leak cross-app identifiers or custody secrets. Because these events affect developer-facing SDK behavior, each implemented contract change must create a handoff note in the public SDK repo. Do not add SDK implementation code to `cubid-passport`.
 
 ### SIWC07. Evaluate smart-account, session-key, and paymaster roadmap
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T10:25:43Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/siwc-roadmap-cleanup
+- Head: 82fcdd6
+- Session-log reference(s): session: v171
 
 Evaluate whether Cubid should support smart accounts, scoped session keys, and paymaster/gas sponsorship after the basic signing lifecycle is secure. This should be a design and sequencing task, not an implementation shortcut. Compare the app-scoped privacy model against user expectations for portable wallets, recovery, gasless onboarding, and asset fragmentation. Decide whether smart accounts should wrap existing app-scoped custodial keys, replace generated EOAs for some chains, or remain a later optional custody mode. Define what would need to change in Admin policy, Passport approval UX, API v3 signing routes, webhook events, and SDK contracts. The output should be a recommendation with explicit "not yet" criteria if the platform is not ready.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -797,22 +797,22 @@ Extend the API v3 webhook contract for app-scoped custody and signing events. Ca
 
 ### SIWC07. Evaluate smart-account, session-key, and paymaster roadmap
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T10:25:43Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T10:40:40Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: 82fcdd6
-- Session-log reference(s): session: v171
+- Head: e3fec1a
+- Session-log reference(s): session: v171, session: v172
 
 Evaluate whether Cubid should support smart accounts, scoped session keys, and paymaster/gas sponsorship after the basic signing lifecycle is secure. This should be a design and sequencing task, not an implementation shortcut. Compare the app-scoped privacy model against user expectations for portable wallets, recovery, gasless onboarding, and asset fragmentation. Decide whether smart accounts should wrap existing app-scoped custodial keys, replace generated EOAs for some chains, or remain a later optional custody mode. Define what would need to change in Admin policy, Passport approval UX, API v3 signing routes, webhook events, and SDK contracts. The output should be a recommendation with explicit "not yet" criteria if the platform is not ready.
 
 ### SIWC08. Build production readiness runbook for SIWC custody and signing
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T10:40:40Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/siwc-roadmap-cleanup
+- Head: e3fec1a
+- Session-log reference(s): session: v173
 
 Create the operator runbook for SIWC custody and signing before exposing signing broadly. The runbook should cover Vault key ownership and rotation, generated-account custody boundaries, migration rollback, audit-log inspection, signing request triage, webhook replay, incident response, abuse monitoring, emergency app suspension, user support, and privacy review for app-scoped account visibility. It should explicitly document what is safe to expose to users and dapps, what is Admin-only, what is service-role-only, and what must never leave server memory. Include local/staging/prod environment requirements, smoke tests, and launch blockers. This todo should close the gap between a technically working signer and an operable platform surface.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -717,3 +717,102 @@ Expand the platform beyond human passports in a way that matches the backgrounde
 - Session-log reference(s): session: v111, session: v112, session: v113
 
 Translate the backgrounder’s product constraints into concrete engineering work. Redesign onboarding and verification journeys so they remain accessible, globally usable, and low-friction for users with limited documentation, limited bandwidth, or limited digital literacy. Establish an accessibility bar of WCAG 2.1 AA across Passport and Admin, including keyboard support, semantic structure, announcement behavior, color contrast, and readable step flows. Replace hard assumptions about phone, email, or wallet availability with progressive trust accumulation so users can start with minimal identity signals and deepen later. This work should include telemetry that measures abandonment at each step without capturing unnecessary personal data. The outcome should be a trust platform that grows identity depth without turning into a heavy KYC product, which is central to the Cubid mission.
+
+### SIWC. Build Sign In With Cubid custody, signing, and wallet-adjacent product surfaces
+
+- Status: Started
+- Timestamp started: 2026-05-05T01:21:18Z
+- Timestamp completed: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
+- Head: TBD
+- Session-log reference(s): session: v160
+
+Promote the SIWC side-roadmap into the main execution backlog as the next wallet-adjacent platform track. The already-landed Cubid foundation covers OIDC Login with Cubid, passkey-first auth, app-scoped identity, selective disclosure, API v3 encrypted dapp-user secrets, generated app-scoped blockchain accounts, and signed webhook infrastructure. The remaining product gap is explicit signing: dapps need a safe way to request message or transaction signatures, humans need Passport-hosted visibility and approval, Admin needs policy controls, and operators need runbooks before any custody signer can be exposed broadly. SIWC work must stay backend/API-contract first in this repo, with public SDK implementation handled through `Cubid-Me/cubid-sdk` handoff notes whenever route or webhook contracts change.
+
+### SIWC01. Define the v3 signing and transaction authorization architecture
+
+- Status: Started
+- Timestamp started: 2026-05-05T01:21:18Z
+- Timestamp completed: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
+- Head: TBD
+- Session-log reference(s): session: v160
+
+Design the first decision-complete signing architecture for app-scoped custody accounts in `docs/engineering/siwc-v3-signing-architecture.md`. The architecture should decide whether v3 signing starts as server-side custodial signing with Supabase Vault-backed private keys, smart-account signing, a future external signer, or a phased hybrid. It must preserve the separation between authentication credentials and blockchain signing keys: passkeys authorize user intent, while wallet private keys or smart-account signer keys perform blockchain signing. Define the signing request lifecycle, approval state machine, actor model, replay/idempotency requirements, audit events, and which chains are included in the first slice. The design should explicitly say that generated accounts are not enough for SIWC wallet parity until users can safely approve signatures or transactions.
+
+### SIWC02. Add Admin policy controls for app-scoped account custody and signing
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add Admin-side controls that let operators configure whether an app may request generated accounts, which chains are enabled, whether signing is enabled, and which approval rules apply. This should extend the existing Admin control-plane pattern rather than creating a separate wallet dashboard. Include fields for allowed chains, custody mode, signing status, allowed signature types, transaction limits, optional contract allowlists, required passkey ACR, webhook event subscriptions, and sandbox/production behavior. Admin list/detail views must not expose private keys, ciphertext, wrapped data keys, Vault key material, or cross-app user identifiers. This todo should also decide how policy names and versions are surfaced to API v3 responses and audit logs, and should treat policy changes as SDK-impacting only when they alter public route or webhook semantics.
+
+### SIWC03. Add Passport user-facing app account visibility
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add user-facing visibility for app-scoped custody accounts in Passport, likely inside the existing Profile and disclosure-management surface. Users should be able to see which apps have generated accounts for them, which chain each account belongs to, public addresses, labels, creation dates, custody status, and whether signing is enabled for that app. The UI should reinforce the privacy model: these accounts are scoped to individual apps, and other apps should not be able to correlate them. This slice should not add private-key export, signing, or cross-app wallet portability. It should only make the already-created v3 account metadata understandable and auditable for the human user, with no exposure of private or encrypted custody fields.
+
+### SIWC04. Implement v3 signing request lifecycle
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Implement the backend lifecycle for signing requests after SIWC01 chooses the architecture. Add API v3 routes for creating a signing request, reading request status, approving or rejecting through Passport, and returning the resulting signature or transaction hash when complete. Requests must be app-scoped, dapp-authenticated, idempotent where appropriate, bound to a specific `dapp_user_uuid` and `user_account_id`, and checked against Admin signing policy before user approval. Approval should be hosted in Passport and require passkey step-up when policy or ACR requires it. Responses must never return private keys, raw decrypted material, Vault wrapping keys, or internal human subject keys. All state changes should write audit/security events and be safe to retry.
+
+### SIWC05. Add transaction risk, policy evaluation, and passkey step-up
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add the first transaction-policy and risk layer before broad transaction signing is considered production-ready. The initial version can be conservative: human-readable request summaries, chain/account matching, requested operation type, recipient or contract metadata where available, amount thresholds, contract allowlist checks, and mandatory passkey step-up for high-risk requests. The goal is not full transaction simulation across every chain in v1; it is to prevent blind signing from becoming the default. Passport approval screens should make the app, chain, public account, action, and risk posture clear. Admin should be able to configure policy strictness. Failed policy checks, rejected approvals, and passkey step-up failures should be auditable and webhook-eligible.
+
+### SIWC06. Add signing and wallet webhook contracts plus SDK handoff notes
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Extend the API v3 webhook contract for app-scoped custody and signing events. Candidate events include `wallet.created`, `wallet.signing_request.created`, `wallet.signing_request.approved`, `wallet.signing_request.rejected`, `wallet.signature.completed`, `wallet.transaction.submitted`, `wallet.transaction.failed`, and `wallet.policy.denied`. Payloads must follow the existing API v3 webhook direction: stable event IDs, timestamps, HMAC signatures, replay-safe delivery semantics, retry metadata, and disclosure-safe payloads that do not leak cross-app identifiers or custody secrets. Because these events affect developer-facing SDK behavior, each implemented contract change must create a handoff note in the public SDK repo. Do not add SDK implementation code to `cubid-passport`.
+
+### SIWC07. Evaluate smart-account, session-key, and paymaster roadmap
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Evaluate whether Cubid should support smart accounts, scoped session keys, and paymaster/gas sponsorship after the basic signing lifecycle is secure. This should be a design and sequencing task, not an implementation shortcut. Compare the app-scoped privacy model against user expectations for portable wallets, recovery, gasless onboarding, and asset fragmentation. Decide whether smart accounts should wrap existing app-scoped custodial keys, replace generated EOAs for some chains, or remain a later optional custody mode. Define what would need to change in Admin policy, Passport approval UX, API v3 signing routes, webhook events, and SDK contracts. The output should be a recommendation with explicit "not yet" criteria if the platform is not ready.
+
+### SIWC08. Build production readiness runbook for SIWC custody and signing
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Create the operator runbook for SIWC custody and signing before exposing signing broadly. The runbook should cover Vault key ownership and rotation, generated-account custody boundaries, migration rollback, audit-log inspection, signing request triage, webhook replay, incident response, abuse monitoring, emergency app suspension, user support, and privacy review for app-scoped account visibility. It should explicitly document what is safe to expose to users and dapps, what is Admin-only, what is service-role-only, and what must never leave server memory. Include local/staging/prod environment requirements, smoke tests, and launch blockers. This todo should close the gap between a technically working signer and an operable platform surface.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -764,23 +764,23 @@ Add user-facing visibility for app-scoped custody accounts in Passport, likely i
 
 ### SIWC04. Implement v3 signing request lifecycle
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T08:31:22Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T08:57:01Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v165
+- Head: a41f6ee
+- Session-log reference(s): session: v165, session: v166
 
 Implement the backend lifecycle for signing requests after SIWC01 chooses the architecture. Add API v3 routes for creating a signing request, reading request status, approving or rejecting through Passport, and returning the resulting signature or transaction hash when complete. Requests must be app-scoped, dapp-authenticated, idempotent where appropriate, bound to a specific `dapp_user_uuid` and `user_account_id`, and checked against Admin signing policy before user approval. Approval should be hosted in Passport and require passkey step-up when policy or ACR requires it. Responses must never return private keys, raw decrypted material, Vault wrapping keys, or internal human subject keys. All state changes should write audit/security events and be safe to retry.
 
 ### SIWC05. Add transaction risk, policy evaluation, and passkey step-up
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T08:57:01Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v167
 
 Add the first transaction-policy and risk layer before broad transaction signing is considered production-ready. The initial version can be conservative: human-readable request summaries, chain/account matching, requested operation type, recipient or contract metadata where available, amount thresholds, contract allowlist checks, and mandatory passkey step-up for high-risk requests. The goal is not full transaction simulation across every chain in v1; it is to prevent blind signing from becoming the default. Passport approval screens should make the app, chain, public account, action, and risk posture clear. Admin should be able to configure policy strictness. Failed policy checks, rejected approvals, and passkey step-up failures should be auditable and webhook-eligible.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -753,23 +753,23 @@ Add Admin-side controls that let operators configure whether an app may request 
 
 ### SIWC03. Add Passport user-facing app account visibility
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-05T23:41:40Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T08:31:22Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v163
+- Head: 774cd64
+- Session-log reference(s): session: v163, session: v164
 
 Add user-facing visibility for app-scoped custody accounts in Passport, likely inside the existing Profile and disclosure-management surface. Users should be able to see which apps have generated accounts for them, which chain each account belongs to, public addresses, labels, creation dates, custody status, and whether signing is enabled for that app. The UI should reinforce the privacy model: these accounts are scoped to individual apps, and other apps should not be able to correlate them. This slice should not add private-key export, signing, or cross-app wallet portability. It should only make the already-created v3 account metadata understandable and auditable for the human user, with no exposure of private or encrypted custody fields.
 
 ### SIWC04. Implement v3 signing request lifecycle
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T08:31:22Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v165
 
 Implement the backend lifecycle for signing requests after SIWC01 chooses the architecture. Add API v3 routes for creating a signing request, reading request status, approving or rejecting through Passport, and returning the resulting signature or transaction hash when complete. Requests must be app-scoped, dapp-authenticated, idempotent where appropriate, bound to a specific `dapp_user_uuid` and `user_account_id`, and checked against Admin signing policy before user approval. Approval should be hosted in Passport and require passkey step-up when policy or ACR requires it. Responses must never return private keys, raw decrypted material, Vault wrapping keys, or internal human subject keys. All state changes should write audit/security events and be safe to retry.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -742,23 +742,23 @@ Design the first decision-complete signing architecture for app-scoped custody a
 
 ### SIWC02. Add Admin policy controls for app-scoped account custody and signing
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-05T01:23:41Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-05T23:41:40Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v161
+- Head: a968016
+- Session-log reference(s): session: v161, session: v162, session: v163
 
 Add Admin-side controls that let operators configure whether an app may request generated accounts, which chains are enabled, whether signing is enabled, and which approval rules apply. This should extend the existing Admin control-plane pattern rather than creating a separate wallet dashboard. Include fields for allowed chains, custody mode, signing status, allowed signature types, transaction limits, optional contract allowlists, required passkey ACR, webhook event subscriptions, and sandbox/production behavior. Admin list/detail views must not expose private keys, ciphertext, wrapped data keys, Vault key material, or cross-app user identifiers. This todo should also decide how policy names and versions are surfaced to API v3 responses and audit logs, and should treat policy changes as SDK-impacting only when they alter public route or webhook semantics.
 
 ### SIWC03. Add Passport user-facing app account visibility
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-05T23:41:40Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/siwc-roadmap-cleanup
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v163
 
 Add user-facing visibility for app-scoped custody accounts in Passport, likely inside the existing Profile and disclosure-management surface. Users should be able to see which apps have generated accounts for them, which chain each account belongs to, public addresses, labels, creation dates, custody status, and whether signing is enabled for that app. The UI should reinforce the privacy model: these accounts are scoped to individual apps, and other apps should not be able to correlate them. This slice should not add private-key export, signing, or cross-app wallet portability. It should only make the already-created v3 account metadata understandable and auditable for the human user, with no exposure of private or encrypted custody fields.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -720,14 +720,14 @@ Translate the backgrounder’s product constraints into concrete engineering wor
 
 ### SIWC. Build Sign In With Cubid custody, signing, and wallet-adjacent product surfaces
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-05T01:21:18Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T11:49:35Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v160
+- Head: 969385a
+- Session-log reference(s): session: v160, session: v175
 
-Promote the SIWC side-roadmap into the main execution backlog as the next wallet-adjacent platform track. The already-landed Cubid foundation covers OIDC Login with Cubid, passkey-first auth, app-scoped identity, selective disclosure, API v3 encrypted dapp-user secrets, generated app-scoped blockchain accounts, and signed webhook infrastructure. The remaining product gap is explicit signing: dapps need a safe way to request message or transaction signatures, humans need Passport-hosted visibility and approval, Admin needs policy controls, and operators need runbooks before any custody signer can be exposed broadly. SIWC work must stay backend/API-contract first in this repo, with public SDK implementation handled through `Cubid-Me/cubid-sdk` handoff notes whenever route or webhook contracts change.
+Promote the SIWC side-roadmap into the main execution backlog as the next wallet-adjacent platform track. The Cubid foundation covers OIDC Login with Cubid, passkey-first auth, app-scoped identity, selective disclosure, API v3 encrypted dapp-user secrets, generated app-scoped blockchain accounts, signed webhook infrastructure, Passport-hosted signing approval, Admin signing policy controls, and SIWC production-readiness runbooks. This track delivered the backend/API-contract foundation for app-scoped custody and message or typed-data signing while keeping transaction signing, smart accounts, session keys, paymasters, and public SDK implementation explicitly deferred.
 
 ### SIWC01. Define the v3 signing and transaction authorization architecture
 
@@ -808,11 +808,11 @@ Evaluate whether Cubid should support smart accounts, scoped session keys, and p
 
 ### SIWC08. Build production readiness runbook for SIWC custody and signing
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T10:40:40Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T11:49:35Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: e3fec1a
-- Session-log reference(s): session: v173
+- Head: 969385a
+- Session-log reference(s): session: v173, session: v174
 
 Create the operator runbook for SIWC custody and signing before exposing signing broadly. The runbook should cover Vault key ownership and rotation, generated-account custody boundaries, migration rollback, audit-log inspection, signing request triage, webhook replay, incident response, abuse monitoring, emergency app suspension, user support, and privacy review for app-scoped account visibility. It should explicitly document what is safe to expose to users and dapps, what is Admin-only, what is service-role-only, and what must never leave server memory. Include local/staging/prod environment requirements, smoke tests, and launch blockers. This todo should close the gap between a technically working signer and an operable platform surface.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -775,23 +775,23 @@ Implement the backend lifecycle for signing requests after SIWC01 chooses the ar
 
 ### SIWC05. Add transaction risk, policy evaluation, and passkey step-up
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-06T08:57:01Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-06T09:22:33Z
 - Feature branch: codex/siwc-roadmap-cleanup
-- Head: TBD
-- Session-log reference(s): session: v167
+- Head: 313f4a5
+- Session-log reference(s): session: v167, session: v168
 
 Add the first transaction-policy and risk layer before broad transaction signing is considered production-ready. The initial version can be conservative: human-readable request summaries, chain/account matching, requested operation type, recipient or contract metadata where available, amount thresholds, contract allowlist checks, and mandatory passkey step-up for high-risk requests. The goal is not full transaction simulation across every chain in v1; it is to prevent blind signing from becoming the default. Passport approval screens should make the app, chain, public account, action, and risk posture clear. Admin should be able to configure policy strictness. Failed policy checks, rejected approvals, and passkey step-up failures should be auditable and webhook-eligible.
 
 ### SIWC06. Add signing and wallet webhook contracts plus SDK handoff notes
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-06T09:22:33Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/siwc-roadmap-cleanup
+- Head: 313f4a5
+- Session-log reference(s): session: v169
 
 Extend the API v3 webhook contract for app-scoped custody and signing events. Candidate events include `wallet.created`, `wallet.signing_request.created`, `wallet.signing_request.approved`, `wallet.signing_request.rejected`, `wallet.signature.completed`, `wallet.transaction.submitted`, `wallet.transaction.failed`, and `wallet.policy.denied`. Payloads must follow the existing API v3 webhook direction: stable event IDs, timestamps, HMAC signatures, replay-safe delivery semantics, retry metadata, and disclosure-safe payloads that do not leak cross-app identifiers or custody secrets. Because these events affect developer-facing SDK behavior, each implemented contract change must create a handoff note in the public SDK repo. Do not add SDK implementation code to `cubid-passport`.
 

--- a/apps/admin/app/admin/page.tsx
+++ b/apps/admin/app/admin/page.tsx
@@ -8,10 +8,17 @@ import AppList from './appList';
 import DisclosureOps from './disclosureOps';
 import OidcOps from './oidcOps';
 import OidcRegistry from './oidcRegistry';
+import SiwcPolicy from './siwcPolicy';
 import Webhooks from './webhook';
 
 // Define the type for the tab state
-type Tab = 'apps' | 'disclosure-ops' | 'oidc' | 'oidc-ops' | 'webhooks';
+type Tab =
+  | 'apps'
+  | 'disclosure-ops'
+  | 'oidc'
+  | 'oidc-ops'
+  | 'siwc-policy'
+  | 'webhooks';
 
 export default function Admin() {
   const [activeTab, setActiveTab] = useState<Tab>('apps'); // Define state with Tab type
@@ -47,6 +54,12 @@ export default function Admin() {
               Disclosure Ops
             </button>
             <button
+              onClick={() => setActiveTab('siwc-policy')}
+              className={`pb-2 ${activeTab === 'siwc-policy' ? 'border-b-2 border-blue-500 text-blue-500' : ''}`}
+            >
+              SIWC Policy
+            </button>
+            <button
               onClick={() => setActiveTab('webhooks')}
               className={`pb-2 ${activeTab === 'webhooks' ? 'border-b-2 border-blue-500 text-blue-500' : ''}`}
             >
@@ -58,6 +71,7 @@ export default function Admin() {
             {activeTab === 'oidc' && <OidcRegistry />}
             {activeTab === 'oidc-ops' && <OidcOps />}
             {activeTab === 'disclosure-ops' && <DisclosureOps />}
+            {activeTab === 'siwc-policy' && <SiwcPolicy />}
             {activeTab === 'webhooks' && <Webhooks />}
           </div>
         </div>

--- a/apps/admin/app/admin/shared.ts
+++ b/apps/admin/app/admin/shared.ts
@@ -226,6 +226,37 @@ export interface DisclosureOpsOverviewPayload {
   };
 }
 
+export type SiwcPolicyStatus = 'disabled' | 'enabled' | 'suspended';
+export type SiwcPolicyChain = 'evm' | 'near' | 'solana' | 'sui';
+export type SiwcPolicyRequestType = 'message' | 'typed_data' | 'transaction';
+
+export interface SiwcPolicyRecord {
+  allowedChains: SiwcPolicyChain[];
+  allowedRequestTypes: SiwcPolicyRequestType[];
+  contractAllowlist: string[];
+  createdAt: string | null;
+  custodyEnabled: boolean;
+  dappId: number;
+  dappName: string;
+  dappUid: string | null;
+  metadata: Record<string, unknown>;
+  policyId: string | null;
+  policyName: string;
+  policyVersion: number;
+  requiredAcr: 'urn:cubid:acr:passkey' | null;
+  sandboxMode: boolean;
+  signingEnabled: boolean;
+  status: SiwcPolicyStatus;
+  transactionValueLimitUsd: number | null;
+  updatedAt: string | null;
+  webhookEventSubscriptions: string[];
+}
+
+export interface SiwcPolicyOverviewPayload {
+  generatedAt: string;
+  policies: SiwcPolicyRecord[];
+}
+
 export type RequestedInfoMap = Record<string, RequestedInfoItem>;
 export type RequestedInfoByIndex = Record<number, RequestedInfoMap>;
 

--- a/apps/admin/app/admin/siwcPolicy.tsx
+++ b/apps/admin/app/admin/siwcPolicy.tsx
@@ -17,13 +17,15 @@ const REQUEST_TYPES: SiwcPolicyRequestType[] = [
   'transaction',
 ];
 const WEBHOOK_EVENTS = [
-  'wallet.signing_request.created',
-  'wallet.signing_request.approved',
-  'wallet.signing_request.rejected',
-  'wallet.signature.completed',
-  'wallet.transaction.submitted',
-  'wallet.transaction.failed',
+  'wallet.created',
   'wallet.policy.denied',
+  'wallet.signature.completed',
+  'wallet.signature.failed',
+  'wallet.signing_request.approved',
+  'wallet.signing_request.cancelled',
+  'wallet.signing_request.created',
+  'wallet.signing_request.rejected',
+  'wallet.signing_request.step_up_failed',
 ];
 const PASSKEY_ACR = 'urn:cubid:acr:passkey' as const;
 

--- a/apps/admin/app/admin/siwcPolicy.tsx
+++ b/apps/admin/app/admin/siwcPolicy.tsx
@@ -1,0 +1,375 @@
+import { authedPost } from 'lib/api';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+
+import type {
+  SiwcPolicyChain,
+  SiwcPolicyOverviewPayload,
+  SiwcPolicyRecord,
+  SiwcPolicyRequestType,
+  SiwcPolicyStatus,
+} from './shared';
+
+const CHAINS: SiwcPolicyChain[] = ['evm', 'near', 'solana', 'sui'];
+const REQUEST_TYPES: SiwcPolicyRequestType[] = [
+  'message',
+  'typed_data',
+  'transaction',
+];
+const WEBHOOK_EVENTS = [
+  'wallet.signing_request.created',
+  'wallet.signing_request.approved',
+  'wallet.signing_request.rejected',
+  'wallet.signature.completed',
+  'wallet.transaction.submitted',
+  'wallet.transaction.failed',
+  'wallet.policy.denied',
+];
+const PASSKEY_ACR = 'urn:cubid:acr:passkey' as const;
+
+const toggleValue = <T extends string>(values: T[], value: T) => {
+  return values.includes(value)
+    ? values.filter((entry) => entry !== value)
+    : [...values, value];
+};
+
+const formatDate = (value: string | null) => {
+  return value ? new Date(value).toLocaleString() : 'Not saved yet';
+};
+
+const PolicyCheckbox = ({
+  checked,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  onChange: () => void;
+}) => (
+  <label className="flex items-center gap-2 rounded border border-gray-700 px-3 py-2 text-sm text-gray-200">
+    <input
+      checked={checked}
+      className="h-4 w-4"
+      onChange={onChange}
+      type="checkbox"
+    />
+    {label}
+  </label>
+);
+
+export default function SiwcPolicy() {
+  const [generatedAt, setGeneratedAt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [policies, setPolicies] = useState<SiwcPolicyRecord[]>([]);
+  const [savingDappId, setSavingDappId] = useState<number | null>(null);
+
+  const loadPolicies = useCallback(async () => {
+    setLoading(true);
+
+    try {
+      const response = await authedPost<{ data: SiwcPolicyOverviewPayload }>(
+        '/api/admin/siwc/policies/list',
+        {}
+      );
+      setGeneratedAt(response.data.data.generatedAt);
+      setPolicies(response.data.data.policies ?? []);
+    } catch {
+      toast.error('Failed to load SIWC policies');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPolicies();
+  }, [loadPolicies]);
+
+  const updatePolicy = (
+    dappId: number,
+    patch: Partial<SiwcPolicyRecord>
+  ) => {
+    setPolicies((current) =>
+      current.map((policy) =>
+        policy.dappId === dappId ? { ...policy, ...patch } : policy
+      )
+    );
+  };
+
+  const savePolicy = async (policy: SiwcPolicyRecord) => {
+    setSavingDappId(policy.dappId);
+
+    try {
+      const response = await authedPost<{
+        data: { policy: SiwcPolicyRecord };
+      }>('/api/admin/siwc/policies/upsert', {
+        allowedChains: policy.allowedChains,
+        allowedRequestTypes: policy.allowedRequestTypes,
+        contractAllowlist: policy.contractAllowlist,
+        custodyEnabled: policy.custodyEnabled,
+        dappId: policy.dappId,
+        metadata: policy.metadata,
+        policyName: policy.policyName,
+        requiredAcr: policy.signingEnabled ? PASSKEY_ACR : policy.requiredAcr,
+        sandboxMode: policy.sandboxMode,
+        signingEnabled: policy.signingEnabled,
+        status: policy.status,
+        transactionValueLimitUsd: policy.transactionValueLimitUsd,
+        webhookEventSubscriptions: policy.webhookEventSubscriptions,
+      });
+      const savedPolicy = response.data.data.policy;
+      setPolicies((current) =>
+        current.map((entry) =>
+          entry.dappId === savedPolicy.dappId ? savedPolicy : entry
+        )
+      );
+      toast.success(`Saved SIWC policy for ${savedPolicy.dappName}`);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to save SIWC policy';
+      toast.error(message);
+    } finally {
+      setSavingDappId(null);
+    }
+  };
+
+  return (
+    <div className="p-3 text-white">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-xl">SIWC Policy</h2>
+          <p className="mt-1 max-w-3xl text-sm text-gray-400">
+            Configure whether each app can use app-scoped account custody and
+            future signing. These controls do not execute signing yet; they
+            define the policy SIWC signing routes must enforce later.
+          </p>
+          {generatedAt ? (
+            <p className="mt-2 text-xs text-gray-500">
+              Generated {formatDate(generatedAt)}
+            </p>
+          ) : null}
+        </div>
+        <button
+          className="rounded bg-gray-700 px-3 py-2 text-sm font-semibold hover:bg-gray-600"
+          onClick={loadPolicies}
+          type="button"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading ? (
+        <p className="mt-6 text-gray-400">Loading SIWC policies...</p>
+      ) : policies.length === 0 ? (
+        <p className="mt-6 text-gray-400">No dapps found.</p>
+      ) : (
+        <div className="mt-5 space-y-5">
+          {policies.map((policy) => (
+            <section
+              className="rounded-lg border border-gray-800 bg-gray-900 p-4 shadow"
+              key={policy.dappId}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-lg font-semibold">{policy.dappName}</h3>
+                  <p className="text-xs text-gray-500">
+                    App ID {policy.dappId}
+                    {policy.dappUid ? ` · UID ${policy.dappUid}` : ''}
+                  </p>
+                  <p className="mt-1 text-xs text-gray-500">
+                    Policy v{policy.policyVersion} · Updated{' '}
+                    {formatDate(policy.updatedAt)}
+                  </p>
+                </div>
+                <button
+                  className="rounded bg-blue-500 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-gray-600"
+                  disabled={savingDappId === policy.dappId}
+                  onClick={() => savePolicy(policy)}
+                  type="button"
+                >
+                  {savingDappId === policy.dappId ? 'Saving...' : 'Save policy'}
+                </button>
+              </div>
+
+              <div className="mt-4 grid gap-4 lg:grid-cols-3">
+                <label className="text-sm text-gray-300">
+                  Policy name
+                  <input
+                    className="mt-1 w-full rounded bg-gray-800 p-2 text-white"
+                    onChange={(event) =>
+                      updatePolicy(policy.dappId, {
+                        policyName: event.target.value,
+                      })
+                    }
+                    value={policy.policyName}
+                  />
+                </label>
+                <label className="text-sm text-gray-300">
+                  Status
+                  <select
+                    className="mt-1 w-full rounded bg-gray-800 p-2 text-white"
+                    onChange={(event) =>
+                      updatePolicy(policy.dappId, {
+                        status: event.target.value as SiwcPolicyStatus,
+                      })
+                    }
+                    value={policy.status}
+                  >
+                    <option value="disabled">Disabled</option>
+                    <option value="enabled">Enabled</option>
+                    <option value="suspended">Suspended</option>
+                  </select>
+                </label>
+                <label className="text-sm text-gray-300">
+                  Transaction value limit USD
+                  <input
+                    className="mt-1 w-full rounded bg-gray-800 p-2 text-white"
+                    min={0}
+                    onChange={(event) =>
+                      updatePolicy(policy.dappId, {
+                        transactionValueLimitUsd: event.target.value
+                          ? Number(event.target.value)
+                          : null,
+                      })
+                    }
+                    type="number"
+                    value={policy.transactionValueLimitUsd ?? ''}
+                  />
+                </label>
+              </div>
+
+              <div className="mt-4 grid gap-3 md:grid-cols-3">
+                <PolicyCheckbox
+                  checked={policy.custodyEnabled}
+                  label="Custody enabled"
+                  onChange={() =>
+                    updatePolicy(policy.dappId, {
+                      custodyEnabled: !policy.custodyEnabled,
+                    })
+                  }
+                />
+                <PolicyCheckbox
+                  checked={policy.signingEnabled}
+                  label="Signing enabled"
+                  onChange={() =>
+                    updatePolicy(policy.dappId, {
+                      requiredAcr: !policy.signingEnabled ? PASSKEY_ACR : null,
+                      signingEnabled: !policy.signingEnabled,
+                    })
+                  }
+                />
+                <PolicyCheckbox
+                  checked={policy.sandboxMode}
+                  label="Sandbox mode"
+                  onChange={() =>
+                    updatePolicy(policy.dappId, {
+                      sandboxMode: !policy.sandboxMode,
+                    })
+                  }
+                />
+              </div>
+
+              <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                <div>
+                  <p className="text-sm font-semibold text-gray-300">
+                    Allowed chains
+                  </p>
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                    {CHAINS.map((chain) => (
+                      <PolicyCheckbox
+                        checked={policy.allowedChains.includes(chain)}
+                        key={chain}
+                        label={chain.toUpperCase()}
+                        onChange={() =>
+                          updatePolicy(policy.dappId, {
+                            allowedChains: toggleValue(
+                              policy.allowedChains,
+                              chain
+                            ),
+                          })
+                        }
+                      />
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-300">
+                    Allowed request types
+                  </p>
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                    {REQUEST_TYPES.map((requestType) => (
+                      <PolicyCheckbox
+                        checked={policy.allowedRequestTypes.includes(
+                          requestType
+                        )}
+                        key={requestType}
+                        label={requestType}
+                        onChange={() =>
+                          updatePolicy(policy.dappId, {
+                            allowedRequestTypes: toggleValue(
+                              policy.allowedRequestTypes,
+                              requestType
+                            ),
+                          })
+                        }
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                <label className="text-sm text-gray-300">
+                  Contract allowlist
+                  <textarea
+                    className="mt-1 h-24 w-full rounded bg-gray-800 p-2 text-white"
+                    onChange={(event) =>
+                      updatePolicy(policy.dappId, {
+                        contractAllowlist: event.target.value
+                          .split('\n')
+                          .map((value) => value.trim())
+                          .filter(Boolean),
+                      })
+                    }
+                    placeholder="One contract or recipient per line"
+                    value={policy.contractAllowlist.join('\n')}
+                  />
+                </label>
+                <div>
+                  <p className="text-sm font-semibold text-gray-300">
+                    Webhook subscriptions
+                  </p>
+                  <div className="mt-2 grid gap-2">
+                    {WEBHOOK_EVENTS.map((eventName) => (
+                      <PolicyCheckbox
+                        checked={policy.webhookEventSubscriptions.includes(
+                          eventName
+                        )}
+                        key={eventName}
+                        label={eventName}
+                        onChange={() =>
+                          updatePolicy(policy.dappId, {
+                            webhookEventSubscriptions: toggleValue(
+                              policy.webhookEventSubscriptions,
+                              eventName
+                            ),
+                          })
+                        }
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-4 rounded border border-gray-800 bg-black/20 p-3 text-xs text-gray-400">
+                Required ACR:{' '}
+                <span className="font-mono">
+                  {policy.signingEnabled ? PASSKEY_ACR : 'none'}
+                </span>
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/lib/server/adminRoutes.test.ts
+++ b/apps/admin/lib/server/adminRoutes.test.ts
@@ -4,6 +4,8 @@ import syncAdminUser from '../../pages/api/admin/auth/sync';
 import metadata from '../../pages/api/admin/metadata';
 import disclosureOpsOverviewRoute from '../../pages/api/admin/disclosures/operations/overview';
 import updateOidcClientOpsRoute from '../../pages/api/admin/oidc/clients/update-ops';
+import listSiwcPoliciesRoute from '../../pages/api/admin/siwc/policies/list';
+import upsertSiwcPolicyRoute from '../../pages/api/admin/siwc/policies/upsert';
 import rotateKey from '../../pages/api/admin/apps/rotate-key';
 import createWebhook from '../../pages/api/admin/webhooks/create';
 import listWebhooks from '../../pages/api/admin/webhooks/list';
@@ -19,6 +21,8 @@ const updateOidcClientOpsMock = jest.fn();
 const loadDisclosureOpsOverviewMock = jest.fn();
 const normalizeClientOpsUpdateInputMock = jest.fn();
 const encryptWebhookSigningSecretMock = jest.fn();
+const listSiwcPoliciesMock = jest.fn();
+const upsertSiwcPolicyMock = jest.fn();
 
 jest.mock('./adminApi', () => ({
   getOwnedDapp: (...args: unknown[]) => getOwnedDappMock(...args),
@@ -55,6 +59,12 @@ jest.mock('./webhookSigningSecrets', () => ({
     encryptWebhookSigningSecretMock(...args),
   WEBHOOK_SIGNING_SECRET_LEGACY_SENTINEL:
     '__cubid_encrypted_webhook_signing_secret__',
+}));
+
+jest.mock('./siwcPolicies', () => ({
+  isSiwcPolicyInputError: () => false,
+  listSiwcPolicies: (...args: unknown[]) => listSiwcPoliciesMock(...args),
+  upsertSiwcPolicy: (...args: unknown[]) => upsertSiwcPolicyMock(...args),
 }));
 
 const createResponse = () => {
@@ -224,6 +234,60 @@ describe('Admin route baseline wiring', () => {
       })
     );
     expect(loadDisclosureOpsOverviewMock).toHaveBeenCalledWith({});
+  });
+
+  it('uses the admin read policy for SIWC policy list', async () => {
+    prepareAdminApiRequestMock.mockResolvedValue({
+      body: {},
+      context: { supabase: {} },
+      requestId: 'admin_request_siwc_list',
+    });
+    listSiwcPoliciesMock.mockResolvedValue({
+      generatedAt: '2026-05-05T00:00:00.000Z',
+      policies: [],
+    });
+
+    await listSiwcPoliciesRoute({} as NextApiRequest, createResponse());
+
+    expect(prepareAdminApiRequestMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        actor: 'admin',
+        rateLimitGroup: 'admin_read',
+        route: 'admin/siwc/policies/list',
+      })
+    );
+    expect(listSiwcPoliciesMock).toHaveBeenCalledWith({});
+  });
+
+  it('uses the sensitive policy for SIWC policy updates', async () => {
+    prepareAdminApiRequestMock.mockResolvedValue({
+      body: { dappId: 42, signingEnabled: true },
+      context: { adminUser: { uid: 'admin_uid' }, supabase: {} },
+      requestId: 'admin_request_siwc_upsert',
+    });
+    upsertSiwcPolicyMock.mockResolvedValue({
+      dappId: 42,
+      policyVersion: 1,
+      status: 'enabled',
+    });
+
+    await upsertSiwcPolicyRoute({} as NextApiRequest, createResponse());
+
+    expect(prepareAdminApiRequestMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        actor: 'admin',
+        rateLimitGroup: 'admin_sensitive',
+        route: 'admin/siwc/policies/upsert',
+      })
+    );
+    expect(upsertSiwcPolicyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ adminUser: { uid: 'admin_uid' } }),
+      { dappId: 42, signingEnabled: true }
+    );
   });
 
   it('creates webhook subscriptions with encrypted one-time signing secrets', async () => {

--- a/apps/admin/lib/server/adminRoutes.test.ts
+++ b/apps/admin/lib/server/adminRoutes.test.ts
@@ -237,9 +237,10 @@ describe('Admin route baseline wiring', () => {
   });
 
   it('uses the admin read policy for SIWC policy list', async () => {
+    const context = { adminUser: { uid: 'admin_uid' }, supabase: {} };
     prepareAdminApiRequestMock.mockResolvedValue({
       body: {},
-      context: { supabase: {} },
+      context,
       requestId: 'admin_request_siwc_list',
     });
     listSiwcPoliciesMock.mockResolvedValue({
@@ -258,7 +259,7 @@ describe('Admin route baseline wiring', () => {
         route: 'admin/siwc/policies/list',
       })
     );
-    expect(listSiwcPoliciesMock).toHaveBeenCalledWith({});
+    expect(listSiwcPoliciesMock).toHaveBeenCalledWith(context);
   });
 
   it('uses the sensitive policy for SIWC policy updates', async () => {

--- a/apps/admin/lib/server/adminSchemas.ts
+++ b/apps/admin/lib/server/adminSchemas.ts
@@ -166,3 +166,23 @@ export const adminOidcClientOpsUpdateSchema = z
     status: z.enum(['active', 'suspended']).optional(),
   })
   .passthrough();
+
+export const adminSiwcPolicyListSchema = z.object({}).passthrough();
+
+export const adminSiwcPolicyUpsertSchema = z
+  .object({
+    allowedChains: z.array(z.enum(['evm', 'near', 'solana', 'sui'])),
+    allowedRequestTypes: z.array(z.enum(['message', 'typed_data', 'transaction'])),
+    contractAllowlist: z.array(z.string().trim().min(1)).optional(),
+    custodyEnabled: z.boolean(),
+    dappId: z.coerce.number().int().positive(),
+    metadata: z.record(z.unknown()).optional(),
+    policyName: z.string().trim().min(1),
+    requiredAcr: z.literal('urn:cubid:acr:passkey').nullable().optional(),
+    sandboxMode: z.boolean(),
+    signingEnabled: z.boolean(),
+    status: z.enum(['disabled', 'enabled', 'suspended']),
+    transactionValueLimitUsd: z.coerce.number().nonnegative().nullable().optional(),
+    webhookEventSubscriptions: z.array(z.string().trim().min(1)).optional(),
+  })
+  .passthrough();

--- a/apps/admin/lib/server/siwcPolicies.test.ts
+++ b/apps/admin/lib/server/siwcPolicies.test.ts
@@ -1,0 +1,289 @@
+import {
+  listSiwcPolicies,
+  normalizeSiwcPolicyInput,
+  upsertSiwcPolicy,
+} from './siwcPolicies';
+
+const createListSupabase = () => ({
+  from: jest.fn((table: string) => {
+    if (table === 'dapps') {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              { appname: 'Demo App', id: 42, uid: 'app_uid_42' },
+              { appname: 'No Policy App', id: 43, uid: 'app_uid_43' },
+            ],
+            error: null,
+          }),
+        }),
+      };
+    }
+
+    if (table === 'siwc_signing_policies') {
+      return {
+        select: () => ({
+          in: async () => ({
+            data: [
+              {
+                allowed_chains: ['evm', 'sui'],
+                allowed_request_types: ['message'],
+                contract_allowlist: ['0xabc'],
+                created_at: '2026-05-05T00:00:00.000Z',
+                custody_enabled: true,
+                dapp_id: 42,
+                id: 'policy_42',
+                metadata: { note: 'safe' },
+                policy_name: 'Demo SIWC policy',
+                policy_version: 2,
+                required_acr: 'urn:cubid:acr:passkey',
+                sandbox_mode: true,
+                signing_enabled: true,
+                status: 'enabled',
+                transaction_value_limit_usd: '50.00',
+                updated_at: '2026-05-05T01:00:00.000Z',
+                webhook_event_subscriptions: ['wallet.signature.completed'],
+              },
+            ],
+            error: null,
+          }),
+        }),
+      };
+    }
+
+    throw new Error(`Unexpected table ${table}`);
+  }),
+});
+
+const createUpsertSupabase = (existingPolicyVersion?: number) => {
+  const eventInsert = jest.fn(async () => ({ error: null }));
+  const policyResult = {
+    select: () => ({
+      maybeSingle: async () => ({
+        data: {
+          allowed_chains: ['evm'],
+          allowed_request_types: ['message'],
+          contract_allowlist: [],
+          created_at: '2026-05-05T00:00:00.000Z',
+          custody_enabled: true,
+          dapp_id: 42,
+          id: 'policy_42',
+          metadata: {},
+          policy_name: 'Production signing',
+          policy_version: existingPolicyVersion ? existingPolicyVersion + 1 : 1,
+          required_acr: 'urn:cubid:acr:passkey',
+          sandbox_mode: true,
+          signing_enabled: true,
+          status: 'enabled',
+          transaction_value_limit_usd: null,
+          updated_at: '2026-05-05T01:00:00.000Z',
+          webhook_event_subscriptions: [],
+        },
+        error: null,
+      }),
+    }),
+  };
+  const policyWrite = jest.fn((_payload?: unknown) => policyResult);
+
+  return {
+    eventInsert,
+    policyWrite,
+    supabase: {
+      from: jest.fn((table: string) => {
+        if (table === 'dapps') {
+          return {
+            select: () => ({
+              match: () => ({
+                maybeSingle: async () => ({
+                  data: { appname: 'Demo App', id: 42, uid: 'app_uid_42' },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+
+        if (table === 'siwc_signing_policies') {
+          return {
+            insert: policyWrite,
+            select: () => ({
+              match: () => ({
+                maybeSingle: async () => ({
+                  data: existingPolicyVersion
+                    ? {
+                        policy_version: existingPolicyVersion,
+                      }
+                    : null,
+                  error: null,
+                }),
+              }),
+            }),
+            update: (payload: unknown) => {
+              policyWrite(payload);
+              return {
+                match: () => policyResult,
+              };
+            },
+          };
+        }
+
+        if (table === 'api_security_events') {
+          return {
+            insert: eventInsert,
+          };
+        }
+
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    },
+  };
+};
+
+describe('SIWC policy helpers', () => {
+  it('lists saved policies and fail-closed defaults for dapps without policies', async () => {
+    const overview = await listSiwcPolicies(createListSupabase() as never);
+
+    expect(overview.policies[0]).toMatchObject({
+      allowedChains: ['evm', 'sui'],
+      allowedRequestTypes: ['message'],
+      custodyEnabled: true,
+      dappId: 42,
+      dappName: 'Demo App',
+      policyVersion: 2,
+      requiredAcr: 'urn:cubid:acr:passkey',
+      signingEnabled: true,
+      status: 'enabled',
+      transactionValueLimitUsd: 50,
+    });
+    expect(overview.policies[1]).toMatchObject({
+      allowedChains: [],
+      allowedRequestTypes: [],
+      custodyEnabled: false,
+      dappId: 43,
+      policyVersion: 0,
+      sandboxMode: true,
+      signingEnabled: false,
+      status: 'disabled',
+    });
+  });
+
+  it('creates a passkey-required signing policy and writes an audit event', async () => {
+    const { eventInsert, policyWrite, supabase } = createUpsertSupabase();
+    const policy = await upsertSiwcPolicy(
+      {
+        adminUser: { email: 'admin@example.com', uid: 'admin_uid' },
+        email: 'admin@example.com',
+        requestId: 'admin_request_siwc',
+        supabase,
+        token: { uid: 'firebase_uid' },
+      } as never,
+      {
+        allowedChains: ['evm'],
+        allowedRequestTypes: ['message'],
+        custodyEnabled: true,
+        dappId: 42,
+        policyName: 'Production signing',
+        requiredAcr: 'urn:cubid:acr:passkey',
+        sandboxMode: true,
+        signingEnabled: true,
+        status: 'enabled',
+      }
+    );
+
+    expect(policy).toMatchObject({
+      dappId: 42,
+      policyVersion: 1,
+      requiredAcr: 'urn:cubid:acr:passkey',
+      signingEnabled: true,
+    });
+    expect(policyWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy_version: 1,
+        required_acr: 'urn:cubid:acr:passkey',
+      })
+    );
+    expect(eventInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'siwc_policy.created',
+        request_id: 'admin_request_siwc',
+      })
+    );
+  });
+
+  it('increments the policy version when updating an existing policy', async () => {
+    const { policyWrite, supabase } = createUpsertSupabase(3);
+    const policy = await upsertSiwcPolicy(
+      {
+        adminUser: { email: 'admin@example.com', uid: 'admin_uid' },
+        email: 'admin@example.com',
+        requestId: 'admin_request_siwc',
+        supabase,
+        token: { uid: 'firebase_uid' },
+      } as never,
+      {
+        allowedChains: ['evm'],
+        allowedRequestTypes: ['message'],
+        custodyEnabled: true,
+        dappId: 42,
+        policyName: 'Production signing',
+        requiredAcr: 'urn:cubid:acr:passkey',
+        sandboxMode: true,
+        signingEnabled: true,
+        status: 'enabled',
+      }
+    );
+
+    expect(policy.policyVersion).toBe(4);
+    expect(policyWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy_version: 4,
+      })
+    );
+  });
+
+  it('rejects unsupported chains and request types', () => {
+    expect(() =>
+      normalizeSiwcPolicyInput({
+        allowedChains: ['cardano' as never],
+        allowedRequestTypes: ['message'],
+        custodyEnabled: true,
+        dappId: 42,
+        policyName: 'Bad policy',
+        requiredAcr: 'urn:cubid:acr:passkey',
+        sandboxMode: true,
+        signingEnabled: true,
+        status: 'enabled',
+      })
+    ).toThrow(/allowedChains/);
+
+    expect(() =>
+      normalizeSiwcPolicyInput({
+        allowedChains: ['evm'],
+        allowedRequestTypes: ['raw' as never],
+        custodyEnabled: true,
+        dappId: 42,
+        policyName: 'Bad policy',
+        requiredAcr: 'urn:cubid:acr:passkey',
+        sandboxMode: true,
+        signingEnabled: true,
+        status: 'enabled',
+      })
+    ).toThrow(/allowedRequestTypes/);
+  });
+
+  it('fails closed when signing is enabled without passkey ACR', () => {
+    expect(() =>
+      normalizeSiwcPolicyInput({
+        allowedChains: ['evm'],
+        allowedRequestTypes: ['message'],
+        custodyEnabled: true,
+        dappId: 42,
+        policyName: 'Bad policy',
+        requiredAcr: null,
+        sandboxMode: true,
+        signingEnabled: true,
+        status: 'enabled',
+      })
+    ).toThrow(/passkey ACR/);
+  });
+});

--- a/apps/admin/lib/server/siwcPolicies.test.ts
+++ b/apps/admin/lib/server/siwcPolicies.test.ts
@@ -7,16 +7,24 @@ import {
 const createListSupabase = () => ({
   from: jest.fn((table: string) => {
     if (table === 'dapps') {
+      const match = jest.fn((criteria: Record<string, unknown>) => ({
+        order: async () => ({
+          data:
+            criteria.admin_uid === 'admin_uid'
+              ? [
+                  { appname: 'Demo App', id: 42, uid: 'app_uid_42' },
+                  { appname: 'No Policy App', id: 43, uid: 'app_uid_43' },
+                ]
+              : [],
+          error: null,
+        }),
+      }));
+
       return {
         select: () => ({
-          order: async () => ({
-            data: [
-              { appname: 'Demo App', id: 42, uid: 'app_uid_42' },
-              { appname: 'No Policy App', id: 43, uid: 'app_uid_43' },
-            ],
-            error: null,
-          }),
+          match,
         }),
+        __match: match,
       };
     }
 
@@ -54,6 +62,15 @@ const createListSupabase = () => ({
     throw new Error(`Unexpected table ${table}`);
   }),
 });
+
+const createAdminContext = (supabase: unknown, uid = 'admin_uid') =>
+  ({
+    adminUser: { email: 'admin@example.com', uid },
+    email: 'admin@example.com',
+    requestId: 'admin_request_siwc',
+    supabase,
+    token: { uid: 'firebase_uid' },
+  }) as never;
 
 const createUpsertSupabase = (existingPolicyVersion?: number) => {
   const eventInsert = jest.fn(async () => ({ error: null }));
@@ -141,7 +158,8 @@ const createUpsertSupabase = (existingPolicyVersion?: number) => {
 
 describe('SIWC policy helpers', () => {
   it('lists saved policies and fail-closed defaults for dapps without policies', async () => {
-    const overview = await listSiwcPolicies(createListSupabase() as never);
+    const supabase = createListSupabase();
+    const overview = await listSiwcPolicies(createAdminContext(supabase));
 
     expect(overview.policies[0]).toMatchObject({
       allowedChains: ['evm', 'sui'],
@@ -165,6 +183,13 @@ describe('SIWC policy helpers', () => {
       signingEnabled: false,
       status: 'disabled',
     });
+  });
+
+  it('scopes the policy list to dapps owned by the current admin', async () => {
+    const supabase = createListSupabase();
+    const overview = await listSiwcPolicies(createAdminContext(supabase, 'other_admin'));
+
+    expect(overview.policies).toEqual([]);
   });
 
   it('creates a passkey-required signing policy and writes an audit event', async () => {

--- a/apps/admin/lib/server/siwcPolicies.ts
+++ b/apps/admin/lib/server/siwcPolicies.ts
@@ -1,0 +1,362 @@
+import { randomUUID } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { AdminRequestContext } from './adminApi';
+
+const ALLOWED_CHAINS = ['evm', 'near', 'solana', 'sui'] as const;
+const ALLOWED_REQUEST_TYPES = ['message', 'typed_data', 'transaction'] as const;
+const POLICY_STATUSES = ['disabled', 'enabled', 'suspended'] as const;
+const PASSKEY_ACR = 'urn:cubid:acr:passkey' as const;
+
+type SiwcAllowedChain = (typeof ALLOWED_CHAINS)[number];
+type SiwcAllowedRequestType = (typeof ALLOWED_REQUEST_TYPES)[number];
+type SiwcPolicyStatus = (typeof POLICY_STATUSES)[number];
+
+interface DappRow {
+  appname: string | null;
+  id: number | string;
+  uid: string | null;
+}
+
+interface SiwcPolicyRow {
+  allowed_chains: unknown;
+  allowed_request_types: unknown;
+  contract_allowlist: unknown;
+  created_at: string;
+  custody_enabled: boolean;
+  dapp_id: number | string;
+  id: string;
+  metadata: unknown;
+  policy_name: string;
+  policy_version: number;
+  required_acr: string | null;
+  sandbox_mode: boolean;
+  signing_enabled: boolean;
+  status: SiwcPolicyStatus;
+  transaction_value_limit_usd: number | string | null;
+  updated_at: string;
+  webhook_event_subscriptions: unknown;
+}
+
+export interface SiwcPolicy {
+  allowedChains: SiwcAllowedChain[];
+  allowedRequestTypes: SiwcAllowedRequestType[];
+  contractAllowlist: string[];
+  createdAt: string | null;
+  custodyEnabled: boolean;
+  dappId: number;
+  dappName: string;
+  dappUid: string | null;
+  metadata: Record<string, unknown>;
+  policyId: string | null;
+  policyName: string;
+  policyVersion: number;
+  requiredAcr: typeof PASSKEY_ACR | null;
+  sandboxMode: boolean;
+  signingEnabled: boolean;
+  status: SiwcPolicyStatus;
+  transactionValueLimitUsd: number | null;
+  updatedAt: string | null;
+  webhookEventSubscriptions: string[];
+}
+
+export interface SiwcPolicyUpsertInput {
+  allowedChains: SiwcAllowedChain[];
+  allowedRequestTypes: SiwcAllowedRequestType[];
+  contractAllowlist?: string[];
+  custodyEnabled: boolean;
+  dappId: number;
+  metadata?: Record<string, unknown>;
+  policyName: string;
+  requiredAcr?: typeof PASSKEY_ACR | null;
+  sandboxMode: boolean;
+  signingEnabled: boolean;
+  status: SiwcPolicyStatus;
+  transactionValueLimitUsd?: number | null;
+  webhookEventSubscriptions?: string[];
+}
+
+export interface SiwcPolicyList {
+  generatedAt: string;
+  policies: SiwcPolicy[];
+}
+
+class SiwcPolicyInputError extends Error {}
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is string => typeof entry === 'string');
+};
+
+const normalizeMetadata = (value: unknown): Record<string, unknown> => {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  return {};
+};
+
+const normalizeNumber = (value: number | string | null | undefined) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+};
+
+const uniqueStrings = (values: string[]) => Array.from(new Set(values));
+
+const ensureAllowedValues = <T extends string>(
+  values: string[],
+  allowed: readonly T[],
+  fieldName: string
+): T[] => {
+  const normalized = uniqueStrings(values.map((value) => value.trim()).filter(Boolean));
+  const invalid = normalized.filter((value) => !allowed.includes(value as T));
+
+  if (invalid.length > 0) {
+    throw new SiwcPolicyInputError(
+      `${fieldName} contains unsupported values: ${invalid.join(', ')}`
+    );
+  }
+
+  return normalized as T[];
+};
+
+const mapPolicy = (dapp: DappRow, policy?: SiwcPolicyRow | null): SiwcPolicy => {
+  const dappId = Number(dapp.id);
+
+  return {
+    allowedChains: ensureAllowedValues(
+      normalizeStringArray(policy?.allowed_chains),
+      ALLOWED_CHAINS,
+      'allowedChains'
+    ),
+    allowedRequestTypes: ensureAllowedValues(
+      normalizeStringArray(policy?.allowed_request_types),
+      ALLOWED_REQUEST_TYPES,
+      'allowedRequestTypes'
+    ),
+    contractAllowlist: uniqueStrings(normalizeStringArray(policy?.contract_allowlist)),
+    createdAt: policy?.created_at ?? null,
+    custodyEnabled: policy?.custody_enabled ?? false,
+    dappId,
+    dappName: dapp.appname ?? `Dapp ${dappId}`,
+    dappUid: dapp.uid ?? null,
+    metadata: normalizeMetadata(policy?.metadata),
+    policyId: policy?.id ?? null,
+    policyName: policy?.policy_name ?? 'Default SIWC policy',
+    policyVersion: policy?.policy_version ?? 0,
+    requiredAcr:
+      policy?.required_acr === PASSKEY_ACR ? PASSKEY_ACR : null,
+    sandboxMode: policy?.sandbox_mode ?? true,
+    signingEnabled: policy?.signing_enabled ?? false,
+    status: policy?.status ?? 'disabled',
+    transactionValueLimitUsd: normalizeNumber(policy?.transaction_value_limit_usd),
+    updatedAt: policy?.updated_at ?? null,
+    webhookEventSubscriptions: uniqueStrings(
+      normalizeStringArray(policy?.webhook_event_subscriptions)
+    ),
+  };
+};
+
+export const normalizeSiwcPolicyInput = (
+  input: SiwcPolicyUpsertInput
+): SiwcPolicyUpsertInput => {
+  const allowedChains = ensureAllowedValues(
+    input.allowedChains,
+    ALLOWED_CHAINS,
+    'allowedChains'
+  );
+  const allowedRequestTypes = ensureAllowedValues(
+    input.allowedRequestTypes,
+    ALLOWED_REQUEST_TYPES,
+    'allowedRequestTypes'
+  );
+  const status = input.status;
+
+  if (!POLICY_STATUSES.includes(status)) {
+    throw new SiwcPolicyInputError('status must be disabled, enabled, or suspended');
+  }
+
+  if (input.signingEnabled && input.requiredAcr !== PASSKEY_ACR) {
+    throw new SiwcPolicyInputError('Signing policies must require passkey ACR');
+  }
+
+  if (status === 'enabled' && input.signingEnabled && allowedRequestTypes.length === 0) {
+    throw new SiwcPolicyInputError('Signing policies must allow at least one request type');
+  }
+
+  if ((input.custodyEnabled || input.signingEnabled) && allowedChains.length === 0) {
+    throw new SiwcPolicyInputError('Custody or signing policies must allow at least one chain');
+  }
+
+  return {
+    ...input,
+    allowedChains,
+    allowedRequestTypes,
+    contractAllowlist: uniqueStrings(input.contractAllowlist ?? []),
+    metadata: input.metadata ?? {},
+    requiredAcr: input.signingEnabled ? PASSKEY_ACR : input.requiredAcr ?? null,
+    transactionValueLimitUsd: input.transactionValueLimitUsd ?? null,
+    webhookEventSubscriptions: uniqueStrings(input.webhookEventSubscriptions ?? []),
+  };
+};
+
+const logPolicyEvent = async (
+  context: AdminRequestContext,
+  eventType: string,
+  policy: SiwcPolicy
+) => {
+  const { error } = await context.supabase.from('api_security_events').insert({
+    actor_identifier: context.adminUser.uid,
+    actor_type: 'admin',
+    details: {
+      dapp_id: policy.dappId,
+      policy_version: policy.policyVersion,
+      status: policy.status,
+    },
+    event_id: `api_event_${randomUUID().replace(/-/g, '')}`,
+    event_type: eventType,
+    outcome: 'success',
+    request_id: context.requestId,
+    route: 'admin/siwc/policies/upsert',
+  });
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const listSiwcPolicies = async (
+  supabase: SupabaseClient
+): Promise<SiwcPolicyList> => {
+  const dappsResponse = await supabase
+    .from('dapps')
+    .select('id,uid,appname')
+    .order('id', { ascending: true });
+
+  if (dappsResponse.error) {
+    throw dappsResponse.error;
+  }
+
+  const dapps = (dappsResponse.data ?? []) as DappRow[];
+  const dappIds = dapps.map((dapp) => Number(dapp.id)).filter(Number.isFinite);
+
+  if (dappIds.length === 0) {
+    return {
+      generatedAt: new Date().toISOString(),
+      policies: [],
+    };
+  }
+
+  const policiesResponse = await supabase
+    .from('siwc_signing_policies')
+    .select('*')
+    .in('dapp_id', dappIds);
+
+  if (policiesResponse.error) {
+    throw policiesResponse.error;
+  }
+
+  const policiesByDappId = new Map<number, SiwcPolicyRow>();
+  for (const policy of (policiesResponse.data ?? []) as SiwcPolicyRow[]) {
+    policiesByDappId.set(Number(policy.dapp_id), policy);
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    policies: dapps.map((dapp) =>
+      mapPolicy(dapp, policiesByDappId.get(Number(dapp.id)) ?? null)
+    ),
+  };
+};
+
+export const upsertSiwcPolicy = async (
+  context: AdminRequestContext,
+  input: SiwcPolicyUpsertInput
+): Promise<SiwcPolicy> => {
+  const normalized = normalizeSiwcPolicyInput(input);
+  const dappResponse = await context.supabase
+    .from('dapps')
+    .select('id,uid,appname')
+    .match({
+      admin_uid: context.adminUser.uid,
+      id: normalized.dappId,
+    })
+    .maybeSingle();
+
+  if (dappResponse.error) {
+    throw dappResponse.error;
+  }
+
+  if (!dappResponse.data) {
+    throw new SiwcPolicyInputError('Dapp was not found for this admin user');
+  }
+
+  const existingResponse = await context.supabase
+    .from('siwc_signing_policies')
+    .select('*')
+    .match({ dapp_id: normalized.dappId })
+    .maybeSingle();
+
+  if (existingResponse.error) {
+    throw existingResponse.error;
+  }
+
+  const existing = existingResponse.data as SiwcPolicyRow | null;
+  const payload = {
+    allowed_chains: normalized.allowedChains,
+    allowed_request_types: normalized.allowedRequestTypes,
+    contract_allowlist: normalized.contractAllowlist,
+    custody_enabled: normalized.custodyEnabled,
+    dapp_id: normalized.dappId,
+    metadata: normalized.metadata,
+    policy_name: normalized.policyName,
+    policy_version: (existing?.policy_version ?? 0) + 1,
+    required_acr: normalized.requiredAcr,
+    sandbox_mode: normalized.sandboxMode,
+    signing_enabled: normalized.signingEnabled,
+    status: normalized.status,
+    transaction_value_limit_usd: normalized.transactionValueLimitUsd,
+    updated_at: new Date().toISOString(),
+    webhook_event_subscriptions: normalized.webhookEventSubscriptions,
+  };
+
+  const write = existing
+    ? context.supabase
+        .from('siwc_signing_policies')
+        .update(payload)
+        .match({ dapp_id: normalized.dappId })
+    : context.supabase.from('siwc_signing_policies').insert(payload);
+
+  const writeResponse = await write.select('*').maybeSingle();
+
+  if (writeResponse.error) {
+    throw writeResponse.error;
+  }
+
+  const policy = mapPolicy(
+    dappResponse.data as DappRow,
+    writeResponse.data as SiwcPolicyRow
+  );
+  const eventType =
+    policy.status === 'suspended'
+      ? 'siwc_policy.suspended'
+      : existing
+        ? 'siwc_policy.updated'
+        : 'siwc_policy.created';
+
+  await logPolicyEvent(context, eventType, policy);
+
+  return policy;
+};
+
+export const isSiwcPolicyInputError = (
+  error: unknown
+): error is SiwcPolicyInputError =>
+  error instanceof SiwcPolicyInputError;

--- a/apps/admin/lib/server/siwcPolicies.ts
+++ b/apps/admin/lib/server/siwcPolicies.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'crypto';
-import type { SupabaseClient } from '@supabase/supabase-js';
 
 import type { AdminRequestContext } from './adminApi';
 
@@ -233,11 +232,12 @@ const logPolicyEvent = async (
 };
 
 export const listSiwcPolicies = async (
-  supabase: SupabaseClient
+  context: AdminRequestContext
 ): Promise<SiwcPolicyList> => {
-  const dappsResponse = await supabase
+  const dappsResponse = await context.supabase
     .from('dapps')
     .select('id,uid,appname')
+    .match({ admin_uid: context.adminUser.uid })
     .order('id', { ascending: true });
 
   if (dappsResponse.error) {
@@ -254,7 +254,7 @@ export const listSiwcPolicies = async (
     };
   }
 
-  const policiesResponse = await supabase
+  const policiesResponse = await context.supabase
     .from('siwc_signing_policies')
     .select('*')
     .in('dapp_id', dappIds);

--- a/apps/admin/pages/api/admin/siwc/policies/list.ts
+++ b/apps/admin/pages/api/admin/siwc/policies/list.ts
@@ -20,7 +20,7 @@ const list = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   try {
-    const data = await listSiwcPolicies(request.context.supabase);
+    const data = await listSiwcPolicies(request.context);
     return res.status(200).json({ data });
   } catch (error) {
     return sendServerError(res, error, 'Failed to load SIWC policies');

--- a/apps/admin/pages/api/admin/siwc/policies/list.ts
+++ b/apps/admin/pages/api/admin/siwc/policies/list.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { adminSiwcPolicyListSchema } from '../../../../../lib/server/adminSchemas';
+import {
+  prepareAdminApiRequest,
+  sendServerError,
+} from '../../../../../lib/server/adminApi';
+import { listSiwcPolicies } from '../../../../../lib/server/siwcPolicies';
+
+const list = async (req: NextApiRequest, res: NextApiResponse) => {
+  const request = await prepareAdminApiRequest(req, res, {
+    actor: 'admin',
+    bodySchema: adminSiwcPolicyListSchema,
+    rateLimitGroup: 'admin_read',
+    route: 'admin/siwc/policies/list',
+  });
+
+  if (!request) {
+    return;
+  }
+
+  try {
+    const data = await listSiwcPolicies(request.context.supabase);
+    return res.status(200).json({ data });
+  } catch (error) {
+    return sendServerError(res, error, 'Failed to load SIWC policies');
+  }
+};
+
+export default list;

--- a/apps/admin/pages/api/admin/siwc/policies/upsert.ts
+++ b/apps/admin/pages/api/admin/siwc/policies/upsert.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { adminSiwcPolicyUpsertSchema } from '../../../../../lib/server/adminSchemas';
+import {
+  prepareAdminApiRequest,
+  sendBadRequest,
+  sendServerError,
+} from '../../../../../lib/server/adminApi';
+import {
+  isSiwcPolicyInputError,
+  upsertSiwcPolicy,
+} from '../../../../../lib/server/siwcPolicies';
+
+const upsert = async (req: NextApiRequest, res: NextApiResponse) => {
+  const request = await prepareAdminApiRequest(req, res, {
+    actor: 'admin',
+    bodySchema: adminSiwcPolicyUpsertSchema,
+    rateLimitGroup: 'admin_sensitive',
+    route: 'admin/siwc/policies/upsert',
+  });
+
+  if (!request) {
+    return;
+  }
+
+  try {
+    const policy = await upsertSiwcPolicy(request.context, request.body);
+    return res.status(200).json({ data: { policy } });
+  } catch (error) {
+    if (isSiwcPolicyInputError(error)) {
+      return sendBadRequest(res, error.message);
+    }
+
+    return sendServerError(res, error, 'Failed to save SIWC policy');
+  }
+};
+
+export default upsert;

--- a/apps/passport/components/profile/index.tsx
+++ b/apps/passport/components/profile/index.tsx
@@ -114,14 +114,22 @@ type SiwcSigningRequestSummary = {
   expiresAt: string
   payloadHash: string
   payloadSummary: Record<string, unknown>
+  policyDecision: string | null
   policyVersion: number
   publicAddress: string
   rejectedAt: string | null
   requiredAcr: "urn:cubid:acr:passkey" | null
   requestType: "message" | "typed_data" | "transaction"
   result: unknown
+  riskLevel: "low" | "medium" | "high" | null
+  riskReasons: string[]
   signingRequestId: string
+  stepUpRequired: boolean
   status: string
+  transactionContractAddress: string | null
+  transactionDeclaredValueUsd: number | null
+  transactionOperationType: string | null
+  transactionRecipient: string | null
   updatedAt: string
   userAccountId: string
 }
@@ -1553,6 +1561,12 @@ export const Profile = () => {
                   typeof request.payloadSummary?.preview === "string"
                     ? request.payloadSummary.preview
                     : request.payloadHash
+                const riskTone =
+                  request.riskLevel === "high"
+                    ? "bg-red-100 text-red-700"
+                    : request.riskLevel === "medium"
+                      ? "bg-amber-100 text-amber-700"
+                      : "bg-emerald-100 text-emerald-700"
 
                 return (
                   <div
@@ -1577,6 +1591,13 @@ export const Profile = () => {
                           >
                             {request.status.replace(/_/g, " ")}
                           </span>
+                          {request.riskLevel && (
+                            <span
+                              className={`rounded-full px-2 py-1 text-xs ${riskTone}`}
+                            >
+                              {request.riskLevel} risk
+                            </span>
+                          )}
                         </div>
                         <p className="mt-1 break-all text-xs text-muted-foreground">
                           {request.publicAddress}
@@ -1606,9 +1627,50 @@ export const Profile = () => {
                         {request.requiredAcr ?? "standard Passport session"}
                       </p>
                       <p>
+                        <span className="text-muted-foreground">Step-up:</span>{" "}
+                        {request.stepUpRequired
+                          ? "fresh passkey required"
+                          : "not required"}
+                      </p>
+                      {request.requestType === "transaction" && (
+                        <>
+                          <p>
+                            <span className="text-muted-foreground">
+                              Action:
+                            </span>{" "}
+                            {request.transactionOperationType ?? "unknown"}
+                          </p>
+                          <p className="break-all">
+                            <span className="text-muted-foreground">
+                              Recipient:
+                            </span>{" "}
+                            {request.transactionRecipient ?? "not provided"}
+                          </p>
+                          <p className="break-all">
+                            <span className="text-muted-foreground">
+                              Contract:
+                            </span>{" "}
+                            {request.transactionContractAddress ?? "none"}
+                          </p>
+                          <p>
+                            <span className="text-muted-foreground">
+                              Declared value:
+                            </span>{" "}
+                            {request.transactionDeclaredValueUsd !== null
+                              ? `$${request.transactionDeclaredValueUsd}`
+                              : "not declared"}
+                          </p>
+                        </>
+                      )}
+                      <p>
                         <span className="text-muted-foreground">Updated:</span>{" "}
                         {dayjs(request.updatedAt).format("YYYY-MM-DD HH:mm")}
                       </p>
+                      {(request.riskReasons ?? []).length > 0 && (
+                        <p className="break-all text-amber-700 md:col-span-2">
+                          Risk notes: {(request.riskReasons ?? []).join(", ")}
+                        </p>
+                      )}
                       {request.errorMessage && (
                         <p className="text-amber-700 md:col-span-2">
                           {request.errorMessage}

--- a/apps/passport/components/profile/index.tsx
+++ b/apps/passport/components/profile/index.tsx
@@ -79,6 +79,28 @@ type AppDisclosureGrantSummary = {
   source: "allow_page"
 }
 
+type SiwcAccountSummary = {
+  accountId: string
+  accountStatus: string
+  chain: string
+  createdAt: string
+  custodyEnabled: boolean
+  custodyStatus: string
+  dappId: string
+  dappName: string
+  dappUserAccountId: string
+  dappUserUuid: string
+  label: string | null
+  linkStatus: string
+  policyStatus: string
+  policyVersion: number
+  publicAddress: string
+  requiredAcr: "urn:cubid:acr:passkey" | null
+  sandboxMode: boolean
+  signingEnabled: boolean
+  updatedAt: string
+}
+
 type PasskeyDeviceSummary = {
   authenticatorAttachment: string | null
   backupEligible: boolean
@@ -212,6 +234,8 @@ export const Profile = () => {
     useState(false)
   const [revokingAppDisclosureGrantId, setRevokingAppDisclosureGrantId] =
     useState<string | null>(null)
+  const [siwcAccounts, setSiwcAccounts] = useState<SiwcAccountSummary[]>([])
+  const [siwcAccountsLoading, setSiwcAccountsLoading] = useState(false)
   const [actorProfile, setActorProfile] = useState<ActorProfileSummary | null>(
     null
   )
@@ -656,6 +680,33 @@ export const Profile = () => {
     },
     [fetchAppDisclosureGrants, getOidcAuthHeaders]
   )
+
+  const fetchSiwcAccounts = useCallback(async () => {
+    if (!email && !phone) {
+      setSiwcAccounts([])
+      return
+    }
+
+    setSiwcAccountsLoading(true)
+    try {
+      const headers = await getOidcAuthHeaders()
+      const { data } = await axios.post<{ data: SiwcAccountSummary[] }>(
+        "/api/siwc/accounts/list",
+        {},
+        { headers }
+      )
+      setSiwcAccounts(data.data ?? [])
+    } catch (error) {
+      console.error(error)
+      toast.error("Failed to load app-scoped accounts")
+    } finally {
+      setSiwcAccountsLoading(false)
+    }
+  }, [email, phone, getOidcAuthHeaders])
+
+  useEffect(() => {
+    fetchSiwcAccounts()
+  }, [fetchSiwcAccounts])
 
   const selectedActorPolicy = actorValidationPolicies[actorType]
 
@@ -1243,6 +1294,118 @@ export const Profile = () => {
                   </div>
                 )
               })}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>App-scoped accounts</CardTitle>
+            <CardDescription>
+              View Cubid-generated accounts that belong to one app at a time.
+              These are not universal wallets, and Cubid never shows private
+              keys or encrypted custody material here.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4 flex justify-end">
+              <Button
+                disabled={siwcAccountsLoading}
+                onClick={fetchSiwcAccounts}
+                variant="outline"
+              >
+                {siwcAccountsLoading ? "Refreshing..." : "Refresh"}
+              </Button>
+            </div>
+            {siwcAccountsLoading && siwcAccounts.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                Loading app-scoped accounts...
+              </p>
+            )}
+            {!siwcAccountsLoading && siwcAccounts.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                No app-scoped accounts found.
+              </p>
+            )}
+            <div className="space-y-3">
+              {siwcAccounts.map((account) => (
+                <div
+                  key={account.dappUserAccountId}
+                  className="rounded-lg border bg-background p-4"
+                >
+                  <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="font-semibold">{account.dappName}</h3>
+                        <span className="rounded-full bg-muted px-2 py-1 text-xs uppercase">
+                          {account.chain}
+                        </span>
+                        <span
+                          className={`rounded-full px-2 py-1 text-xs ${
+                            account.signingEnabled &&
+                            account.policyStatus === "enabled"
+                              ? "bg-emerald-100 text-emerald-700"
+                              : "bg-amber-100 text-amber-700"
+                          }`}
+                        >
+                          {account.signingEnabled &&
+                          account.policyStatus === "enabled"
+                            ? "Signing policy enabled"
+                            : "Signing not live"}
+                        </span>
+                      </div>
+                      <p className="mt-1 break-all text-xs text-muted-foreground">
+                        {account.publicAddress}
+                      </p>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Policy v{account.policyVersion} · {account.policyStatus}
+                    </div>
+                  </div>
+
+                  <div className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+                    <p>
+                      <span className="text-muted-foreground">Label:</span>{" "}
+                      {account.label ?? "No label"}
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">Custody:</span>{" "}
+                      {account.custodyStatus}
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">Account:</span>{" "}
+                      {account.accountStatus}
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">App link:</span>{" "}
+                      {account.linkStatus}
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">Signing:</span>{" "}
+                      {account.signingEnabled
+                        ? `requires ${account.requiredAcr ?? "configured auth"}`
+                        : "disabled"}
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">Sandbox:</span>{" "}
+                      {account.sandboxMode ? "yes" : "no"}
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">Created:</span>{" "}
+                      {dayjs(account.createdAt).format("YYYY-MM-DD HH:mm")}
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">Updated:</span>{" "}
+                      {dayjs(account.updatedAt).format("YYYY-MM-DD HH:mm")}
+                    </p>
+                  </div>
+
+                  <p className="mt-4 text-xs text-muted-foreground">
+                    Signing requests are not available yet. Future requests
+                    must use Passport approval and the app policy shown above.
+                  </p>
+                </div>
+              ))}
             </div>
           </CardContent>
         </Card>

--- a/apps/passport/components/profile/index.tsx
+++ b/apps/passport/components/profile/index.tsx
@@ -1510,10 +1510,10 @@ export const Profile = () => {
                     </p>
                   </div>
 
-                  <p className="mt-4 text-xs text-muted-foreground">
-                    Signing requests are not available yet. Future requests
-                    must use Passport approval and the app policy shown above.
-                  </p>
+	                  <p className="mt-4 text-xs text-muted-foreground">
+	                    Signing requests use Passport approval and the app policy
+	                    shown above. Transaction signing remains disabled.
+	                  </p>
                 </div>
               ))}
             </div>

--- a/apps/passport/components/profile/index.tsx
+++ b/apps/passport/components/profile/index.tsx
@@ -101,6 +101,31 @@ type SiwcAccountSummary = {
   updatedAt: string
 }
 
+type SiwcSigningRequestSummary = {
+  approvedAt: string | null
+  chain: string
+  completedAt: string | null
+  createdAt: string
+  dappId: string
+  dappName: string
+  dappUserUuid: string
+  errorCode: string | null
+  errorMessage: string | null
+  expiresAt: string
+  payloadHash: string
+  payloadSummary: Record<string, unknown>
+  policyVersion: number
+  publicAddress: string
+  rejectedAt: string | null
+  requiredAcr: "urn:cubid:acr:passkey" | null
+  requestType: "message" | "typed_data" | "transaction"
+  result: unknown
+  signingRequestId: string
+  status: string
+  updatedAt: string
+  userAccountId: string
+}
+
 type PasskeyDeviceSummary = {
   authenticatorAttachment: string | null
   backupEligible: boolean
@@ -236,6 +261,13 @@ export const Profile = () => {
     useState<string | null>(null)
   const [siwcAccounts, setSiwcAccounts] = useState<SiwcAccountSummary[]>([])
   const [siwcAccountsLoading, setSiwcAccountsLoading] = useState(false)
+  const [siwcSigningRequests, setSiwcSigningRequests] = useState<
+    SiwcSigningRequestSummary[]
+  >([])
+  const [siwcSigningRequestsLoading, setSiwcSigningRequestsLoading] =
+    useState(false)
+  const [actingSiwcSigningRequestId, setActingSiwcSigningRequestId] =
+    useState<string | null>(null)
   const [actorProfile, setActorProfile] = useState<ActorProfileSummary | null>(
     null
   )
@@ -707,6 +739,76 @@ export const Profile = () => {
   useEffect(() => {
     fetchSiwcAccounts()
   }, [fetchSiwcAccounts])
+
+  const fetchSiwcSigningRequests = useCallback(async () => {
+    if (!email && !phone) {
+      setSiwcSigningRequests([])
+      return
+    }
+
+    setSiwcSigningRequestsLoading(true)
+    try {
+      const headers = await getOidcAuthHeaders()
+      const { data } = await axios.post<{ data: SiwcSigningRequestSummary[] }>(
+        "/api/siwc/signing/requests/list",
+        {},
+        { headers }
+      )
+      setSiwcSigningRequests(data.data ?? [])
+    } catch (error) {
+      console.error(error)
+      toast.error("Failed to load signing requests")
+    } finally {
+      setSiwcSigningRequestsLoading(false)
+    }
+  }, [email, phone, getOidcAuthHeaders])
+
+  useEffect(() => {
+    fetchSiwcSigningRequests()
+  }, [fetchSiwcSigningRequests])
+
+  const decideSiwcSigningRequest = useCallback(
+    async (
+      request: SiwcSigningRequestSummary,
+      decision: "approve" | "reject"
+    ) => {
+      const verb = decision === "approve" ? "Approve" : "Reject"
+      if (
+        !window.confirm(
+          `${verb} signing request from ${request.dappName} for ${request.chain}?`
+        )
+      ) {
+        return
+      }
+
+      setActingSiwcSigningRequestId(request.signingRequestId)
+      try {
+        const headers = await getOidcAuthHeaders()
+        await axios.post(
+          `/api/siwc/signing/requests/${decision}`,
+          { signingRequestId: request.signingRequestId },
+          { headers }
+        )
+        toast.success(
+          decision === "approve"
+            ? "Signing request approved"
+            : "Signing request rejected"
+        )
+        await fetchSiwcSigningRequests()
+      } catch (error: any) {
+        console.error(error)
+        const message =
+          error?.response?.data?.error?.message ??
+          (decision === "approve"
+            ? "Failed to approve signing request"
+            : "Failed to reject signing request")
+        toast.error(message)
+      } finally {
+        setActingSiwcSigningRequestId(null)
+      }
+    },
+    [fetchSiwcSigningRequests, getOidcAuthHeaders]
+  )
 
   const selectedActorPolicy = actorValidationPolicies[actorType]
 
@@ -1406,6 +1508,144 @@ export const Profile = () => {
                   </p>
                 </div>
               ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>Signing requests</CardTitle>
+            <CardDescription>
+              Review app requests to sign with Cubid-generated accounts. Only
+              approve requests you recognize; transaction signing remains
+              disabled until risk controls are live.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4 flex justify-end">
+              <Button
+                disabled={siwcSigningRequestsLoading}
+                onClick={fetchSiwcSigningRequests}
+                variant="outline"
+              >
+                {siwcSigningRequestsLoading ? "Refreshing..." : "Refresh"}
+              </Button>
+            </div>
+            {siwcSigningRequestsLoading && siwcSigningRequests.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                Loading signing requests...
+              </p>
+            )}
+            {!siwcSigningRequestsLoading &&
+              siwcSigningRequests.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  No signing requests found.
+                </p>
+              )}
+            <div className="space-y-3">
+              {siwcSigningRequests.map((request) => {
+                const pending = request.status === "pending_user_approval"
+                const payloadKind =
+                  typeof request.payloadSummary?.kind === "string"
+                    ? request.payloadSummary.kind
+                    : request.requestType
+                const payloadPreview =
+                  typeof request.payloadSummary?.preview === "string"
+                    ? request.payloadSummary.preview
+                    : request.payloadHash
+
+                return (
+                  <div
+                    key={request.signingRequestId}
+                    className="rounded-lg border bg-background p-4"
+                  >
+                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="font-semibold">{request.dappName}</h3>
+                          <span className="rounded-full bg-muted px-2 py-1 text-xs uppercase">
+                            {request.chain}
+                          </span>
+                          <span
+                            className={`rounded-full px-2 py-1 text-xs ${
+                              pending
+                                ? "bg-blue-100 text-blue-700"
+                                : request.status === "completed"
+                                  ? "bg-emerald-100 text-emerald-700"
+                                  : "bg-muted text-muted-foreground"
+                            }`}
+                          >
+                            {request.status.replace(/_/g, " ")}
+                          </span>
+                        </div>
+                        <p className="mt-1 break-all text-xs text-muted-foreground">
+                          {request.publicAddress}
+                        </p>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Policy v{request.policyVersion} · expires{" "}
+                        {dayjs(request.expiresAt).format("YYYY-MM-DD HH:mm")}
+                      </div>
+                    </div>
+
+                    <div className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+                      <p>
+                        <span className="text-muted-foreground">Type:</span>{" "}
+                        {request.requestType}
+                      </p>
+                      <p>
+                        <span className="text-muted-foreground">Payload:</span>{" "}
+                        {payloadKind}
+                      </p>
+                      <p className="break-all md:col-span-2">
+                        <span className="text-muted-foreground">Summary:</span>{" "}
+                        {payloadPreview}
+                      </p>
+                      <p>
+                        <span className="text-muted-foreground">Required auth:</span>{" "}
+                        {request.requiredAcr ?? "standard Passport session"}
+                      </p>
+                      <p>
+                        <span className="text-muted-foreground">Updated:</span>{" "}
+                        {dayjs(request.updatedAt).format("YYYY-MM-DD HH:mm")}
+                      </p>
+                      {request.errorMessage && (
+                        <p className="text-amber-700 md:col-span-2">
+                          {request.errorMessage}
+                        </p>
+                      )}
+                    </div>
+
+                    {pending && (
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        <Button
+                          disabled={
+                            actingSiwcSigningRequestId ===
+                            request.signingRequestId
+                          }
+                          onClick={() =>
+                            decideSiwcSigningRequest(request, "approve")
+                          }
+                        >
+                          Approve
+                        </Button>
+                        <Button
+                          disabled={
+                            actingSiwcSigningRequestId ===
+                            request.signingRequestId
+                          }
+                          onClick={() =>
+                            decideSiwcSigningRequest(request, "reject")
+                          }
+                          variant="outline"
+                        >
+                          Reject
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </CardContent>
         </Card>

--- a/apps/passport/lib/server/apiV3Webhooks.ts
+++ b/apps/passport/lib/server/apiV3Webhooks.ts
@@ -1,5 +1,10 @@
 import crypto from "crypto"
 
+import axios from "axios"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import { resolveWebhookSigningSecret } from "./webhookSigningSecrets"
+
 export const API_V3_WEBHOOK_VERSION = "v3" as const
 export const API_V3_WEBHOOK_PAYLOAD_VERSION = "2026-05-03" as const
 export const API_V3_WEBHOOK_SIGNATURE_VERSION = "v1" as const
@@ -16,18 +21,33 @@ export const LEGACY_TO_API_V3_WEBHOOK_EVENT = {
 
 export type LegacyWebhookEventType = keyof typeof LEGACY_TO_API_V3_WEBHOOK_EVENT
 
+export const SIWC_API_V3_WEBHOOK_EVENTS = [
+  "wallet.created",
+  "wallet.policy.denied",
+  "wallet.signature.completed",
+  "wallet.signature.failed",
+  "wallet.signing_request.approved",
+  "wallet.signing_request.cancelled",
+  "wallet.signing_request.created",
+  "wallet.signing_request.rejected",
+  "wallet.signing_request.step_up_failed",
+] as const
+
+export type SiwcApiV3WebhookEventType =
+  (typeof SIWC_API_V3_WEBHOOK_EVENTS)[number]
+
 export type ApiV3WebhookPayload = {
   apiVersion: typeof API_V3_WEBHOOK_VERSION
   createdAt: string
   dapp: {
     id: string
   }
-  data: {
-    stampId: number
-  }
+  data: Record<string, unknown>
   eventId: string
-  eventType: (typeof LEGACY_TO_API_V3_WEBHOOK_EVENT)[LegacyWebhookEventType]
-  legacyEventType: LegacyWebhookEventType
+  eventType:
+    | (typeof LEGACY_TO_API_V3_WEBHOOK_EVENT)[LegacyWebhookEventType]
+    | SiwcApiV3WebhookEventType
+  legacyEventType?: LegacyWebhookEventType
   payloadVersion: typeof API_V3_WEBHOOK_PAYLOAD_VERSION
   requestId: string
   subject: {
@@ -41,16 +61,18 @@ const sha256Hex = (value: string) =>
 export const buildApiV3WebhookEventId = (input: {
   dappId: number | string
   dappUserUuid: string
-  legacyEventType: LegacyWebhookEventType
-  stampId: number
+  eventKey?: string | number
+  eventType?: string
+  legacyEventType?: LegacyWebhookEventType
+  stampId?: number
 }) => {
   const digest = sha256Hex(
     [
       API_V3_WEBHOOK_VERSION,
       input.dappId,
       input.dappUserUuid,
-      input.legacyEventType,
-      input.stampId,
+      input.eventType ?? input.legacyEventType,
+      input.eventKey ?? input.stampId,
     ].join(":")
   )
   return `wh_evt_${digest.slice(0, 32)}`
@@ -83,6 +105,35 @@ export const buildApiV3WebhookPayload = (input: {
     },
   }
 }
+
+export const buildSiwcApiV3WebhookPayload = (input: {
+  createdAt?: string
+  dappId: number | string
+  dappUserUuid: string
+  eventKey: string
+  eventType: SiwcApiV3WebhookEventType
+  requestId: string
+  data: Record<string, unknown>
+}): ApiV3WebhookPayload => ({
+  apiVersion: API_V3_WEBHOOK_VERSION,
+  createdAt: input.createdAt ?? new Date().toISOString(),
+  dapp: {
+    id: String(input.dappId),
+  },
+  data: input.data,
+  eventId: buildApiV3WebhookEventId({
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    eventKey: input.eventKey,
+    eventType: input.eventType,
+  }),
+  eventType: input.eventType,
+  payloadVersion: API_V3_WEBHOOK_PAYLOAD_VERSION,
+  requestId: input.requestId,
+  subject: {
+    dappUserUuid: input.dappUserUuid,
+  },
+})
 
 export const serializeApiV3WebhookPayload = (
   payload: ApiV3WebhookPayload
@@ -144,4 +195,228 @@ export const classifyApiV3WebhookDeliveryError = (error: unknown) => {
   }
 
   return "request_error"
+}
+
+const normalizeStringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : []
+
+const upsertApiV3WebhookEvent = async (
+  supabase: SupabaseClient,
+  payload: ApiV3WebhookPayload
+) => {
+  const { data: existingEvents, error: existingError } = await supabase
+    .from("webhook_events")
+    .select("*")
+    .eq("dapp_id", payload.dapp.id)
+    .eq("event_id", payload.eventId)
+
+  if (existingError) {
+    throw existingError
+  }
+
+  let eventRow = existingEvents?.[0] ?? null
+  const attemptNumber = Number(eventRow?.retries ?? 0) + 1
+  const patch = {
+    api_version: payload.apiVersion,
+    dapp_id: payload.dapp.id,
+    event_id: payload.eventId,
+    event_type: payload.eventType,
+    last_attempt_at: new Date().toISOString(),
+    payload,
+    payload_version: payload.payloadVersion,
+    retries: attemptNumber,
+  }
+
+  if (eventRow) {
+    const { data, error } = await supabase
+      .from("webhook_events")
+      .update(patch)
+      .eq("id", eventRow.id)
+      .select("*")
+
+    if (error) {
+      throw error
+    }
+
+    eventRow = data?.[0] ?? eventRow
+  } else {
+    const { data, error } = await supabase
+      .from("webhook_events")
+      .insert(patch)
+      .select("*")
+
+    if (error) {
+      throw error
+    }
+
+    eventRow = data?.[0] ?? null
+  }
+
+  return { attemptNumber, eventRow }
+}
+
+export const deliverApiV3WebhookPayload = async (input: {
+  payload: ApiV3WebhookPayload
+  signingSecret: string
+  supabase: SupabaseClient
+  webhookUrl: string
+}) => {
+  const payloadBody = serializeApiV3WebhookPayload(input.payload)
+  const headers = buildApiV3WebhookHeaders({
+    body: payloadBody,
+    eventId: input.payload.eventId,
+    secret: input.signingSecret,
+  })
+  const { attemptNumber, eventRow } = await upsertApiV3WebhookEvent(
+    input.supabase,
+    input.payload
+  )
+
+  try {
+    const response = await axios.post(input.webhookUrl, payloadBody, {
+      headers,
+    })
+
+    await input.supabase.from("webhook_event_deliveries").insert({
+      attempt_number: attemptNumber,
+      delivery_status: "succeeded",
+      dapp_id: input.payload.dapp.id,
+      event_id: input.payload.eventId,
+      request_body: input.payload,
+      request_headers: {
+        "X-Cubid-Event-Id": headers["X-Cubid-Event-Id"],
+        "X-Cubid-Signature-Version": headers["X-Cubid-Signature-Version"],
+        "X-Cubid-Timestamp": headers["X-Cubid-Timestamp"],
+      },
+      response_body:
+        typeof response.data === "string"
+          ? response.data
+          : JSON.stringify(response.data ?? null),
+      response_status_code: response.status,
+      signature_version: headers["X-Cubid-Signature-Version"],
+      webhook_event_id: eventRow?.id,
+    })
+  } catch (error) {
+    await input.supabase.from("webhook_event_deliveries").insert({
+      attempt_number: attemptNumber,
+      delivery_status: "failed",
+      dapp_id: input.payload.dapp.id,
+      error_category: classifyApiV3WebhookDeliveryError(error),
+      event_id: input.payload.eventId,
+      request_body: input.payload,
+      request_headers: {
+        "X-Cubid-Event-Id": headers["X-Cubid-Event-Id"],
+        "X-Cubid-Signature-Version": headers["X-Cubid-Signature-Version"],
+        "X-Cubid-Timestamp": headers["X-Cubid-Timestamp"],
+      },
+      response_body:
+        typeof (error as { response?: { data?: unknown } })?.response?.data ===
+        "string"
+          ? String((error as { response?: { data?: unknown } }).response?.data)
+          : JSON.stringify(
+              (error as { response?: { data?: unknown }; message?: unknown })
+                ?.response?.data ??
+                (error as { message?: unknown })?.message ??
+                "Unknown error"
+            ),
+      response_status_code:
+        (error as { response?: { status?: number } })?.response?.status ?? 500,
+      signature_version: headers["X-Cubid-Signature-Version"],
+      webhook_event_id: eventRow?.id,
+    })
+  }
+}
+
+export const deliverSiwcApiV3Webhook = async (input: {
+  dappId: number | string
+  dappUserUuid: string
+  eventKey: string
+  eventType: SiwcApiV3WebhookEventType
+  requestId: string
+  data: Record<string, unknown>
+  supabase: SupabaseClient
+}) => {
+  try {
+    const { data: policy, error: policyError } = await input.supabase
+      .from("siwc_signing_policies")
+      .select("webhook_event_subscriptions")
+      .eq("dapp_id", input.dappId)
+      .maybeSingle()
+
+    if (policyError) {
+      throw policyError
+    }
+
+    if (
+      !normalizeStringArray(policy?.webhook_event_subscriptions).includes(
+        input.eventType
+      )
+    ) {
+      return
+    }
+
+    const { data: subscriptions, error: subscriptionError } = await input.supabase
+      .from("dapp_webhook_subscriptions")
+      .select("*")
+      .match({
+        dapp: input.dappId,
+        webhook: input.eventType,
+      })
+
+    if (subscriptionError) {
+      throw subscriptionError
+    }
+
+    const subscription = (subscriptions ?? []).find(
+      (row) => row.status === undefined || row.status === "active"
+    )
+
+    if (!subscription?.webhook_url) {
+      return
+    }
+
+    const signingSecret = await resolveWebhookSigningSecret(
+      input.supabase,
+      subscription
+    )
+
+    if (!signingSecret) {
+      return
+    }
+
+    await deliverApiV3WebhookPayload({
+      payload: buildSiwcApiV3WebhookPayload({
+        dappId: input.dappId,
+        dappUserUuid: input.dappUserUuid,
+        eventKey: input.eventKey,
+        eventType: input.eventType,
+        requestId: input.requestId,
+        data: input.data,
+      }),
+      signingSecret,
+      supabase: input.supabase,
+      webhookUrl: String(subscription.webhook_url),
+    })
+  } catch (error) {
+    try {
+      await input.supabase.from("api_security_events").insert({
+        actor_identifier: String(input.dappId),
+        actor_type: "dapp",
+        details: {
+          dappUserUuid: input.dappUserUuid,
+          error: error instanceof Error ? error.message : String(error),
+          eventType: input.eventType,
+        },
+        event_id: `api_event_${crypto.randomUUID().replace(/-/g, "")}`,
+        event_type: "siwc_webhook.delivery_failed",
+        outcome: "failure",
+        request_id: input.requestId,
+        route: "api_v3.webhook.siwc",
+      })
+    } catch {
+      // SIWC webhooks are best-effort and must not roll back signing state.
+    }
+  }
 }

--- a/apps/passport/lib/server/blockchainAccounts.ts
+++ b/apps/passport/lib/server/blockchainAccounts.ts
@@ -12,6 +12,8 @@ import { KeyPair } from "near-api-js"
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519"
 import { Keypair } from "@solana/web3.js"
 
+import { deliverSiwcApiV3Webhook } from "./apiV3Webhooks"
+
 export const BLOCKCHAIN_PRIVATE_KEY_ALGORITHM =
   "aes-256-gcm-envelope" as const
 export const BLOCKCHAIN_PRIVATE_KEY_ID =
@@ -353,6 +355,22 @@ export async function createGeneratedBlockchainAccount(input: {
       outcome: "success",
       request_id: input.requestId,
       route: "v3.accounts.generate",
+    })
+
+    await deliverSiwcApiV3Webhook({
+      dappId: input.dappId,
+      dappUserUuid: input.dappUserUuid,
+      eventKey: userAccountId,
+      eventType: "wallet.created",
+      requestId: input.requestId,
+      supabase: input.supabase,
+      data: {
+        accountId: userAccountId,
+        chain: chainKey,
+        custodyStatus: String(userAccount.custody_status),
+        dappUserAccountId: String(link.id),
+        publicAddress: String(userAccount.public_address),
+      },
     })
 
     return {

--- a/apps/passport/lib/server/siwcAccountVisibility.ts
+++ b/apps/passport/lib/server/siwcAccountVisibility.ts
@@ -1,0 +1,228 @@
+import type { NextApiRequest } from "next"
+
+import { requirePassportFirebaseUser } from "./oidcConsentManagement"
+import { getPassportSupabase } from "./supabase"
+
+type UserAccountRow = {
+  account_label: string | null
+  chain_key: string
+  created_at: string
+  custody_status: string
+  id: string
+  public_address: string
+  status: string
+  updated_at: string
+  user_id: number | string
+}
+
+type DappUserAccountRow = {
+  created_at: string
+  dapp_id: number | string
+  dapp_user_uuid: string
+  id: string
+  status: string
+  updated_at: string
+  user_account_id: string
+}
+
+type DappRow = {
+  appname?: string | null
+  id: number | string
+}
+
+type SiwcPolicyRow = {
+  custody_enabled: boolean
+  dapp_id: number | string
+  policy_version: number
+  required_acr: string | null
+  sandbox_mode: boolean
+  signing_enabled: boolean
+  status: string
+}
+
+export type PassportSiwcAccountSummary = {
+  accountId: string
+  accountStatus: string
+  chain: string
+  createdAt: string
+  custodyEnabled: boolean
+  custodyStatus: string
+  dappId: string
+  dappName: string
+  dappUserAccountId: string
+  dappUserUuid: string
+  label: string | null
+  linkStatus: string
+  policyStatus: string
+  policyVersion: number
+  publicAddress: string
+  requiredAcr: "urn:cubid:acr:passkey" | null
+  sandboxMode: boolean
+  signingEnabled: boolean
+  updatedAt: string
+}
+
+const resolvePassportUserIds = async (req: NextApiRequest) => {
+  const token = await requirePassportFirebaseUser(req)
+  const supabase = getPassportSupabase()
+  const userIds = new Set<number>()
+
+  if (token.email) {
+    const { data, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("email", token.email)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    if (typeof data?.id === "number") {
+      userIds.add(data.id)
+    }
+  }
+
+  if (token.phone_number) {
+    const { data, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("phone", token.phone_number)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    if (typeof data?.id === "number") {
+      userIds.add(data.id)
+    }
+  }
+
+  return [...userIds]
+}
+
+const mapPolicy = (row?: SiwcPolicyRow | null) => ({
+  custodyEnabled: row?.custody_enabled ?? false,
+  policyStatus: row?.status ?? "disabled",
+  policyVersion: row?.policy_version ?? 0,
+  requiredAcr:
+    row?.required_acr === "urn:cubid:acr:passkey"
+      ? ("urn:cubid:acr:passkey" as const)
+      : null,
+  sandboxMode: row?.sandbox_mode ?? true,
+  signingEnabled: row?.signing_enabled ?? false,
+})
+
+export const listPassportSiwcAccounts = async (
+  req: NextApiRequest
+): Promise<PassportSiwcAccountSummary[]> => {
+  const supabase = getPassportSupabase()
+  const userIds = await resolvePassportUserIds(req)
+
+  if (userIds.length === 0) {
+    return []
+  }
+
+  const { data: accountRows, error: accountError } = await supabase
+    .from("user_accounts")
+    .select(
+      "id,user_id,chain_key,public_address,account_label,custody_status,status,created_at,updated_at"
+    )
+    .in("user_id", userIds)
+    .eq("status", "active")
+
+  if (accountError) {
+    throw accountError
+  }
+
+  const accounts = (accountRows ?? []) as UserAccountRow[]
+  const accountIds = accounts.map((account) => String(account.id))
+
+  if (accountIds.length === 0) {
+    return []
+  }
+
+  const { data: linkRows, error: linkError } = await supabase
+    .from("dapp_user_accounts")
+    .select("id,dapp_user_uuid,user_account_id,dapp_id,status,created_at,updated_at")
+    .in("user_account_id", accountIds)
+    .eq("status", "active")
+
+  if (linkError) {
+    throw linkError
+  }
+
+  const links = (linkRows ?? []) as DappUserAccountRow[]
+
+  if (links.length === 0) {
+    return []
+  }
+
+  const dappIds = [...new Set(links.map((link) => String(link.dapp_id)))]
+  const { data: dappRows, error: dappError } = await supabase
+    .from("dapps")
+    .select("id,appname")
+    .in("id", dappIds)
+
+  if (dappError) {
+    throw dappError
+  }
+
+  const { data: policyRows, error: policyError } = await supabase
+    .from("siwc_signing_policies")
+    .select(
+      "dapp_id,status,policy_version,custody_enabled,signing_enabled,sandbox_mode,required_acr"
+    )
+    .in("dapp_id", dappIds)
+
+  if (policyError) {
+    throw policyError
+  }
+
+  const dappsById = new Map(
+    ((dappRows ?? []) as DappRow[]).map((dapp) => [String(dapp.id), dapp])
+  )
+  const policiesByDappId = new Map(
+    ((policyRows ?? []) as SiwcPolicyRow[]).map((policy) => [
+      String(policy.dapp_id),
+      policy,
+    ])
+  )
+  const accountsById = new Map(
+    accounts.map((account) => [String(account.id), account])
+  )
+
+  return links
+    .flatMap((link): PassportSiwcAccountSummary[] => {
+      const account = accountsById.get(String(link.user_account_id))
+
+      if (!account) {
+        return []
+      }
+
+      const dappId = String(link.dapp_id)
+      const dapp = dappsById.get(dappId)
+      const policy = mapPolicy(policiesByDappId.get(dappId))
+
+      return [
+        {
+          accountId: String(account.id),
+          accountStatus: String(account.status),
+          chain: String(account.chain_key),
+          createdAt: String(account.created_at),
+          custodyStatus: String(account.custody_status),
+          dappId,
+          dappName: dapp?.appname ?? `Dapp ${dappId}`,
+          dappUserAccountId: String(link.id),
+          dappUserUuid: String(link.dapp_user_uuid),
+          label: account.account_label ? String(account.account_label) : null,
+          linkStatus: String(link.status),
+          publicAddress: String(account.public_address),
+          updatedAt: String(account.updated_at),
+          ...policy,
+        },
+      ]
+    })
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+}

--- a/apps/passport/lib/server/siwcSigningRequests.ts
+++ b/apps/passport/lib/server/siwcSigningRequests.ts
@@ -25,8 +25,10 @@ import { getPassportSupabase } from "./supabase"
 
 export const SIWC_PASSKEY_ACR = "urn:cubid:acr:passkey" as const
 const SIGNING_REQUEST_TTL_MS = 10 * 60 * 1000
+const SIWC_PASSKEY_STEP_UP_MAX_AGE_MS = 5 * 60 * 1000
 
 type SigningRequestType = "message" | "transaction" | "typed_data"
+type SiwcRiskLevel = "low" | "medium" | "high"
 type SigningRequestStatus =
   | "approved"
   | "cancelled"
@@ -41,13 +43,16 @@ type SigningRequestStatus =
 type SiwcPolicyRow = {
   allowed_chains: unknown
   allowed_request_types: unknown
+  contract_allowlist: unknown
   custody_enabled: boolean
   dapp_id: number | string
+  metadata: unknown
   policy_version: number
   required_acr: string | null
   sandbox_mode: boolean
   signing_enabled: boolean
   status: string
+  transaction_value_limit_usd: number | string | null
 }
 
 type DappUserRow = {
@@ -89,13 +94,21 @@ type SiwcSigningRequestRow = {
   payload: unknown
   payload_hash: string
   payload_summary: unknown
+  policy_decision: string | null
   policy_version: number
   rejected_at: string | null
   required_acr: string | null
   result: unknown
+  risk_level: string | null
+  risk_reasons: unknown
   request_type: string
   signing_request_id: string
+  step_up_required: boolean | null
   status: SigningRequestStatus
+  transaction_contract_address: string | null
+  transaction_declared_value_usd: number | string | null
+  transaction_operation_type: string | null
+  transaction_recipient: string | null
   updated_at: string
   user_account_id: string
   user_id: number | string
@@ -111,8 +124,20 @@ type PolicyEvaluation = {
   allowed: boolean
   denialCode?: string
   denialMessage?: string
+  policyDecision: string
   policyVersion: number
   requiredAcr: typeof SIWC_PASSKEY_ACR | null
+  risk: TransactionRiskEvaluation
+  stepUpRequired: boolean
+}
+
+type TransactionRiskEvaluation = {
+  contractAddress: string | null
+  declaredValueUsd: number | null
+  operationType: string | null
+  recipient: string | null
+  riskLevel: SiwcRiskLevel
+  riskReasons: string[]
 }
 
 export type SiwcSigningRequestSummary = {
@@ -128,13 +153,21 @@ export type SiwcSigningRequestSummary = {
   expiresAt: string
   payloadHash: string
   payloadSummary: Record<string, unknown>
+  policyDecision: string | null
   policyVersion: number
   rejectedAt: string | null
   requiredAcr: typeof SIWC_PASSKEY_ACR | null
   requestType: SigningRequestType
   result: unknown
+  riskLevel: SiwcRiskLevel | null
+  riskReasons: string[]
   signingRequestId: string
+  stepUpRequired: boolean
   status: SigningRequestStatus
+  transactionContractAddress: string | null
+  transactionDeclaredValueUsd: number | null
+  transactionOperationType: string | null
+  transactionRecipient: string | null
   updatedAt: string
   userAccountId: string
 }
@@ -148,6 +181,31 @@ const normalizeStringArray = (value: unknown): string[] =>
   Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === "string")
     : []
+
+const normalizeAllowlist = (value: unknown): string[] =>
+  normalizeStringArray(value).map((entry) => entry.trim().toLowerCase())
+
+const parseOptionalUsdValue = (value: unknown): number | null => {
+  if (value === undefined || value === null || value === "") {
+    return null
+  }
+
+  const parsed = typeof value === "number" ? value : Number(String(value))
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
+}
+
+const getObjectValue = (
+  value: Record<string, unknown>,
+  keys: string[]
+): unknown => {
+  for (const key of keys) {
+    if (value[key] !== undefined) {
+      return value[key]
+    }
+  }
+
+  return undefined
+}
 
 const stableValue = (value: unknown): unknown => {
   if (Array.isArray(value)) {
@@ -218,6 +276,26 @@ const summarizePayload = (
     }
   }
 
+  if (requestType === "transaction" && payload && typeof payload === "object") {
+    const transaction = payload as Record<string, unknown>
+    const to = getObjectValue(transaction, [
+      "to",
+      "recipient",
+      "contract",
+      "contractAddress",
+      "contract_address",
+    ])
+    const data = getObjectValue(transaction, ["data", "callData", "calldata"])
+    return {
+      kind: "transaction",
+      operation:
+        typeof data === "string" && data.trim() && data.trim() !== "0x"
+          ? "contract_call"
+          : "native_transfer",
+      to: typeof to === "string" ? to : null,
+    }
+  }
+
   return {
     kind: requestType,
     payloadHash: hashPayload(payload),
@@ -242,13 +320,28 @@ const mapSigningRequest = (
     typeof row.payload_summary === "object" && row.payload_summary !== null
       ? (row.payload_summary as Record<string, unknown>)
       : {},
+  policyDecision: row.policy_decision ?? null,
   policyVersion: Number(row.policy_version ?? 0),
   rejectedAt: row.rejected_at,
   requiredAcr: row.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
   requestType: row.request_type as SigningRequestType,
   result: row.result ?? null,
+  riskLevel:
+    row.risk_level === "low" ||
+    row.risk_level === "medium" ||
+    row.risk_level === "high"
+      ? row.risk_level
+      : null,
+  riskReasons: normalizeStringArray(row.risk_reasons),
   signingRequestId: row.signing_request_id,
+  stepUpRequired: row.step_up_required === true,
   status: row.status,
+  transactionContractAddress: row.transaction_contract_address ?? null,
+  transactionDeclaredValueUsd: parseOptionalUsdValue(
+    row.transaction_declared_value_usd
+  ),
+  transactionOperationType: row.transaction_operation_type ?? null,
+  transactionRecipient: row.transaction_recipient ?? null,
   updatedAt: row.updated_at,
   userAccountId: String(row.user_account_id),
 })
@@ -285,7 +378,7 @@ const loadPolicy = async (supabase: SupabaseClient, dappId: number | string) => 
   const { data, error } = await supabase
     .from("siwc_signing_policies")
     .select(
-      "dapp_id,status,policy_version,custody_enabled,signing_enabled,sandbox_mode,allowed_chains,allowed_request_types,required_acr"
+      "dapp_id,status,policy_version,custody_enabled,signing_enabled,sandbox_mode,allowed_chains,allowed_request_types,required_acr,transaction_value_limit_usd,contract_allowlist,metadata"
     )
     .eq("dapp_id", dappId)
     .maybeSingle()
@@ -297,28 +390,157 @@ const loadPolicy = async (supabase: SupabaseClient, dappId: number | string) => 
   return data as SiwcPolicyRow | null
 }
 
+const baseRisk = (riskLevel: SiwcRiskLevel): TransactionRiskEvaluation => ({
+  contractAddress: null,
+  declaredValueUsd: null,
+  operationType: null,
+  recipient: null,
+  riskLevel,
+  riskReasons: [],
+})
+
+const evaluateTransactionRisk = (input: {
+  chain: string
+  payload: unknown
+  policy: SiwcPolicyRow | null
+}): TransactionRiskEvaluation => {
+  const risk = baseRisk("high")
+
+  if (input.chain !== "evm") {
+    return {
+      ...risk,
+      operationType: "unsupported_transaction",
+      riskReasons: ["transaction_chain_risk_unsupported"],
+    }
+  }
+
+  if (!input.payload || typeof input.payload !== "object") {
+    return {
+      ...risk,
+      operationType: "malformed_transaction",
+      riskReasons: ["transaction_payload_malformed"],
+    }
+  }
+
+  const payload = input.payload as Record<string, unknown>
+  const toValue = getObjectValue(payload, [
+    "to",
+    "recipient",
+    "contract",
+    "contractAddress",
+    "contract_address",
+  ])
+  const dataValue = getObjectValue(payload, ["data", "callData", "calldata"])
+  const hasCallData =
+    typeof dataValue === "string" &&
+    dataValue.trim().length > 0 &&
+    dataValue.trim() !== "0x"
+  const declaredValueUsd = parseOptionalUsdValue(
+    getObjectValue(payload, [
+      "declaredValueUsd",
+      "declared_value_usd",
+      "transactionValueUsd",
+      "transaction_value_usd",
+      "valueUsd",
+      "value_usd",
+    ])
+  )
+  const payloadChain = getObjectValue(payload, ["chain", "chainKey", "chain_key"])
+  const reasons: string[] = []
+  let normalizedRecipient: string | null = null
+
+  if (
+    typeof payloadChain === "string" &&
+    payloadChain.trim().length > 0 &&
+    normalizeChainKey(payloadChain) !== input.chain
+  ) {
+    reasons.push("transaction_chain_account_mismatch")
+  }
+
+  if (typeof toValue === "string" && ethers.utils.isAddress(toValue)) {
+    normalizedRecipient = ethers.utils.getAddress(toValue).toLowerCase()
+  } else {
+    reasons.push("transaction_recipient_invalid")
+  }
+
+  const operationType = hasCallData ? "contract_call" : "native_transfer"
+  const contractAddress = hasCallData ? normalizedRecipient : null
+  const allowlist = normalizeAllowlist(input.policy?.contract_allowlist)
+
+  if (contractAddress && allowlist.length > 0) {
+    if (allowlist.includes(contractAddress)) {
+      reasons.push("contract_allowlist_match")
+    } else {
+      reasons.push("contract_not_allowlisted")
+    }
+  } else if (contractAddress) {
+    reasons.push("contract_allowlist_missing")
+  }
+
+  if (declaredValueUsd !== null) {
+    const limit = parseOptionalUsdValue(input.policy?.transaction_value_limit_usd)
+    if (limit !== null && declaredValueUsd > limit) {
+      reasons.push("transaction_value_limit_exceeded")
+    }
+  } else {
+    reasons.push("transaction_value_usd_not_declared")
+  }
+
+  reasons.push("transaction_signing_deferred")
+
+  return {
+    contractAddress,
+    declaredValueUsd,
+    operationType,
+    recipient: normalizedRecipient,
+    riskLevel: "high",
+    riskReasons: reasons,
+  }
+}
+
 const evaluatePolicy = (
   policy: SiwcPolicyRow | null,
-  input: { chain: string; requestType: SigningRequestType }
+  input: { chain: string; payload: unknown; requestType: SigningRequestType }
 ): PolicyEvaluation => {
+  const risk =
+    input.requestType === "transaction"
+      ? evaluateTransactionRisk({
+          chain: input.chain,
+          payload: input.payload,
+          policy,
+        })
+      : baseRisk(input.requestType === "typed_data" ? "medium" : "low")
+  const requiredAcr =
+    policy?.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null
+  const stepUpRequired = requiredAcr === SIWC_PASSKEY_ACR
+
   if (!policy) {
     return {
       allowed: false,
       denialCode: "policy_missing",
       denialMessage: "Signing policy is not configured for this app.",
       policyVersion: 0,
+      policyDecision: "denied",
       requiredAcr: null,
+      risk,
+      stepUpRequired: false,
     }
   }
 
-  if (policy.status !== "enabled" || !policy.signing_enabled) {
+  if (
+    policy.status !== "enabled" ||
+    !policy.custody_enabled ||
+    !policy.signing_enabled
+  ) {
     return {
       allowed: false,
       denialCode: "signing_disabled",
       denialMessage: "Signing is disabled for this app.",
       policyVersion: Number(policy.policy_version ?? 0),
-      requiredAcr:
-        policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+      policyDecision: "denied",
+      requiredAcr,
+      risk,
+      stepUpRequired,
     }
   }
 
@@ -328,8 +550,10 @@ const evaluatePolicy = (
       denialCode: "chain_not_allowed",
       denialMessage: "This chain is not enabled for app signing.",
       policyVersion: Number(policy.policy_version ?? 0),
-      requiredAcr:
-        policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+      policyDecision: "denied",
+      requiredAcr,
+      risk,
+      stepUpRequired,
     }
   }
 
@@ -343,28 +567,44 @@ const evaluatePolicy = (
       denialCode: "request_type_not_allowed",
       denialMessage: "This signing request type is not enabled for this app.",
       policyVersion: Number(policy.policy_version ?? 0),
-      requiredAcr:
-        policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+      policyDecision: "denied",
+      requiredAcr,
+      risk,
+      stepUpRequired,
     }
   }
 
   if (input.requestType === "transaction") {
+    const denialCode = risk.riskReasons.includes(
+      "transaction_value_limit_exceeded"
+    )
+      ? "transaction_value_limit_exceeded"
+      : risk.riskReasons.includes("contract_not_allowlisted")
+        ? "contract_not_allowlisted"
+        : risk.riskReasons.includes("transaction_chain_risk_unsupported")
+          ? "transaction_chain_risk_unsupported"
+          : "transaction_signing_deferred"
+
     return {
       allowed: false,
-      denialCode: "transaction_signing_deferred",
+      denialCode,
       denialMessage:
-        "Transaction signing requires SIWC05 risk controls before it can be approved.",
+        "Transaction signing remains disabled until SIWC transaction enablement is explicitly approved.",
       policyVersion: Number(policy.policy_version ?? 0),
-      requiredAcr:
-        policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+      policyDecision: "denied",
+      requiredAcr,
+      risk,
+      stepUpRequired,
     }
   }
 
   return {
     allowed: true,
+    policyDecision: "allowed",
     policyVersion: Number(policy.policy_version ?? 0),
-    requiredAcr:
-      policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+    requiredAcr,
+    risk,
+    stepUpRequired,
   }
 }
 
@@ -457,6 +697,7 @@ export async function createSiwcSigningRequest(input: {
   const policy = await loadPolicy(input.supabase, input.dappId)
   const evaluation = evaluatePolicy(policy, {
     chain,
+    payload: input.payload,
     requestType: input.requestType,
   })
   const now = new Date().toISOString()
@@ -485,12 +726,20 @@ export async function createSiwcSigningRequest(input: {
         input.payload,
         input.payloadSummary
       ),
+      policy_decision: evaluation.policyDecision,
       policy_version: evaluation.policyVersion,
       request_id_header: input.requestId,
       request_type: input.requestType,
       required_acr: evaluation.requiredAcr,
+      risk_level: evaluation.risk.riskLevel,
+      risk_reasons: evaluation.risk.riskReasons,
       signing_request_id: signingRequestId,
+      step_up_required: evaluation.stepUpRequired,
       status,
+      transaction_contract_address: evaluation.risk.contractAddress,
+      transaction_declared_value_usd: evaluation.risk.declaredValueUsd,
+      transaction_operation_type: evaluation.risk.operationType,
+      transaction_recipient: evaluation.risk.recipient,
       updated_at: now,
       user_account_id: input.userAccountId,
       user_id: context.dappUser.user_id,
@@ -510,7 +759,10 @@ export async function createSiwcSigningRequest(input: {
       dappId: String(input.dappId),
       dappUserUuid: input.dappUserUuid,
       policyVersion: evaluation.policyVersion,
+      riskLevel: evaluation.risk.riskLevel,
+      riskReasons: evaluation.risk.riskReasons,
       signingRequestId,
+      stepUpRequired: evaluation.stepUpRequired,
       status,
       userAccountId: input.userAccountId,
     },
@@ -812,7 +1064,7 @@ const assertPasskeyAcrSatisfied = async (
   const supabase = getPassportSupabase()
   const { data: session, error } = await supabase
     .from("oidc_sessions")
-    .select("session_id,human_subject_key,metadata,expires_at,revoked_at")
+    .select("session_id,human_subject_key,metadata,expires_at,revoked_at,created_at")
     .eq("session_id", sessionId)
     .maybeSingle()
 
@@ -825,13 +1077,30 @@ const assertPasskeyAcrSatisfied = async (
     metadata.authentication_methods ?? metadata.authenticationMethods
   )
   const acr = typeof metadata.acr === "string" ? metadata.acr : null
+  const authTimeValue =
+    metadata.auth_time ??
+    metadata.authTime ??
+    metadata.passkey_authenticated_at ??
+    metadata.passkeyAuthenticatedAt
+  const authTimeMs =
+    typeof authTimeValue === "number"
+      ? authTimeValue > 10_000_000_000
+        ? authTimeValue
+        : authTimeValue * 1000
+      : typeof authTimeValue === "string" && authTimeValue.trim().length > 0
+        ? new Date(authTimeValue).getTime()
+        : session?.created_at
+          ? new Date(String(session.created_at)).getTime()
+          : NaN
 
   if (
     !session ||
     !session.human_subject_key ||
     session.revoked_at ||
     new Date(String(session.expires_at)).getTime() <= Date.now() ||
-    (acr !== SIWC_PASSKEY_ACR && !authMethods.includes("passkey"))
+    (acr !== SIWC_PASSKEY_ACR && !authMethods.includes("passkey")) ||
+    !Number.isFinite(authTimeMs) ||
+    Date.now() - authTimeMs > SIWC_PASSKEY_STEP_UP_MAX_AGE_MS
   ) {
     throw new ApiSecurityError(
       403,
@@ -897,7 +1166,7 @@ const signPayload = async (
     throw new ApiSecurityError(
       409,
       "transaction_signing_deferred",
-      "Transaction signing requires SIWC05 risk controls before it can be approved."
+      "Transaction signing remains disabled until SIWC transaction enablement is explicitly approved."
     )
   }
 
@@ -1012,6 +1281,7 @@ const completeApprovedSigning = async (
   const policy = await loadPolicy(supabase, row.dapp_id)
   const evaluation = evaluatePolicy(policy, {
     chain: String(account.chain_key),
+    payload: row.payload,
     requestType: row.request_type as SigningRequestType,
   })
 
@@ -1022,7 +1292,15 @@ const completeApprovedSigning = async (
       .update({
         error_code: evaluation.denialCode ?? "policy_denied",
         error_message: evaluation.denialMessage ?? "Signing policy denied.",
+        policy_decision: evaluation.policyDecision,
         status: "policy_denied",
+        risk_level: evaluation.risk.riskLevel,
+        risk_reasons: evaluation.risk.riskReasons,
+        step_up_required: evaluation.stepUpRequired,
+        transaction_contract_address: evaluation.risk.contractAddress,
+        transaction_declared_value_usd: evaluation.risk.declaredValueUsd,
+        transaction_operation_type: evaluation.risk.operationType,
+        transaction_recipient: evaluation.risk.recipient,
         updated_at: now,
       })
       .eq("signing_request_id", row.signing_request_id)
@@ -1139,7 +1417,29 @@ export async function approvePassportSiwcSigningRequest(input: {
     )
   }
 
-  await assertPasskeyAcrSatisfied(input.req, row, token)
+  try {
+    await assertPasskeyAcrSatisfied(input.req, row, token)
+  } catch (error) {
+    if (
+      error instanceof ApiSecurityError &&
+      (error.code === "step_up_required" || error.code === "step_up_stale")
+    ) {
+      await insertSecurityEvent(supabase, {
+        actorIdentifier: token.uid,
+        actorType: "user",
+        details: {
+          signingRequestId: row.signing_request_id,
+          status: row.status,
+        },
+        eventType: "signing_request.step_up_failed",
+        outcome: "failure",
+        requestId: input.requestId,
+        route: "passport.siwc.signing.requests.approve",
+      })
+    }
+
+    throw error
+  }
 
   const approvedAt = new Date().toISOString()
   const { data: approvedRow, error: approveError } = await supabase

--- a/apps/passport/lib/server/siwcSigningRequests.ts
+++ b/apps/passport/lib/server/siwcSigningRequests.ts
@@ -10,6 +10,10 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519"
 import { Keypair } from "@solana/web3.js"
 
 import {
+  deliverSiwcApiV3Webhook,
+  type SiwcApiV3WebhookEventType,
+} from "./apiV3Webhooks"
+import {
   decryptBlockchainPrivateKeyWithKey,
   getBlockchainPrivateKeyWrappingKey,
   normalizeChainKey,
@@ -345,6 +349,63 @@ const mapSigningRequest = (
   updatedAt: row.updated_at,
   userAccountId: String(row.user_account_id),
 })
+
+const summarizeSigningResult = (result: unknown) => {
+  if (!result || typeof result !== "object") {
+    return null
+  }
+
+  const value = result as Record<string, unknown>
+  return {
+    algorithm: typeof value.algorithm === "string" ? value.algorithm : null,
+    publicAddress:
+      typeof value.publicAddress === "string" ? value.publicAddress : null,
+    type: typeof value.type === "string" ? value.type : null,
+  }
+}
+
+const buildSiwcSigningWebhookData = (row: SiwcSigningRequestRow) => {
+  const summary = mapSigningRequest(row)
+  return {
+    accountId: summary.userAccountId,
+    chain: summary.chain,
+    errorCode: summary.errorCode,
+    errorMessage: summary.errorMessage,
+    payloadHash: summary.payloadHash,
+    policyDecision: summary.policyDecision,
+    policyVersion: summary.policyVersion,
+    requestType: summary.requestType,
+    result: summarizeSigningResult(summary.result),
+    riskLevel: summary.riskLevel,
+    riskReasons: summary.riskReasons,
+    signingRequestId: summary.signingRequestId,
+    status: summary.status,
+    stepUpRequired: summary.stepUpRequired,
+    transactionContractAddress: summary.transactionContractAddress,
+    transactionDeclaredValueUsd: summary.transactionDeclaredValueUsd,
+    transactionOperationType: summary.transactionOperationType,
+    transactionRecipient: summary.transactionRecipient,
+  }
+}
+
+const publishSiwcSigningWebhook = async (
+  supabase: SupabaseClient,
+  row: SiwcSigningRequestRow,
+  input: {
+    eventType: SiwcApiV3WebhookEventType
+    requestId: string
+  }
+) => {
+  await deliverSiwcApiV3Webhook({
+    dappId: row.dapp_id,
+    dappUserUuid: row.dapp_user_uuid,
+    eventKey: `${input.eventType}:${row.signing_request_id}`,
+    eventType: input.eventType,
+    requestId: input.requestId,
+    supabase,
+    data: buildSiwcSigningWebhookData(row),
+  })
+}
 
 const insertSecurityEvent = async (
   supabase: SupabaseClient,
@@ -751,6 +812,8 @@ export async function createSiwcSigningRequest(input: {
     throw error
   }
 
+  const insertedRow = data as SiwcSigningRequestRow
+
   await insertSecurityEvent(input.supabase, {
     actorIdentifier: String(input.dappId),
     actorType: "dapp",
@@ -774,7 +837,14 @@ export async function createSiwcSigningRequest(input: {
     route: "v3.signing.requests.create",
   })
 
-  return mapSigningRequest(data as SiwcSigningRequestRow)
+  await publishSiwcSigningWebhook(input.supabase, insertedRow, {
+    eventType: evaluation.allowed
+      ? "wallet.signing_request.created"
+      : "wallet.policy.denied",
+    requestId: input.requestId,
+  })
+
+  return mapSigningRequest(insertedRow)
 }
 
 const loadDappSigningRequest = async (
@@ -886,6 +956,11 @@ export async function cancelSiwcSigningRequestForDapp(input: {
     outcome: "success",
     requestId: input.requestId,
     route: "v3.signing.requests.cancel",
+  })
+
+  await publishSiwcSigningWebhook(input.supabase, data as SiwcSigningRequestRow, {
+    eventType: "wallet.signing_request.cancelled",
+    requestId: input.requestId,
   })
 
   return mapSigningRequest(data as SiwcSigningRequestRow)
@@ -1436,6 +1511,10 @@ export async function approvePassportSiwcSigningRequest(input: {
         requestId: input.requestId,
         route: "passport.siwc.signing.requests.approve",
       })
+      await publishSiwcSigningWebhook(supabase, row, {
+        eventType: "wallet.signing_request.step_up_failed",
+        requestId: input.requestId,
+      })
     }
 
     throw error
@@ -1471,10 +1550,45 @@ export async function approvePassportSiwcSigningRequest(input: {
     route: "passport.siwc.signing.requests.approve",
   })
 
-  const completedRow = await completeApprovedSigning(
-    supabase,
-    approvedRow as SiwcSigningRequestRow
-  )
+  await publishSiwcSigningWebhook(supabase, approvedRow as SiwcSigningRequestRow, {
+    eventType: "wallet.signing_request.approved",
+    requestId: input.requestId,
+  })
+
+  let completedRow: SiwcSigningRequestRow
+  try {
+    completedRow = await completeApprovedSigning(
+      supabase,
+      approvedRow as SiwcSigningRequestRow
+    )
+  } catch (error) {
+    const failedAt = new Date().toISOString()
+    const { data: failedRow } = await supabase
+      .from("siwc_signing_requests")
+      .update({
+        error_code:
+          error instanceof ApiSecurityError ? error.code : "signing_failed",
+        error_message:
+          error instanceof Error ? error.message : "Signing failed.",
+        status: "failed",
+        updated_at: failedAt,
+      })
+      .eq("signing_request_id", row.signing_request_id)
+      .select("*")
+      .single()
+
+    await publishSiwcSigningWebhook(
+      supabase,
+      (failedRow as SiwcSigningRequestRow | null) ??
+        (approvedRow as SiwcSigningRequestRow),
+      {
+        eventType: "wallet.signature.failed",
+        requestId: input.requestId,
+      }
+    )
+
+    throw error
+  }
 
   await insertSecurityEvent(supabase, {
     actorIdentifier: token.uid,
@@ -1490,6 +1604,14 @@ export async function approvePassportSiwcSigningRequest(input: {
     outcome: completedRow.status === "completed" ? "success" : "failure",
     requestId: input.requestId,
     route: "passport.siwc.signing.requests.approve",
+  })
+
+  await publishSiwcSigningWebhook(supabase, completedRow, {
+    eventType:
+      completedRow.status === "completed"
+        ? "wallet.signature.completed"
+        : "wallet.policy.denied",
+    requestId: input.requestId,
   })
 
   return mapSigningRequest(completedRow)
@@ -1546,6 +1668,11 @@ export async function rejectPassportSiwcSigningRequest(input: {
     outcome: "success",
     requestId: input.requestId,
     route: "passport.siwc.signing.requests.reject",
+  })
+
+  await publishSiwcSigningWebhook(supabase, data as SiwcSigningRequestRow, {
+    eventType: "wallet.signing_request.rejected",
+    requestId: input.requestId,
   })
 
   return mapSigningRequest(data as SiwcSigningRequestRow)

--- a/apps/passport/lib/server/siwcSigningRequests.ts
+++ b/apps/passport/lib/server/siwcSigningRequests.ts
@@ -1,0 +1,1252 @@
+import { createHash, randomUUID } from "node:crypto"
+
+import { ApiSecurityError } from "@cubid/auth/server"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { ethers } from "ethers"
+import { KeyPair } from "near-api-js"
+import type { NextApiRequest } from "next"
+import nacl from "tweetnacl"
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519"
+import { Keypair } from "@solana/web3.js"
+
+import {
+  decryptBlockchainPrivateKeyWithKey,
+  getBlockchainPrivateKeyWrappingKey,
+  normalizeChainKey,
+  normalizePublicAddress,
+  type SupportedGeneratedChain,
+} from "./blockchainAccounts"
+import { getOidcSessionId } from "./oidcInteractionProxy"
+import {
+  requirePassportFirebaseUser,
+  resolveHumanSubjectKeys,
+} from "./oidcConsentManagement"
+import { getPassportSupabase } from "./supabase"
+
+export const SIWC_PASSKEY_ACR = "urn:cubid:acr:passkey" as const
+const SIGNING_REQUEST_TTL_MS = 10 * 60 * 1000
+
+type SigningRequestType = "message" | "transaction" | "typed_data"
+type SigningRequestStatus =
+  | "approved"
+  | "cancelled"
+  | "completed"
+  | "expired"
+  | "failed"
+  | "pending_user_approval"
+  | "policy_denied"
+  | "rejected"
+  | "signing"
+
+type SiwcPolicyRow = {
+  allowed_chains: unknown
+  allowed_request_types: unknown
+  custody_enabled: boolean
+  dapp_id: number | string
+  policy_version: number
+  required_acr: string | null
+  sandbox_mode: boolean
+  signing_enabled: boolean
+  status: string
+}
+
+type DappUserRow = {
+  dapp_id: number | string
+  user_id: number | string
+  uuid: string
+}
+
+type UserAccountRow = {
+  chain_key: string
+  custody_status: string
+  id: string
+  public_address: string
+  public_address_normalized: string | null
+  status: string
+  user_id: number | string
+}
+
+type DappUserAccountRow = {
+  dapp_id: number | string
+  dapp_user_uuid: string
+  id: string
+  status: string
+  user_account_id: string
+}
+
+type SiwcSigningRequestRow = {
+  approved_at: string | null
+  chain_key: string
+  completed_at: string | null
+  created_at: string
+  dapp_id: number | string
+  dapp_user_account_id: string
+  dapp_user_uuid: string
+  error_code: string | null
+  error_message: string | null
+  expires_at: string
+  idempotency_key: string | null
+  payload: unknown
+  payload_hash: string
+  payload_summary: unknown
+  policy_version: number
+  rejected_at: string | null
+  required_acr: string | null
+  result: unknown
+  request_type: string
+  signing_request_id: string
+  status: SigningRequestStatus
+  updated_at: string
+  user_account_id: string
+  user_id: number | string
+}
+
+type RequestContext = {
+  account: UserAccountRow
+  dappUser: DappUserRow
+  link: DappUserAccountRow
+}
+
+type PolicyEvaluation = {
+  allowed: boolean
+  denialCode?: string
+  denialMessage?: string
+  policyVersion: number
+  requiredAcr: typeof SIWC_PASSKEY_ACR | null
+}
+
+export type SiwcSigningRequestSummary = {
+  approvedAt: string | null
+  chain: string
+  completedAt: string | null
+  createdAt: string
+  dappId: string
+  dappUserAccountId: string
+  dappUserUuid: string
+  errorCode: string | null
+  errorMessage: string | null
+  expiresAt: string
+  payloadHash: string
+  payloadSummary: Record<string, unknown>
+  policyVersion: number
+  rejectedAt: string | null
+  requiredAcr: typeof SIWC_PASSKEY_ACR | null
+  requestType: SigningRequestType
+  result: unknown
+  signingRequestId: string
+  status: SigningRequestStatus
+  updatedAt: string
+  userAccountId: string
+}
+
+export type PassportSiwcSigningRequestSummary = SiwcSigningRequestSummary & {
+  dappName: string
+  publicAddress: string
+}
+
+const normalizeStringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : []
+
+const stableValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(stableValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, stableValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+const hashPayload = (payload: unknown) =>
+  createHash("sha256")
+    .update(JSON.stringify(stableValue(payload)))
+    .digest("hex")
+
+const createSigningRequestId = () =>
+  `siwc_req_${randomUUID().replace(/-/g, "")}`
+
+const isExpired = (row: Pick<SiwcSigningRequestRow, "expires_at">) =>
+  new Date(row.expires_at).getTime() <= Date.now()
+
+const isTerminalStatus = (status: SigningRequestStatus) =>
+  [
+    "cancelled",
+    "completed",
+    "expired",
+    "failed",
+    "policy_denied",
+    "rejected",
+  ].includes(status)
+
+const summarizePayload = (
+  requestType: SigningRequestType,
+  payload: unknown,
+  providedSummary?: Record<string, unknown>
+) => {
+  if (providedSummary) {
+    return providedSummary
+  }
+
+  if (
+    requestType === "message" &&
+    typeof payload === "object" &&
+    payload !== null &&
+    typeof (payload as { message?: unknown }).message === "string"
+  ) {
+    const message = (payload as { message: string }).message
+    return {
+      kind: "message",
+      preview: message.slice(0, 160),
+      sizeBytes: Buffer.byteLength(message, "utf8"),
+    }
+  }
+
+  if (requestType === "typed_data") {
+    const domain = (payload as { domain?: Record<string, unknown> })?.domain
+    return {
+      kind: "typed_data",
+      domainName:
+        domain && typeof domain.name === "string" ? domain.name : null,
+    }
+  }
+
+  return {
+    kind: requestType,
+    payloadHash: hashPayload(payload),
+  }
+}
+
+const mapSigningRequest = (
+  row: SiwcSigningRequestRow
+): SiwcSigningRequestSummary => ({
+  approvedAt: row.approved_at,
+  chain: row.chain_key,
+  completedAt: row.completed_at,
+  createdAt: row.created_at,
+  dappId: String(row.dapp_id),
+  dappUserAccountId: String(row.dapp_user_account_id),
+  dappUserUuid: String(row.dapp_user_uuid),
+  errorCode: row.error_code,
+  errorMessage: row.error_message,
+  expiresAt: row.expires_at,
+  payloadHash: row.payload_hash,
+  payloadSummary:
+    typeof row.payload_summary === "object" && row.payload_summary !== null
+      ? (row.payload_summary as Record<string, unknown>)
+      : {},
+  policyVersion: Number(row.policy_version ?? 0),
+  rejectedAt: row.rejected_at,
+  requiredAcr: row.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+  requestType: row.request_type as SigningRequestType,
+  result: row.result ?? null,
+  signingRequestId: row.signing_request_id,
+  status: row.status,
+  updatedAt: row.updated_at,
+  userAccountId: String(row.user_account_id),
+})
+
+const insertSecurityEvent = async (
+  supabase: SupabaseClient,
+  input: {
+    actorIdentifier: string
+    actorType: "dapp" | "user"
+    details: Record<string, unknown>
+    eventType: string
+    outcome: "failure" | "success"
+    requestId: string
+    route: string
+  }
+) => {
+  const { error } = await supabase.from("api_security_events").insert({
+    actor_identifier: input.actorIdentifier,
+    actor_type: input.actorType,
+    details: input.details,
+    event_id: `api_event_${randomUUID().replace(/-/g, "")}`,
+    event_type: input.eventType,
+    outcome: input.outcome,
+    request_id: input.requestId,
+    route: input.route,
+  })
+
+  if (error) {
+    throw error
+  }
+}
+
+const loadPolicy = async (supabase: SupabaseClient, dappId: number | string) => {
+  const { data, error } = await supabase
+    .from("siwc_signing_policies")
+    .select(
+      "dapp_id,status,policy_version,custody_enabled,signing_enabled,sandbox_mode,allowed_chains,allowed_request_types,required_acr"
+    )
+    .eq("dapp_id", dappId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return data as SiwcPolicyRow | null
+}
+
+const evaluatePolicy = (
+  policy: SiwcPolicyRow | null,
+  input: { chain: string; requestType: SigningRequestType }
+): PolicyEvaluation => {
+  if (!policy) {
+    return {
+      allowed: false,
+      denialCode: "policy_missing",
+      denialMessage: "Signing policy is not configured for this app.",
+      policyVersion: 0,
+      requiredAcr: null,
+    }
+  }
+
+  if (policy.status !== "enabled" || !policy.signing_enabled) {
+    return {
+      allowed: false,
+      denialCode: "signing_disabled",
+      denialMessage: "Signing is disabled for this app.",
+      policyVersion: Number(policy.policy_version ?? 0),
+      requiredAcr:
+        policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+    }
+  }
+
+  if (!normalizeStringArray(policy.allowed_chains).includes(input.chain)) {
+    return {
+      allowed: false,
+      denialCode: "chain_not_allowed",
+      denialMessage: "This chain is not enabled for app signing.",
+      policyVersion: Number(policy.policy_version ?? 0),
+      requiredAcr:
+        policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+    }
+  }
+
+  if (
+    !normalizeStringArray(policy.allowed_request_types).includes(
+      input.requestType
+    )
+  ) {
+    return {
+      allowed: false,
+      denialCode: "request_type_not_allowed",
+      denialMessage: "This signing request type is not enabled for this app.",
+      policyVersion: Number(policy.policy_version ?? 0),
+      requiredAcr:
+        policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+    }
+  }
+
+  if (input.requestType === "transaction") {
+    return {
+      allowed: false,
+      denialCode: "transaction_signing_deferred",
+      denialMessage:
+        "Transaction signing requires SIWC05 risk controls before it can be approved.",
+      policyVersion: Number(policy.policy_version ?? 0),
+      requiredAcr:
+        policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+    }
+  }
+
+  return {
+    allowed: true,
+    policyVersion: Number(policy.policy_version ?? 0),
+    requiredAcr:
+      policy.required_acr === SIWC_PASSKEY_ACR ? SIWC_PASSKEY_ACR : null,
+  }
+}
+
+const assertRequestContext = async (
+  supabase: SupabaseClient,
+  input: {
+    dappId: number | string
+    dappUserUuid: string
+    userAccountId: string
+  }
+): Promise<RequestContext | null> => {
+  const { data: dappUser, error: dappUserError } = await supabase
+    .from("dapp_users")
+    .select("uuid,dapp_id,user_id")
+    .eq("uuid", input.dappUserUuid)
+    .eq("dapp_id", input.dappId)
+    .maybeSingle()
+
+  if (dappUserError) {
+    throw dappUserError
+  }
+
+  if (!dappUser?.user_id) {
+    return null
+  }
+
+  const { data: link, error: linkError } = await supabase
+    .from("dapp_user_accounts")
+    .select("id,dapp_user_uuid,user_account_id,dapp_id,status")
+    .eq("dapp_user_uuid", input.dappUserUuid)
+    .eq("dapp_id", input.dappId)
+    .eq("user_account_id", input.userAccountId)
+    .eq("status", "active")
+    .maybeSingle()
+
+  if (linkError) {
+    throw linkError
+  }
+
+  if (!link) {
+    return null
+  }
+
+  const { data: account, error: accountError } = await supabase
+    .from("user_accounts")
+    .select(
+      "id,user_id,chain_key,public_address,public_address_normalized,custody_status,status"
+    )
+    .eq("id", input.userAccountId)
+    .eq("status", "active")
+    .maybeSingle()
+
+  if (accountError) {
+    throw accountError
+  }
+
+  if (!account || String(account.user_id) !== String(dappUser.user_id)) {
+    return null
+  }
+
+  return {
+    account: account as UserAccountRow,
+    dappUser: dappUser as DappUserRow,
+    link: link as DappUserAccountRow,
+  }
+}
+
+export async function createSiwcSigningRequest(input: {
+  dappId: number | string
+  dappUserUuid: string
+  idempotencyKey: string
+  payload: unknown
+  payloadSummary?: Record<string, unknown>
+  requestId: string
+  requestType: SigningRequestType
+  supabase: SupabaseClient
+  userAccountId: string
+}) {
+  const context = await assertRequestContext(input.supabase, input)
+
+  if (!context) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "The requested app-scoped account was not found for this dapp user."
+    )
+  }
+
+  const chain = normalizeChainKey(context.account.chain_key)
+  const policy = await loadPolicy(input.supabase, input.dappId)
+  const evaluation = evaluatePolicy(policy, {
+    chain,
+    requestType: input.requestType,
+  })
+  const now = new Date().toISOString()
+  const status: SigningRequestStatus = evaluation.allowed
+    ? "pending_user_approval"
+    : "policy_denied"
+  const signingRequestId = createSigningRequestId()
+  const payloadHash = hashPayload(input.payload)
+  const expiresAt = new Date(Date.now() + SIGNING_REQUEST_TTL_MS).toISOString()
+
+  const { data, error } = await input.supabase
+    .from("siwc_signing_requests")
+    .insert({
+      chain_key: chain,
+      dapp_id: input.dappId,
+      dapp_user_account_id: context.link.id,
+      dapp_user_uuid: input.dappUserUuid,
+      error_code: evaluation.denialCode ?? null,
+      error_message: evaluation.denialMessage ?? null,
+      expires_at: expiresAt,
+      idempotency_key: input.idempotencyKey,
+      payload: input.payload,
+      payload_hash: payloadHash,
+      payload_summary: summarizePayload(
+        input.requestType,
+        input.payload,
+        input.payloadSummary
+      ),
+      policy_version: evaluation.policyVersion,
+      request_id_header: input.requestId,
+      request_type: input.requestType,
+      required_acr: evaluation.requiredAcr,
+      signing_request_id: signingRequestId,
+      status,
+      updated_at: now,
+      user_account_id: input.userAccountId,
+      user_id: context.dappUser.user_id,
+    })
+    .select("*")
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  await insertSecurityEvent(input.supabase, {
+    actorIdentifier: String(input.dappId),
+    actorType: "dapp",
+    details: {
+      chain,
+      dappId: String(input.dappId),
+      dappUserUuid: input.dappUserUuid,
+      policyVersion: evaluation.policyVersion,
+      signingRequestId,
+      status,
+      userAccountId: input.userAccountId,
+    },
+    eventType: evaluation.allowed
+      ? "signing_request.created"
+      : "signing_request.policy_denied",
+    outcome: evaluation.allowed ? "success" : "failure",
+    requestId: input.requestId,
+    route: "v3.signing.requests.create",
+  })
+
+  return mapSigningRequest(data as SiwcSigningRequestRow)
+}
+
+const loadDappSigningRequest = async (
+  supabase: SupabaseClient,
+  input: { dappId: number | string; signingRequestId: string }
+) => {
+  const { data, error } = await supabase
+    .from("siwc_signing_requests")
+    .select("*")
+    .eq("signing_request_id", input.signingRequestId)
+    .eq("dapp_id", input.dappId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return data as SiwcSigningRequestRow | null
+}
+
+export async function getSiwcSigningRequestForDapp(input: {
+  dappId: number | string
+  signingRequestId: string
+  supabase: SupabaseClient
+}) {
+  const row = await loadDappSigningRequest(input.supabase, input)
+
+  if (!row) {
+    throw new ApiSecurityError(404, "not_found", "Signing request not found.")
+  }
+
+  return mapSigningRequest(row)
+}
+
+export async function listSiwcSigningRequestsForDapp(input: {
+  dappId: number | string
+  dappUserUuid?: string | null
+  limit?: number
+  supabase: SupabaseClient
+}) {
+  let query = input.supabase
+    .from("siwc_signing_requests")
+    .select("*")
+    .eq("dapp_id", input.dappId)
+
+  if (input.dappUserUuid) {
+    query = query.eq("dapp_user_uuid", input.dappUserUuid)
+  }
+
+  const { data, error } = await query
+    .order("created_at", { ascending: false })
+    .limit(input.limit ?? 25)
+
+  if (error) {
+    throw error
+  }
+
+  return ((data ?? []) as SiwcSigningRequestRow[]).map(mapSigningRequest)
+}
+
+export async function cancelSiwcSigningRequestForDapp(input: {
+  dappId: number | string
+  requestId: string
+  signingRequestId: string
+  supabase: SupabaseClient
+}) {
+  const row = await loadDappSigningRequest(input.supabase, input)
+
+  if (!row) {
+    throw new ApiSecurityError(404, "not_found", "Signing request not found.")
+  }
+
+  if (isTerminalStatus(row.status)) {
+    return mapSigningRequest(row)
+  }
+
+  if (row.status !== "pending_user_approval") {
+    throw new ApiSecurityError(
+      409,
+      "invalid_state",
+      "Only pending signing requests can be cancelled."
+    )
+  }
+
+  const now = new Date().toISOString()
+  const { data, error } = await input.supabase
+    .from("siwc_signing_requests")
+    .update({
+      cancelled_at: now,
+      status: "cancelled",
+      updated_at: now,
+    })
+    .eq("signing_request_id", input.signingRequestId)
+    .eq("dapp_id", input.dappId)
+    .select("*")
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  await insertSecurityEvent(input.supabase, {
+    actorIdentifier: String(input.dappId),
+    actorType: "dapp",
+    details: {
+      signingRequestId: input.signingRequestId,
+    },
+    eventType: "signing_request.cancelled",
+    outcome: "success",
+    requestId: input.requestId,
+    route: "v3.signing.requests.cancel",
+  })
+
+  return mapSigningRequest(data as SiwcSigningRequestRow)
+}
+
+const resolvePassportUserIds = async (req: NextApiRequest) => {
+  const token = await requirePassportFirebaseUser(req)
+  const supabase = getPassportSupabase()
+  const userIds = new Set<string>()
+
+  if (token.email) {
+    const { data, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("email", token.email)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    if (data?.id !== undefined && data.id !== null) {
+      userIds.add(String(data.id))
+    }
+  }
+
+  if (token.phone_number) {
+    const { data, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("phone", token.phone_number)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    if (data?.id !== undefined && data.id !== null) {
+      userIds.add(String(data.id))
+    }
+  }
+
+  return { token, userIds: [...userIds] }
+}
+
+const loadDappNames = async (supabase: SupabaseClient, dappIds: string[]) => {
+  if (dappIds.length === 0) {
+    return new Map<string, string>()
+  }
+
+  const { data, error } = await supabase
+    .from("dapps")
+    .select("id,appname")
+    .in("id", dappIds)
+
+  if (error) {
+    throw error
+  }
+
+  return new Map(
+    ((data ?? []) as Array<{ appname?: string | null; id: string | number }>).map(
+      (row) => [String(row.id), row.appname ?? `Dapp ${row.id}`]
+    )
+  )
+}
+
+const loadAccountAddresses = async (
+  supabase: SupabaseClient,
+  accountIds: string[]
+) => {
+  if (accountIds.length === 0) {
+    return new Map<string, string>()
+  }
+
+  const { data, error } = await supabase
+    .from("user_accounts")
+    .select("id,public_address")
+    .in("id", accountIds)
+
+  if (error) {
+    throw error
+  }
+
+  return new Map(
+    ((data ?? []) as Array<{ id: string | number; public_address: string }>).map(
+      (row) => [String(row.id), String(row.public_address)]
+    )
+  )
+}
+
+export async function listPassportSiwcSigningRequests(req: NextApiRequest) {
+  const supabase = getPassportSupabase()
+  const { userIds } = await resolvePassportUserIds(req)
+
+  if (userIds.length === 0) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from("siwc_signing_requests")
+    .select("*")
+    .in("user_id", userIds)
+    .order("created_at", { ascending: false })
+    .limit(50)
+
+  if (error) {
+    throw error
+  }
+
+  const rows = (data ?? []) as SiwcSigningRequestRow[]
+  const dappNames = await loadDappNames(
+    supabase,
+    [...new Set(rows.map((row) => String(row.dapp_id)))]
+  )
+  const addresses = await loadAccountAddresses(
+    supabase,
+    [...new Set(rows.map((row) => String(row.user_account_id)))]
+  )
+
+  return rows.map((row) => ({
+    ...mapSigningRequest(row),
+    dappName: dappNames.get(String(row.dapp_id)) ?? `Dapp ${row.dapp_id}`,
+    publicAddress: addresses.get(String(row.user_account_id)) ?? "",
+  }))
+}
+
+const loadOwnedPassportSigningRequest = async (
+  req: NextApiRequest,
+  signingRequestId: string
+) => {
+  const supabase = getPassportSupabase()
+  const { token, userIds } = await resolvePassportUserIds(req)
+
+  if (userIds.length === 0) {
+    throw new ApiSecurityError(404, "not_found", "Signing request not found.")
+  }
+
+  const { data, error } = await supabase
+    .from("siwc_signing_requests")
+    .select("*")
+    .eq("signing_request_id", signingRequestId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  const row = data as SiwcSigningRequestRow | null
+
+  if (!row || !userIds.includes(String(row.user_id))) {
+    throw new ApiSecurityError(404, "not_found", "Signing request not found.")
+  }
+
+  return { row, token }
+}
+
+const assertPasskeyAcrSatisfied = async (
+  req: NextApiRequest,
+  row: SiwcSigningRequestRow,
+  token: Awaited<ReturnType<typeof requirePassportFirebaseUser>>
+) => {
+  if (row.required_acr !== SIWC_PASSKEY_ACR) {
+    return
+  }
+
+  const sessionId = getOidcSessionId(req)
+
+  if (!sessionId) {
+    throw new ApiSecurityError(
+      403,
+      "step_up_required",
+      "Passkey step-up is required before approving this signing request."
+    )
+  }
+
+  const supabase = getPassportSupabase()
+  const { data: session, error } = await supabase
+    .from("oidc_sessions")
+    .select("session_id,human_subject_key,metadata,expires_at,revoked_at")
+    .eq("session_id", sessionId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  const metadata = (session?.metadata ?? {}) as Record<string, unknown>
+  const authMethods = normalizeStringArray(
+    metadata.authentication_methods ?? metadata.authenticationMethods
+  )
+  const acr = typeof metadata.acr === "string" ? metadata.acr : null
+
+  if (
+    !session ||
+    !session.human_subject_key ||
+    session.revoked_at ||
+    new Date(String(session.expires_at)).getTime() <= Date.now() ||
+    (acr !== SIWC_PASSKEY_ACR && !authMethods.includes("passkey"))
+  ) {
+    throw new ApiSecurityError(
+      403,
+      "step_up_required",
+      "Passkey step-up is required before approving this signing request."
+    )
+  }
+
+  const subjectKeys = await resolveHumanSubjectKeys(supabase, token)
+
+  if (!subjectKeys.includes(String(session.human_subject_key))) {
+    throw new ApiSecurityError(
+      403,
+      "step_up_required",
+      "Passkey step-up is required before approving this signing request."
+    )
+  }
+}
+
+const assertMessagePayload = (payload: unknown) => {
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    typeof (payload as { message?: unknown }).message === "string"
+  ) {
+    return (payload as { message: string }).message
+  }
+
+  throw new ApiSecurityError(
+    400,
+    "invalid_request",
+    "Signing payload is not valid for message signing."
+  )
+}
+
+const assertTypedDataPayload = (payload: unknown) => {
+  if (typeof payload === "object" && payload !== null) {
+    return payload as {
+      domain?: Record<string, unknown>
+      types?: Record<string, Array<Record<string, string>>>
+      value?: Record<string, unknown>
+    }
+  }
+
+  throw new ApiSecurityError(
+    400,
+    "invalid_request",
+    "Signing payload is not valid for typed-data signing."
+  )
+}
+
+const signPayload = async (
+  input: {
+    account: UserAccountRow
+    payload: unknown
+    requestType: SigningRequestType
+  },
+  privateKey: string
+) => {
+  const chain = normalizeChainKey(input.account.chain_key)
+
+  if (input.requestType === "transaction") {
+    throw new ApiSecurityError(
+      409,
+      "transaction_signing_deferred",
+      "Transaction signing requires SIWC05 risk controls before it can be approved."
+    )
+  }
+
+  if (chain === "evm") {
+    const wallet = new ethers.Wallet(privateKey)
+
+    if (input.requestType === "message") {
+      const message = assertMessagePayload(input.payload)
+      return {
+        algorithm: "evm_secp256k1",
+        publicAddress: input.account.public_address,
+        signature: await wallet.signMessage(message),
+        type: "signature",
+      }
+    }
+
+    const typedData = assertTypedDataPayload(input.payload)
+    return {
+      algorithm: "evm_eip712",
+      publicAddress: input.account.public_address,
+      signature: await wallet._signTypedData(
+        typedData.domain ?? {},
+        (typedData.types ?? {}) as never,
+        typedData.value ?? {}
+      ),
+      type: "signature",
+    }
+  }
+
+  if (input.requestType !== "message") {
+    throw new ApiSecurityError(
+      409,
+      "request_type_not_supported",
+      "This chain only supports message signing in the current SIWC slice."
+    )
+  }
+
+  const message = assertMessagePayload(input.payload)
+  const messageBytes = Buffer.from(message, "utf8")
+
+  if (chain === "near") {
+    const keyPair = KeyPair.fromString(privateKey)
+    return {
+      algorithm: "near_ed25519",
+      publicAddress: input.account.public_address,
+      signature: Buffer.from(keyPair.sign(messageBytes).signature).toString(
+        "base64"
+      ),
+      type: "signature",
+    }
+  }
+
+  if (chain === "solana") {
+    const keypair = Keypair.fromSecretKey(Buffer.from(privateKey, "base64"))
+    return {
+      algorithm: "solana_ed25519",
+      publicAddress: input.account.public_address,
+      signature: Buffer.from(
+        nacl.sign.detached(messageBytes, keypair.secretKey)
+      ).toString("base64"),
+      type: "signature",
+    }
+  }
+
+  if (chain === "sui") {
+    const keypair = (Ed25519Keypair as unknown as {
+      fromSecretKey: (secretKey: string) => Ed25519Keypair
+    }).fromSecretKey(privateKey)
+    const result = await (keypair as unknown as {
+      signPersonalMessage: (bytes: Uint8Array) => Promise<{ signature: string }>
+    }).signPersonalMessage(messageBytes)
+    return {
+      algorithm: "sui_ed25519_personal_message",
+      publicAddress: input.account.public_address,
+      signature: result.signature,
+      type: "signature",
+    }
+  }
+
+  throw new ApiSecurityError(
+    409,
+    "chain_not_supported",
+    "This chain is not supported for SIWC signing."
+  )
+}
+
+const completeApprovedSigning = async (
+  supabase: SupabaseClient,
+  row: SiwcSigningRequestRow
+) => {
+  const { data: account, error: accountError } = await supabase
+    .from("user_accounts")
+    .select(
+      "id,user_id,chain_key,public_address,public_address_normalized,custody_status,status"
+    )
+    .eq("id", row.user_account_id)
+    .eq("status", "active")
+    .maybeSingle()
+
+  if (accountError) {
+    throw accountError
+  }
+
+  if (!account) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "Signing account is no longer active."
+    )
+  }
+
+  const policy = await loadPolicy(supabase, row.dapp_id)
+  const evaluation = evaluatePolicy(policy, {
+    chain: String(account.chain_key),
+    requestType: row.request_type as SigningRequestType,
+  })
+
+  if (!evaluation.allowed) {
+    const now = new Date().toISOString()
+    const { data, error } = await supabase
+      .from("siwc_signing_requests")
+      .update({
+        error_code: evaluation.denialCode ?? "policy_denied",
+        error_message: evaluation.denialMessage ?? "Signing policy denied.",
+        status: "policy_denied",
+        updated_at: now,
+      })
+      .eq("signing_request_id", row.signing_request_id)
+      .select("*")
+      .single()
+
+    if (error) {
+      throw error
+    }
+
+    return data as SiwcSigningRequestRow
+  }
+
+  const chainKey = normalizeChainKey(String(account.chain_key)) as SupportedGeneratedChain
+  const normalizedAddress =
+    typeof account.public_address_normalized === "string" &&
+    account.public_address_normalized
+      ? account.public_address_normalized
+      : normalizePublicAddress(chainKey, String(account.public_address))
+  const { data: keyRow, error: keyError } = await supabase
+    .schema("private")
+    .from("private_keys")
+    .select("*")
+    .eq("user_account_id", row.user_account_id)
+    .eq("status", "active")
+    .maybeSingle()
+
+  if (keyError) {
+    throw keyError
+  }
+
+  if (!keyRow) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "Signing key is not available for this account."
+    )
+  }
+
+  const wrappingKey = await getBlockchainPrivateKeyWrappingKey(supabase)
+  const privateKey = decryptBlockchainPrivateKeyWithKey(keyRow, wrappingKey, {
+    chainKey,
+    publicAddressNormalized: normalizedAddress,
+    userAccountId: String(account.id),
+    userId: account.user_id,
+  })
+  const result = await signPayload(
+    {
+      account: account as UserAccountRow,
+      payload: row.payload,
+      requestType: row.request_type as SigningRequestType,
+    },
+    privateKey
+  )
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from("siwc_signing_requests")
+    .update({
+      completed_at: now,
+      result,
+      status: "completed",
+      updated_at: now,
+    })
+    .eq("signing_request_id", row.signing_request_id)
+    .select("*")
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  return data as SiwcSigningRequestRow
+}
+
+export async function approvePassportSiwcSigningRequest(input: {
+  req: NextApiRequest
+  requestId: string
+  signingRequestId: string
+}) {
+  const supabase = getPassportSupabase()
+  const { row, token } = await loadOwnedPassportSigningRequest(
+    input.req,
+    input.signingRequestId
+  )
+
+  if (isExpired(row) && row.status === "pending_user_approval") {
+    const now = new Date().toISOString()
+    const { data, error } = await supabase
+      .from("siwc_signing_requests")
+      .update({
+        status: "expired",
+        updated_at: now,
+      })
+      .eq("signing_request_id", row.signing_request_id)
+      .select("*")
+      .single()
+
+    if (error) {
+      throw error
+    }
+
+    return mapSigningRequest(data as SiwcSigningRequestRow)
+  }
+
+  if (row.status === "completed") {
+    return mapSigningRequest(row)
+  }
+
+  if (row.status !== "pending_user_approval") {
+    throw new ApiSecurityError(
+      409,
+      "invalid_state",
+      "Only pending signing requests can be approved."
+    )
+  }
+
+  await assertPasskeyAcrSatisfied(input.req, row, token)
+
+  const approvedAt = new Date().toISOString()
+  const { data: approvedRow, error: approveError } = await supabase
+    .from("siwc_signing_requests")
+    .update({
+      approved_at: approvedAt,
+      approved_by_firebase_uid: token.uid,
+      status: "approved",
+      updated_at: approvedAt,
+    })
+    .eq("signing_request_id", row.signing_request_id)
+    .eq("status", "pending_user_approval")
+    .select("*")
+    .single()
+
+  if (approveError) {
+    throw approveError
+  }
+
+  await insertSecurityEvent(supabase, {
+    actorIdentifier: token.uid,
+    actorType: "user",
+    details: {
+      signingRequestId: row.signing_request_id,
+    },
+    eventType: "signing_request.approved",
+    outcome: "success",
+    requestId: input.requestId,
+    route: "passport.siwc.signing.requests.approve",
+  })
+
+  const completedRow = await completeApprovedSigning(
+    supabase,
+    approvedRow as SiwcSigningRequestRow
+  )
+
+  await insertSecurityEvent(supabase, {
+    actorIdentifier: token.uid,
+    actorType: "user",
+    details: {
+      signingRequestId: row.signing_request_id,
+      status: completedRow.status,
+    },
+    eventType:
+      completedRow.status === "completed"
+        ? "signing_request.completed"
+        : "signing_request.policy_denied",
+    outcome: completedRow.status === "completed" ? "success" : "failure",
+    requestId: input.requestId,
+    route: "passport.siwc.signing.requests.approve",
+  })
+
+  return mapSigningRequest(completedRow)
+}
+
+export async function rejectPassportSiwcSigningRequest(input: {
+  req: NextApiRequest
+  requestId: string
+  signingRequestId: string
+}) {
+  const supabase = getPassportSupabase()
+  const { row, token } = await loadOwnedPassportSigningRequest(
+    input.req,
+    input.signingRequestId
+  )
+
+  if (isTerminalStatus(row.status)) {
+    return mapSigningRequest(row)
+  }
+
+  if (row.status !== "pending_user_approval") {
+    throw new ApiSecurityError(
+      409,
+      "invalid_state",
+      "Only pending signing requests can be rejected."
+    )
+  }
+
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from("siwc_signing_requests")
+    .update({
+      rejected_at: now,
+      rejected_by_firebase_uid: token.uid,
+      status: "rejected",
+      updated_at: now,
+    })
+    .eq("signing_request_id", row.signing_request_id)
+    .eq("status", "pending_user_approval")
+    .select("*")
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  await insertSecurityEvent(supabase, {
+    actorIdentifier: token.uid,
+    actorType: "user",
+    details: {
+      signingRequestId: row.signing_request_id,
+    },
+    eventType: "signing_request.rejected",
+    outcome: "success",
+    requestId: input.requestId,
+    route: "passport.siwc.signing.requests.reject",
+  })
+
+  return mapSigningRequest(data as SiwcSigningRequestRow)
+}

--- a/apps/passport/package.json
+++ b/apps/passport/package.json
@@ -114,6 +114,7 @@
     "styled-components": "^6.0.8",
     "tailwind-merge": "^1.13.2",
     "tailwindcss-animate": "^1.0.6",
+    "tweetnacl": "^1.0.3",
     "twilio": "^4.19.0",
     "url": "^0.11.3",
     "util": "^0.12.5",

--- a/apps/passport/pages/api/siwc/accounts/list.ts
+++ b/apps/passport/pages/api/siwc/accounts/list.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { listPassportSiwcAccounts } from "@/lib/server/siwcAccountVisibility"
+
+const listSiwcAccounts = async (req: NextApiRequest, res: NextApiResponse) => {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      bodySchema: passportSchemas.z.object({}).passthrough(),
+      rateLimitGroup: "passport_user_read",
+      route: "passport.siwc.accounts.list",
+    },
+    async () => {
+      const data = await listPassportSiwcAccounts(req)
+      return res.status(200).json({ data })
+    }
+  )
+}
+
+export default listSiwcAccounts

--- a/apps/passport/pages/api/siwc/signing/requests/approve.ts
+++ b/apps/passport/pages/api/siwc/signing/requests/approve.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { approvePassportSiwcSigningRequest } from "@/lib/server/siwcSigningRequests"
+
+const schema = passportSchemas.z.object({
+  signingRequestId: passportSchemas.z.string().min(1),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      bodySchema: schema,
+      rateLimitGroup: "passport_user_mutation",
+      route: "passport.siwc.signing.requests.approve",
+    },
+    async ({ body, context }) => {
+      const data = await approvePassportSiwcSigningRequest({
+        req,
+        requestId: context.requestId,
+        signingRequestId: body.signingRequestId,
+      })
+
+      return res.status(200).json({ data })
+    }
+  )
+}

--- a/apps/passport/pages/api/siwc/signing/requests/list.ts
+++ b/apps/passport/pages/api/siwc/signing/requests/list.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { listPassportSiwcSigningRequests } from "@/lib/server/siwcSigningRequests"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      bodySchema: passportSchemas.z.object({}).passthrough(),
+      rateLimitGroup: "passport_user_read",
+      route: "passport.siwc.signing.requests.list",
+    },
+    async () => {
+      const data = await listPassportSiwcSigningRequests(req)
+      return res.status(200).json({ data })
+    }
+  )
+}

--- a/apps/passport/pages/api/siwc/signing/requests/reject.ts
+++ b/apps/passport/pages/api/siwc/signing/requests/reject.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { rejectPassportSiwcSigningRequest } from "@/lib/server/siwcSigningRequests"
+
+const schema = passportSchemas.z.object({
+  signingRequestId: passportSchemas.z.string().min(1),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      bodySchema: schema,
+      rateLimitGroup: "passport_user_mutation",
+      route: "passport.siwc.signing.requests.reject",
+    },
+    async ({ body, context }) => {
+      const data = await rejectPassportSiwcSigningRequest({
+        req,
+        requestId: context.requestId,
+        signingRequestId: body.signingRequestId,
+      })
+
+      return res.status(200).json({ data })
+    }
+  )
+}

--- a/apps/passport/pages/api/v3/signing/requests/cancel.ts
+++ b/apps/passport/pages/api/v3/signing/requests/cancel.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { cancelSiwcSigningRequestForDapp } from "@/lib/server/siwcSigningRequests"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const schema = passportSchemas.z.object({
+  api_key: passportSchemas.z.string().min(1).optional(),
+  apikey: passportSchemas.z.string().min(1).optional(),
+  dapp_id: passportSchemas.z.union([
+    passportSchemas.z.number().int().positive(),
+    passportSchemas.z.string().min(1),
+  ]).optional(),
+  signing_request_id: passportSchemas.z.string().min(1),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "dapp",
+      bodySchema: schema,
+      rateLimitGroup: "passport_dapp_mutation",
+      route: "v3.signing.requests.cancel",
+    },
+    async ({ body, context }) => {
+      const data = await cancelSiwcSigningRequestForDapp({
+        dappId: context.dapp.id,
+        requestId: context.requestId,
+        signingRequestId: body.signing_request_id,
+        supabase: getPassportSupabase(),
+      })
+
+      return res.status(200).json({ data })
+    }
+  )
+}

--- a/apps/passport/pages/api/v3/signing/requests/create.ts
+++ b/apps/passport/pages/api/v3/signing/requests/create.ts
@@ -1,0 +1,74 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  getApiV3IdempotencyKey,
+  runApiV3IdempotentWrite,
+} from "@/lib/server/apiV3Idempotency"
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { createSiwcSigningRequest } from "@/lib/server/siwcSigningRequests"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const jsonObject = passportSchemas.z.record(passportSchemas.z.unknown())
+
+const schema = passportSchemas.z.object({
+  api_key: passportSchemas.z.string().min(1).optional(),
+  apikey: passportSchemas.z.string().min(1).optional(),
+  dapp_id: passportSchemas.z.union([
+    passportSchemas.z.number().int().positive(),
+    passportSchemas.z.string().min(1),
+  ]).optional(),
+  dapp_user_uuid: passportSchemas.z.string().uuid(),
+  payload: passportSchemas.z.unknown(),
+  payload_summary: jsonObject.optional(),
+  request_type: passportSchemas.z.enum(["message", "typed_data", "transaction"]),
+  user_account_id: passportSchemas.z.string().uuid(),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "dapp",
+      bodySchema: schema,
+      rateLimitGroup: "passport_dapp_mutation",
+      route: "v3.signing.requests.create",
+    },
+    async ({ body, context }) => {
+      const supabase = getPassportSupabase()
+      const idempotencyKey = getApiV3IdempotencyKey(req)
+      const response = await runApiV3IdempotentWrite({
+        actorIdentifier: context.actorIdentifier,
+        actorType: context.actorType,
+        body,
+        idempotencyKey,
+        requestId: context.requestId,
+        route: "v3.signing.requests.create",
+        supabase,
+        handler: async () => {
+          const request = await createSiwcSigningRequest({
+            dappId: context.dapp.id,
+            dappUserUuid: body.dapp_user_uuid,
+            idempotencyKey,
+            payload: body.payload,
+            payloadSummary: body.payload_summary,
+            requestId: context.requestId,
+            requestType: body.request_type,
+            supabase,
+            userAccountId: body.user_account_id,
+          })
+
+          return { body: { data: request }, statusCode: 200 }
+        },
+      })
+
+      return res.status(response.statusCode).json(response.body)
+    }
+  )
+}

--- a/apps/passport/pages/api/v3/signing/requests/get.ts
+++ b/apps/passport/pages/api/v3/signing/requests/get.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { getSiwcSigningRequestForDapp } from "@/lib/server/siwcSigningRequests"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const schema = passportSchemas.z.object({
+  api_key: passportSchemas.z.string().min(1).optional(),
+  apikey: passportSchemas.z.string().min(1).optional(),
+  dapp_id: passportSchemas.z.union([
+    passportSchemas.z.number().int().positive(),
+    passportSchemas.z.string().min(1),
+  ]).optional(),
+  signing_request_id: passportSchemas.z.string().min(1),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "dapp",
+      bodySchema: schema,
+      rateLimitGroup: "passport_dapp_read",
+      route: "v3.signing.requests.get",
+    },
+    async ({ body, context }) => {
+      const data = await getSiwcSigningRequestForDapp({
+        dappId: context.dapp.id,
+        signingRequestId: body.signing_request_id,
+        supabase: getPassportSupabase(),
+      })
+
+      return res.status(200).json({ data })
+    }
+  )
+}

--- a/apps/passport/pages/api/v3/signing/requests/list.ts
+++ b/apps/passport/pages/api/v3/signing/requests/list.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { listSiwcSigningRequestsForDapp } from "@/lib/server/siwcSigningRequests"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const schema = passportSchemas.z.object({
+  api_key: passportSchemas.z.string().min(1).optional(),
+  apikey: passportSchemas.z.string().min(1).optional(),
+  dapp_id: passportSchemas.z.union([
+    passportSchemas.z.number().int().positive(),
+    passportSchemas.z.string().min(1),
+  ]).optional(),
+  dapp_user_uuid: passportSchemas.z.string().uuid().optional(),
+  limit: passportSchemas.z.number().int().min(1).max(100).optional(),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "dapp",
+      bodySchema: schema,
+      rateLimitGroup: "passport_dapp_read",
+      route: "v3.signing.requests.list",
+    },
+    async ({ body, context }) => {
+      const data = await listSiwcSigningRequestsForDapp({
+        dappId: context.dapp.id,
+        dappUserUuid: body.dapp_user_uuid ?? null,
+        limit: body.limit,
+        supabase: getPassportSupabase(),
+      })
+
+      return res.status(200).json({ data })
+    }
+  )
+}

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -47,6 +47,7 @@ export class MockPassportSupabase {
   readonly lastUsedUpdates: number[] = []
   readonly privateKeys: Array<Record<string, unknown>> = []
   readonly selectiveDisclosureGrants: Array<Record<string, unknown>> = []
+  readonly siwcSigningPolicies: Array<Record<string, unknown>> = []
   readonly stampPermissions: Array<Record<string, unknown>> = []
   readonly stamps: Array<Record<string, unknown>> = []
   readonly userAccounts: Array<Record<string, unknown>> = []
@@ -152,6 +153,10 @@ export class MockPassportSupabase {
       id: row.id ?? this.nextEmailOtpId++,
     })
     this.emailOtps.set(row.email, rows)
+  }
+
+  setSiwcSigningPolicy(row: Record<string, unknown>) {
+    this.siwcSigningPolicies.push(row)
   }
 
   setWebhookSubscription(row: Record<string, unknown>) {
@@ -1030,11 +1035,11 @@ export class MockPassportSupabase {
         },
         select: () => {
           const filters: Record<string, unknown> = {}
-          let idFilter: string[] | null = null
+          const inFilters: Record<string, string[]> = {}
           const resolve = () => {
             let rows = [...this.userAccounts]
-            if (idFilter) {
-              rows = rows.filter((row) => idFilter?.includes(String(row.id)))
+            for (const [column, values] of Object.entries(inFilters)) {
+              rows = rows.filter((row) => values.includes(String(row[column])))
             }
             for (const [column, value] of Object.entries(filters)) {
               rows = rows.filter((row) => String(row[column]) === String(value))
@@ -1046,8 +1051,8 @@ export class MockPassportSupabase {
               filters[column] = value
               return query
             },
-            in: (_column: string, values: string[]) => {
-              idFilter = values
+            in: (column: string, values: unknown[]) => {
+              inFilters[column] = values.map(String)
               return query
             },
             then: (
@@ -1126,17 +1131,54 @@ export class MockPassportSupabase {
         },
         select: () => {
           const filters: Record<string, unknown> = {}
+          const inFilters: Record<string, string[]> = {}
           const resolve = () => {
             const rows = this.dappUserAccounts.filter((row) => {
-              return Object.entries(filters).every(
+              const matchesEq = Object.entries(filters).every(
                 ([column, value]) => String(row[column]) === String(value)
               )
+              const matchesIn = Object.entries(inFilters).every(
+                ([column, values]) => values.includes(String(row[column]))
+              )
+              return matchesEq && matchesIn
             })
             return { data: rows, error: null }
           }
           const query = {
             eq: (column: string, value: unknown) => {
               filters[column] = value
+              return query
+            },
+            in: (column: string, values: unknown[]) => {
+              inFilters[column] = values.map(String)
+              return query
+            },
+            then: (
+              resolveThen: (value: {
+                data: Record<string, unknown>[]
+                error: null
+              }) => unknown
+            ) => Promise.resolve(resolve()).then(resolveThen),
+          }
+          return query
+        },
+      }
+    }
+
+    if (table === "siwc_signing_policies") {
+      return {
+        select: () => {
+          const inFilters: Record<string, string[]> = {}
+          const resolve = () => {
+            let rows = [...this.siwcSigningPolicies]
+            for (const [column, values] of Object.entries(inFilters)) {
+              rows = rows.filter((row) => values.includes(String(row[column])))
+            }
+            return { data: rows, error: null }
+          }
+          const query = {
+            in: (column: string, values: unknown[]) => {
+              inFilters[column] = values.map(String)
               return query
             },
             then: (

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -45,9 +45,12 @@ export class MockPassportSupabase {
   readonly emailOtps = new Map<string, EmailOtpRow[]>()
   readonly eventInserts: Array<Record<string, unknown>> = []
   readonly lastUsedUpdates: number[] = []
+  readonly oidcHumanSubjects: Array<Record<string, unknown>> = []
   readonly privateKeys: Array<Record<string, unknown>> = []
   readonly selectiveDisclosureGrants: Array<Record<string, unknown>> = []
+  readonly siwcSigningRequests: Array<Record<string, unknown>> = []
   readonly siwcSigningPolicies: Array<Record<string, unknown>> = []
+  readonly oidcSessions: Array<Record<string, unknown>> = []
   readonly stampPermissions: Array<Record<string, unknown>> = []
   readonly stamps: Array<Record<string, unknown>> = []
   readonly userAccounts: Array<Record<string, unknown>> = []
@@ -157,6 +160,14 @@ export class MockPassportSupabase {
 
   setSiwcSigningPolicy(row: Record<string, unknown>) {
     this.siwcSigningPolicies.push(row)
+  }
+
+  setOidcSession(row: Record<string, unknown>) {
+    this.oidcSessions.push(row)
+  }
+
+  setOidcHumanSubject(row: Record<string, unknown>) {
+    this.oidcHumanSubjects.push(row)
   }
 
   setWebhookSubscription(row: Record<string, unknown>) {
@@ -1055,6 +1066,10 @@ export class MockPassportSupabase {
               inFilters[column] = values.map(String)
               return query
             },
+            maybeSingle: async () => {
+              const result = resolve()
+              return { data: result.data[0] ?? null, error: null }
+            },
             then: (
               resolveThen: (value: {
                 data: Record<string, unknown>[]
@@ -1092,6 +1107,28 @@ export class MockPassportSupabase {
             ...row,
           })
           return { error: null }
+        },
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const resolve = () => {
+            const rows = this.privateKeys.filter((row) =>
+              Object.entries(filters).every(
+                ([column, value]) => String(row[column]) === String(value)
+              )
+            )
+            return { data: rows, error: null }
+          }
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            maybeSingle: async () => {
+              const result = resolve()
+              return { data: result.data[0] ?? null, error: null }
+            },
+          }
+          return query
         },
       }
     }
@@ -1153,6 +1190,10 @@ export class MockPassportSupabase {
               inFilters[column] = values.map(String)
               return query
             },
+            maybeSingle: async () => {
+              const result = resolve()
+              return { data: result.data[0] ?? null, error: null }
+            },
             then: (
               resolveThen: (value: {
                 data: Record<string, unknown>[]
@@ -1168,15 +1209,90 @@ export class MockPassportSupabase {
     if (table === "siwc_signing_policies") {
       return {
         select: () => {
+          const filters: Record<string, unknown> = {}
           const inFilters: Record<string, string[]> = {}
           const resolve = () => {
             let rows = [...this.siwcSigningPolicies]
             for (const [column, values] of Object.entries(inFilters)) {
               rows = rows.filter((row) => values.includes(String(row[column])))
             }
+            for (const [column, value] of Object.entries(filters)) {
+              rows = rows.filter((row) => String(row[column]) === String(value))
+            }
             return { data: rows, error: null }
           }
           const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            in: (column: string, values: unknown[]) => {
+              inFilters[column] = values.map(String)
+              return query
+            },
+            maybeSingle: async () => {
+              const result = resolve()
+              return { data: result.data[0] ?? null, error: null }
+            },
+            then: (
+              resolveThen: (value: {
+                data: Record<string, unknown>[]
+                error: null
+              }) => unknown
+            ) => Promise.resolve(resolve()).then(resolveThen),
+          }
+          return query
+        },
+      }
+    }
+
+    if (table === "oidc_sessions") {
+      return {
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const resolve = () => {
+            const rows = this.oidcSessions.filter((row) =>
+              Object.entries(filters).every(
+                ([column, value]) => String(row[column]) === String(value)
+              )
+            )
+            return { data: rows, error: null }
+          }
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            maybeSingle: async () => {
+              const result = resolve()
+              return { data: result.data[0] ?? null, error: null }
+            },
+          }
+          return query
+        },
+      }
+    }
+
+    if (table === "oidc_human_subjects") {
+      return {
+        select: () => {
+          const filters: Record<string, unknown> = {}
+          const inFilters: Record<string, string[]> = {}
+          const resolve = () => {
+            let rows = [...this.oidcHumanSubjects]
+            for (const [column, values] of Object.entries(inFilters)) {
+              rows = rows.filter((row) => values.includes(String(row[column])))
+            }
+            for (const [column, value] of Object.entries(filters)) {
+              rows = rows.filter((row) => String(row[column]) === String(value))
+            }
+            return { data: rows, error: null }
+          }
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
             in: (column: string, values: unknown[]) => {
               inFilters[column] = values.map(String)
               return query
@@ -1187,6 +1303,114 @@ export class MockPassportSupabase {
                 error: null
               }) => unknown
             ) => Promise.resolve(resolve()).then(resolveThen),
+          }
+          return query
+        },
+      }
+    }
+
+    if (table === "siwc_signing_requests") {
+      const createQuery = () => {
+        const filters: Record<string, unknown> = {}
+        const inFilters: Record<string, string[]> = {}
+        let limitValue: number | null = null
+        const resolve = () => {
+          let rows = [...this.siwcSigningRequests]
+          for (const [column, values] of Object.entries(inFilters)) {
+            rows = rows.filter((row) => values.includes(String(row[column])))
+          }
+          for (const [column, value] of Object.entries(filters)) {
+            rows = rows.filter((row) => String(row[column]) === String(value))
+          }
+          rows.sort((left, right) =>
+            String(right.created_at ?? "").localeCompare(
+              String(left.created_at ?? "")
+            )
+          )
+          if (limitValue !== null) {
+            rows = rows.slice(0, limitValue)
+          }
+          return { data: rows, error: null }
+        }
+        const query = {
+          eq: (column: string, value: unknown) => {
+            filters[column] = value
+            return query
+          },
+          in: (column: string, values: unknown[]) => {
+            inFilters[column] = values.map(String)
+            return query
+          },
+          limit: (value: number) => {
+            limitValue = value
+            return query
+          },
+          maybeSingle: async () => {
+            const result = resolve()
+            return { data: result.data[0] ?? null, error: null }
+          },
+          order: () => query,
+          single: async () => {
+            const result = resolve()
+            return { data: result.data[0] ?? null, error: null }
+          },
+          then: (
+            resolveThen: (value: {
+              data: Record<string, unknown>[]
+              error: null
+            }) => unknown
+          ) => Promise.resolve(resolve()).then(resolveThen),
+        }
+        return query
+      }
+
+      return {
+        insert: (row: Record<string, unknown>) => {
+          const inserted = {
+            approved_at: null,
+            completed_at: null,
+            created_at: new Date().toISOString(),
+            id: `siwc_signing_request_${this.siwcSigningRequests.length + 1}`,
+            rejected_at: null,
+            result: null,
+            updated_at: new Date().toISOString(),
+            ...row,
+          }
+          this.siwcSigningRequests.push(inserted)
+          return {
+            select: () => ({
+              single: async () => ({ data: inserted, error: null }),
+            }),
+          }
+        },
+        select: createQuery,
+        update: (patch: Record<string, unknown>) => {
+          const filters: Record<string, unknown> = {}
+          const updateRows = () => {
+            const updatedRows: Record<string, unknown>[] = []
+            for (const row of this.siwcSigningRequests) {
+              if (
+                Object.entries(filters).every(
+                  ([column, value]) => String(row[column]) === String(value)
+                )
+              ) {
+                Object.assign(row, patch)
+                updatedRows.push(row)
+              }
+            }
+            return updatedRows
+          }
+          const query = {
+            eq: (column: string, value: unknown) => {
+              filters[column] = value
+              return query
+            },
+            select: () => ({
+              single: async () => ({
+                data: updateRows()[0] ?? null,
+                error: null,
+              }),
+            }),
           }
           return query
         },

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -93,6 +93,19 @@ const addFirebaseUserAuth = () => {
   })
 }
 
+const addSiwcWebhookSubscription = (
+  supabase: MockPassportSupabase,
+  webhook: string
+) => {
+  supabase.setWebhookSubscription({
+    dapp: 42,
+    secret: "webhook-signing-secret",
+    status: "active",
+    webhook,
+    webhook_url: `https://example.test/${webhook}`,
+  })
+}
+
 test("legacy Passport Supabase select endpoint is hard-disabled with a request id", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
@@ -707,6 +720,77 @@ test("Passport API v3 SIWC transaction risk fails closed for unsupported chains"
   assert.deepEqual(data.riskReasons, ["transaction_chain_risk_unsupported"])
 })
 
+test("Passport API v3 SIWC signing request emits created and policy-denied webhooks", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  const fixtures = addSiwcSigningFixtures(supabase, {
+    webhook_event_subscriptions: [
+      "wallet.policy.denied",
+      "wallet.signing_request.created",
+    ],
+  })
+  addSiwcWebhookSubscription(supabase, "wallet.signing_request.created")
+  addSiwcWebhookSubscription(supabase, "wallet.policy.denied")
+  const delivered: Array<Record<string, unknown>> = []
+  axios.post = (async (_url: string, body: unknown) => {
+    delivered.push(JSON.parse(String(body)) as Record<string, unknown>)
+    return { data: "accepted", status: 202 }
+  }) as typeof axios.post
+
+  await createSiwcSigningRequestHandler(
+    createApiRequest({
+      body: {
+        apikey: fixtures.apiKey,
+        dapp_user_uuid: fixtures.dappUserUuid,
+        payload: { message: "webhook me" },
+        request_type: "message",
+        user_account_id: fixtures.userAccountId,
+      },
+      headers: {
+        "idempotency-key": "signing-created-webhook",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/signing/requests/create",
+    }),
+    createApiResponse()
+  )
+  await createSiwcSigningRequestHandler(
+    createApiRequest({
+      body: {
+        apikey: fixtures.apiKey,
+        dapp_user_uuid: fixtures.dappUserUuid,
+        payload: {
+          declaredValueUsd: 10,
+          to: "0x0000000000000000000000000000000000000000",
+        },
+        request_type: "transaction",
+        user_account_id: fixtures.userAccountId,
+      },
+      headers: {
+        "idempotency-key": "signing-policy-denied-webhook",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/signing/requests/create",
+    }),
+    createApiResponse()
+  )
+
+  assert.deepEqual(
+    delivered.map((payload) => payload.eventType).sort(),
+    ["wallet.policy.denied", "wallet.signing_request.created"]
+  )
+  const denied = delivered.find(
+    (payload) => payload.eventType === "wallet.policy.denied"
+  )
+  assert.equal(
+    (denied?.data as Record<string, unknown>).errorCode,
+    "transaction_signing_deferred"
+  )
+  assert.equal(JSON.stringify(delivered).includes('"payload"'), false)
+  assert.equal(JSON.stringify(delivered).includes("private"), false)
+  assert.equal(JSON.stringify(delivered).includes("human_subject_key"), false)
+})
+
 test("Passport SIWC signing approval requires passkey step-up then completes EVM message signatures", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
@@ -791,11 +875,122 @@ test("Passport SIWC signing approval requires passkey step-up then completes EVM
   assert.equal(JSON.stringify(approveRes.body).includes(fixtures.wallet.privateKey), false)
 })
 
+test("Passport SIWC signing approval emits approved and signature completed webhooks", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+  const fixtures = addSiwcSigningFixtures(supabase, {
+    webhook_event_subscriptions: [
+      "wallet.signature.completed",
+      "wallet.signing_request.approved",
+      "wallet.signing_request.created",
+    ],
+  })
+  addSiwcWebhookSubscription(supabase, "wallet.signing_request.created")
+  addSiwcWebhookSubscription(supabase, "wallet.signing_request.approved")
+  addSiwcWebhookSubscription(supabase, "wallet.signature.completed")
+  const delivered: Array<Record<string, unknown>> = []
+  axios.post = (async (_url: string, body: unknown) => {
+    delivered.push(JSON.parse(String(body)) as Record<string, unknown>)
+    return { data: "accepted", status: 202 }
+  }) as typeof axios.post
+
+  const createRes = createApiResponse()
+  await createSiwcSigningRequestHandler(
+    createApiRequest({
+      body: {
+        apikey: fixtures.apiKey,
+        dapp_user_uuid: fixtures.dappUserUuid,
+        payload: { message: "complete webhook" },
+        request_type: "message",
+        user_account_id: fixtures.userAccountId,
+      },
+      headers: {
+        "idempotency-key": "signing-completed-webhook",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/signing/requests/create",
+    }),
+    createRes
+  )
+  const signingRequestId = String(
+    (createRes.body as DataResponse<Record<string, unknown>>).data
+      .signingRequestId
+  )
+
+  supabase.setOidcHumanSubject({
+    cubid_user_id: 1234,
+    human_subject_key: "human_subject_1",
+    primary_email: "person@example.com",
+  })
+  supabase.setOidcSession({
+    created_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    human_subject_key: "human_subject_1",
+    metadata: {
+      acr: "urn:cubid:acr:passkey",
+      authentication_methods: ["passkey"],
+    },
+    revoked_at: null,
+    session_id: "oidc_session_passkey_webhook",
+  })
+
+  await approveSiwcSigningRequestHandler(
+    createApiRequest({
+      body: { signingRequestId },
+      headers: {
+        authorization: "Bearer firebase-test-token",
+        cookie: "cubid_oidc_session_id=oidc_session_passkey_webhook",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/siwc/signing/requests/approve",
+    }),
+    createApiResponse()
+  )
+
+  assert.deepEqual(
+    delivered.map((payload) => payload.eventType),
+    [
+      "wallet.signing_request.created",
+      "wallet.signing_request.approved",
+      "wallet.signature.completed",
+    ]
+  )
+  const completed = delivered[2]
+  assert.equal((completed.data as Record<string, unknown>).status, "completed")
+  assert.equal(
+    ((completed.data as Record<string, unknown>).result as Record<string, unknown>)
+      .algorithm,
+    "evm_secp256k1"
+  )
+  assert.equal(
+    "signature" in
+      (((completed.data as Record<string, unknown>).result as Record<
+        string,
+        unknown
+      >) ?? {}),
+    false
+  )
+  assert.equal(JSON.stringify(completed).includes(fixtures.wallet.privateKey), false)
+})
+
 test("Passport SIWC signing approval rejects stale passkey step-up sessions", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   addFirebaseUserAuth()
-  const fixtures = addSiwcSigningFixtures(supabase)
+  const fixtures = addSiwcSigningFixtures(supabase, {
+    webhook_event_subscriptions: [
+      "wallet.signing_request.created",
+      "wallet.signing_request.step_up_failed",
+    ],
+  })
+  addSiwcWebhookSubscription(supabase, "wallet.signing_request.created")
+  addSiwcWebhookSubscription(supabase, "wallet.signing_request.step_up_failed")
+  const delivered: Array<Record<string, unknown>> = []
+  axios.post = (async (_url: string, body: unknown) => {
+    delivered.push(JSON.parse(String(body)) as Record<string, unknown>)
+    return { data: "accepted", status: 202 }
+  }) as typeof axios.post
 
   const createReq = createApiRequest({
     body: {
@@ -861,13 +1056,31 @@ test("Passport SIWC signing approval rejects stale passkey step-up sessions", as
     ),
     true
   )
+  assert.equal(
+    delivered.some(
+      (payload) => payload.eventType === "wallet.signing_request.step_up_failed"
+    ),
+    true
+  )
 })
 
 test("Passport SIWC signing requests can be listed, rejected, and cancelled", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   addFirebaseUserAuth()
-  const fixtures = addSiwcSigningFixtures(supabase)
+  const fixtures = addSiwcSigningFixtures(supabase, {
+    webhook_event_subscriptions: [
+      "wallet.signing_request.cancelled",
+      "wallet.signing_request.rejected",
+    ],
+  })
+  addSiwcWebhookSubscription(supabase, "wallet.signing_request.cancelled")
+  addSiwcWebhookSubscription(supabase, "wallet.signing_request.rejected")
+  const delivered: Array<Record<string, unknown>> = []
+  axios.post = (async (_url: string, body: unknown) => {
+    delivered.push(JSON.parse(String(body)) as Record<string, unknown>)
+    return { data: "accepted", status: 202 }
+  }) as typeof axios.post
 
   const createSigning = async (idempotencyKey: string) => {
     const req = createApiRequest({
@@ -939,6 +1152,10 @@ test("Passport SIWC signing requests can be listed, rejected, and cancelled", as
   assert.equal(
     (cancelRes.body as DataResponse<Record<string, unknown>>).data.status,
     "cancelled"
+  )
+  assert.deepEqual(
+    delivered.map((payload) => payload.eventType).sort(),
+    ["wallet.signing_request.cancelled", "wallet.signing_request.rejected"]
   )
 })
 
@@ -1976,6 +2193,143 @@ test("Passport v3 account generation cleans up public account rows on private-ke
   assert.equal(supabase.privateKeys.length, 0)
   assert.equal(supabase.dappUserAccounts.length, 0)
   assert.equal(supabase.apiIdempotencyKeys[0]?.status, "failed")
+})
+
+test("Passport v3 account generation emits safe wallet.created webhooks", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000057"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.setSiwcSigningPolicy({
+    dapp_id: 42,
+    webhook_event_subscriptions: ["wallet.created"],
+  })
+  addSiwcWebhookSubscription(supabase, "wallet.created")
+  setPassportSupabaseForTests(supabase as never)
+
+  let deliveredBody = ""
+  axios.post = (async (_url: string, body: unknown) => {
+    deliveredBody = String(body)
+    return { data: "accepted", status: 202 }
+  }) as typeof axios.post
+
+  const res = createApiResponse()
+  await generateAccountV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        chain: "evm",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        "idempotency-key": "generate-wallet-created-webhook",
+        origin: "https://passport.cubid.me",
+        "x-request-id": "passport_wallet_created_webhook",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(supabase.webhookEvents.length, 1)
+  assert.equal(supabase.webhookEventDeliveries[0]?.delivery_status, "succeeded")
+  const payload = JSON.parse(deliveredBody) as Record<string, unknown>
+  assert.equal(payload.eventType, "wallet.created")
+  assert.equal(payload.requestId, "passport_wallet_created_webhook")
+  assert.deepEqual(payload.subject, { dappUserUuid })
+  assert.equal(
+    (payload.data as Record<string, unknown>).accountId,
+    (res.body as DataResponse<Record<string, unknown>>).data.accountId
+  )
+  assert.equal(JSON.stringify(payload).includes("private"), false)
+  assert.equal(JSON.stringify(payload).includes("ciphertext"), false)
+  assert.equal(JSON.stringify(payload).includes("wrapped"), false)
+  assert.equal(JSON.stringify(payload).includes("human_subject_key"), false)
+})
+
+test("Passport v3 account generation skips SIWC webhooks not enabled by policy", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000053"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.setSiwcSigningPolicy({
+    dapp_id: 42,
+    webhook_event_subscriptions: [],
+  })
+  addSiwcWebhookSubscription(supabase, "wallet.created")
+  setPassportSupabaseForTests(supabase as never)
+
+  let delivered = false
+  axios.post = (async () => {
+    delivered = true
+    return { data: "accepted", status: 202 }
+  }) as typeof axios.post
+
+  const res = createApiResponse()
+  await generateAccountV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        chain: "evm",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        "idempotency-key": "generate-wallet-created-not-subscribed",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(delivered, false)
+  assert.equal(supabase.webhookEvents.length, 0)
+  assert.equal(supabase.webhookEventDeliveries.length, 0)
+})
+
+test("Passport v3 account generation records failed SIWC webhook delivery without failing the response", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000054"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.setSiwcSigningPolicy({
+    dapp_id: 42,
+    webhook_event_subscriptions: ["wallet.created"],
+  })
+  addSiwcWebhookSubscription(supabase, "wallet.created")
+  setPassportSupabaseForTests(supabase as never)
+  axios.post = (async () => {
+    throw {
+      response: {
+        data: { error: "down" },
+        status: 503,
+      },
+    }
+  }) as typeof axios.post
+
+  const res = createApiResponse()
+  await generateAccountV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        chain: "evm",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        "idempotency-key": "generate-wallet-created-failed-webhook",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(supabase.webhookEventDeliveries.length, 1)
+  assert.equal(supabase.webhookEventDeliveries[0]?.delivery_status, "failed")
+  assert.equal(supabase.webhookEventDeliveries[0]?.error_category, "server_error")
 })
 
 test("Passport v3 account list returns dapp-user-visible metadata without secret material", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -417,7 +417,10 @@ test("Passport SIWC account list returns an empty list for signed-in users witho
   assert.deepEqual((res.body as DataResponse<unknown[]>).data, [])
 })
 
-const addSiwcSigningFixtures = (supabase: MockPassportSupabase) => {
+const addSiwcSigningFixtures = (
+  supabase: MockPassportSupabase,
+  policyOverrides: Record<string, unknown> = {}
+) => {
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000071"
   const userAccountId = "00000000-0000-4000-8000-000000000072"
@@ -453,6 +456,7 @@ const addSiwcSigningFixtures = (supabase: MockPassportSupabase) => {
   supabase.setSiwcSigningPolicy({
     allowed_chains: ["evm"],
     allowed_request_types: ["message", "typed_data", "transaction"],
+    contract_allowlist: [],
     custody_enabled: true,
     dapp_id: 42,
     policy_version: 2,
@@ -460,6 +464,8 @@ const addSiwcSigningFixtures = (supabase: MockPassportSupabase) => {
     sandbox_mode: true,
     signing_enabled: true,
     status: "enabled",
+    transaction_value_limit_usd: null,
+    ...policyOverrides,
   })
   supabase.privateKeys.push({
     ...encryptBlockchainPrivateKeyWithKey(
@@ -564,12 +570,18 @@ test("Passport API v3 SIWC signing request create/get/list use policy and idempo
 test("Passport API v3 SIWC signing request policy-denies deferred transactions", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
-  const fixtures = addSiwcSigningFixtures(supabase)
+  const fixtures = addSiwcSigningFixtures(supabase, {
+    contract_allowlist: ["0x0000000000000000000000000000000000000000"],
+    transaction_value_limit_usd: 25,
+  })
   const req = createApiRequest({
     body: {
       apikey: fixtures.apiKey,
       dapp_user_uuid: fixtures.dappUserUuid,
-      payload: { to: "0x0000000000000000000000000000000000000000" },
+      payload: {
+        declaredValueUsd: 10,
+        to: "0x0000000000000000000000000000000000000000",
+      },
       request_type: "transaction",
       user_account_id: fixtures.userAccountId,
     },
@@ -587,6 +599,112 @@ test("Passport API v3 SIWC signing request policy-denies deferred transactions",
   assert.equal(res.statusCode, 200)
   assert.equal(data.status, "policy_denied")
   assert.equal(data.errorCode, "transaction_signing_deferred")
+  assert.equal(data.riskLevel, "high")
+  assert.equal(data.transactionOperationType, "native_transfer")
+  assert.equal(
+    data.transactionRecipient,
+    "0x0000000000000000000000000000000000000000"
+  )
+  assert.equal(data.transactionDeclaredValueUsd, 10)
+  assert.deepEqual(data.riskReasons, ["transaction_signing_deferred"])
+  assert.equal(data.stepUpRequired, true)
+})
+
+test("Passport API v3 SIWC transaction risk records value and allowlist denials", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  const fixtures = addSiwcSigningFixtures(supabase, {
+    contract_allowlist: ["0x0000000000000000000000000000000000000042"],
+    transaction_value_limit_usd: 25,
+  })
+  const req = createApiRequest({
+    body: {
+      apikey: fixtures.apiKey,
+      dapp_user_uuid: fixtures.dappUserUuid,
+      payload: {
+        data: "0xabcdef",
+        declaredValueUsd: 50,
+        to: "0x0000000000000000000000000000000000000099",
+      },
+      request_type: "transaction",
+      user_account_id: fixtures.userAccountId,
+    },
+    headers: {
+      "idempotency-key": "signing-create-transaction-denied",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/v3/signing/requests/create",
+  })
+  const res = createApiResponse()
+
+  await createSiwcSigningRequestHandler(req, res)
+
+  const data = (res.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(res.statusCode, 200)
+  assert.equal(data.status, "policy_denied")
+  assert.equal(data.errorCode, "transaction_value_limit_exceeded")
+  assert.equal(data.transactionOperationType, "contract_call")
+  assert.equal(
+    data.transactionContractAddress,
+    "0x0000000000000000000000000000000000000099"
+  )
+  assert.deepEqual(data.riskReasons, [
+    "contract_not_allowlisted",
+    "transaction_value_limit_exceeded",
+    "transaction_signing_deferred",
+  ])
+})
+
+test("Passport API v3 SIWC transaction risk fails closed for unsupported chains", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  const fixtures = addSiwcSigningFixtures(supabase, {
+    allowed_chains: ["evm", "solana"],
+  })
+  const solanaAccountId = "00000000-0000-4000-8000-000000000075"
+  supabase.userAccounts.push({
+    chain_key: "solana",
+    created_at: "2026-05-01T00:00:00.000Z",
+    custody_status: "cubid_custodied",
+    id: solanaAccountId,
+    public_address: "solana-address",
+    public_address_normalized: "solana-address",
+    status: "active",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    user_id: 1234,
+  })
+  supabase.dappUserAccounts.push({
+    created_at: "2026-05-01T00:00:00.000Z",
+    dapp_id: 42,
+    dapp_user_uuid: fixtures.dappUserUuid,
+    id: "00000000-0000-4000-8000-000000000076",
+    status: "active",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    user_account_id: solanaAccountId,
+  })
+  const req = createApiRequest({
+    body: {
+      apikey: fixtures.apiKey,
+      dapp_user_uuid: fixtures.dappUserUuid,
+      payload: { to: "solana-destination" },
+      request_type: "transaction",
+      user_account_id: solanaAccountId,
+    },
+    headers: {
+      "idempotency-key": "signing-create-transaction-solana",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/v3/signing/requests/create",
+  })
+  const res = createApiResponse()
+
+  await createSiwcSigningRequestHandler(req, res)
+
+  const data = (res.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(res.statusCode, 200)
+  assert.equal(data.status, "policy_denied")
+  assert.equal(data.errorCode, "transaction_chain_risk_unsupported")
+  assert.deepEqual(data.riskReasons, ["transaction_chain_risk_unsupported"])
 })
 
 test("Passport SIWC signing approval requires passkey step-up then completes EVM message signatures", async () => {
@@ -639,6 +757,7 @@ test("Passport SIWC signing approval requires passkey step-up then completes EVM
     primary_email: "person@example.com",
   })
   supabase.setOidcSession({
+    created_at: new Date().toISOString(),
     expires_at: new Date(Date.now() + 60_000).toISOString(),
     human_subject_key: "human_subject_1",
     metadata: {
@@ -670,6 +789,78 @@ test("Passport SIWC signing approval requires passkey step-up then completes EVM
     fixtures.wallet.address
   )
   assert.equal(JSON.stringify(approveRes.body).includes(fixtures.wallet.privateKey), false)
+})
+
+test("Passport SIWC signing approval rejects stale passkey step-up sessions", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+  const fixtures = addSiwcSigningFixtures(supabase)
+
+  const createReq = createApiRequest({
+    body: {
+      apikey: fixtures.apiKey,
+      dapp_user_uuid: fixtures.dappUserUuid,
+      payload: { message: "stale passkey approval" },
+      request_type: "message",
+      user_account_id: fixtures.userAccountId,
+    },
+    headers: {
+      "idempotency-key": "signing-approve-stale-stepup",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/v3/signing/requests/create",
+  })
+  const createRes = createApiResponse()
+  await createSiwcSigningRequestHandler(createReq, createRes)
+  const signingRequestId = String(
+    (createRes.body as DataResponse<Record<string, unknown>>).data
+      .signingRequestId
+  )
+
+  supabase.setOidcHumanSubject({
+    cubid_user_id: 1234,
+    human_subject_key: "human_subject_1",
+    primary_email: "person@example.com",
+  })
+  supabase.setOidcSession({
+    created_at: new Date(Date.now() - 10 * 60_000).toISOString(),
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    human_subject_key: "human_subject_1",
+    metadata: {
+      acr: "urn:cubid:acr:passkey",
+      authentication_methods: ["passkey"],
+    },
+    revoked_at: null,
+    session_id: "oidc_session_stale_passkey",
+  })
+
+  const approveReq = createApiRequest({
+    body: { signingRequestId },
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      cookie: "cubid_oidc_session_id=oidc_session_stale_passkey",
+      origin: "https://passport.cubid.me",
+      "x-request-id": "passport_siwc_stale_stepup",
+    },
+    url: "/api/siwc/signing/requests/approve",
+  })
+  const approveRes = createApiResponse()
+  await approveSiwcSigningRequestHandler(approveReq, approveRes)
+
+  assert.equal(approveRes.statusCode, 403)
+  assert.equal(
+    (approveRes.body as { error: { code: string } }).error.code,
+    "step_up_required"
+  )
+  assert.equal(
+    supabase.eventInserts.some(
+      (event) =>
+        event.event_type === "signing_request.step_up_failed" &&
+        event.request_id === "passport_siwc_stale_stepup"
+    ),
+    true
+  )
 })
 
 test("Passport SIWC signing requests can be listed, rejected, and cancelled", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -9,6 +9,7 @@ import actorProfileUpsertHandler from "../pages/api/actors/profile/upsert"
 import appDisclosureGrantListHandler from "../pages/api/disclosures/app-grants/list"
 import appDisclosureGrantRevokeHandler from "../pages/api/disclosures/app-grants/revoke"
 import consentListHandler from "../pages/api/oidc/consents/list"
+import siwcAccountListHandler from "../pages/api/siwc/accounts/list"
 import supabaseSelectHandler from "../pages/api/supabase/select"
 import sendOtpHandler from "../pages/api/twillio/send-otp"
 import sendEmailOtpHandler from "../pages/api/v2/email/send_otp"
@@ -221,6 +222,188 @@ test("Passport app disclosure grants list and revoke Allow Page grants", async (
     ),
     true
   )
+})
+
+test("Passport SIWC account list requires Firebase bearer auth", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+
+  const req = createApiRequest({
+    body: {},
+    headers: {
+      origin: "https://passport.cubid.me",
+      "x-request-id": "passport_siwc_missing_auth",
+    },
+    url: "/api/siwc/accounts/list",
+  })
+  const res = createApiResponse()
+
+  await siwcAccountListHandler(req, res)
+
+  assert.equal(res.statusCode, 401)
+  assert.equal(res.headers["x-request-id"], "passport_siwc_missing_auth")
+  assert.deepEqual(res.body, {
+    error: {
+      code: "unauthorized",
+      message: "Missing Firebase bearer token.",
+      requestId: "passport_siwc_missing_auth",
+    },
+  })
+})
+
+test("Passport SIWC account list returns public app-scoped account metadata only", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setDapp({ appname: "Wallet App", id: 42 })
+  supabase.setDapp({ appname: "Other App", id: 99 })
+  supabase.userAccounts.push(
+    {
+      account_label: "Primary EVM",
+      chain_key: "evm",
+      created_at: "2026-05-01T00:00:00.000Z",
+      custody_status: "cubid_custodied",
+      id: "account_visible",
+      private_key_ciphertext: "must_not_surface",
+      public_address: "0xabc",
+      status: "active",
+      updated_at: "2026-05-02T00:00:00.000Z",
+      user_id: 1234,
+      wrapped_data_key: "must_not_surface",
+    },
+    {
+      chain_key: "solana",
+      created_at: "2026-05-01T00:00:00.000Z",
+      custody_status: "cubid_custodied",
+      id: "account_other_user",
+      public_address: "other",
+      status: "active",
+      updated_at: "2026-05-02T00:00:00.000Z",
+      user_id: 9999,
+    },
+    {
+      chain_key: "sui",
+      created_at: "2026-05-01T00:00:00.000Z",
+      custody_status: "cubid_custodied",
+      id: "account_revoked",
+      public_address: "0xdead",
+      status: "revoked",
+      updated_at: "2026-05-02T00:00:00.000Z",
+      user_id: 1234,
+    }
+  )
+  supabase.dappUserAccounts.push(
+    {
+      created_at: "2026-05-01T00:00:00.000Z",
+      dapp_id: 42,
+      dapp_user_uuid: "00000000-0000-4000-8000-000000000061",
+      id: "link_visible",
+      status: "active",
+      updated_at: "2026-05-02T00:00:00.000Z",
+      user_account_id: "account_visible",
+    },
+    {
+      created_at: "2026-05-01T00:00:00.000Z",
+      dapp_id: 99,
+      dapp_user_uuid: "00000000-0000-4000-8000-000000000062",
+      id: "link_other_user",
+      status: "active",
+      updated_at: "2026-05-02T00:00:00.000Z",
+      user_account_id: "account_other_user",
+    },
+    {
+      created_at: "2026-05-01T00:00:00.000Z",
+      dapp_id: 42,
+      dapp_user_uuid: "00000000-0000-4000-8000-000000000063",
+      id: "link_revoked",
+      status: "active",
+      updated_at: "2026-05-02T00:00:00.000Z",
+      user_account_id: "account_revoked",
+    },
+    {
+      created_at: "2026-05-01T00:00:00.000Z",
+      dapp_id: 42,
+      dapp_user_uuid: "00000000-0000-4000-8000-000000000064",
+      id: "link_archived",
+      status: "archived",
+      updated_at: "2026-05-02T00:00:00.000Z",
+      user_account_id: "account_visible",
+    }
+  )
+  supabase.setSiwcSigningPolicy({
+    custody_enabled: true,
+    dapp_id: 42,
+    policy_version: 3,
+    required_acr: "urn:cubid:acr:passkey",
+    sandbox_mode: true,
+    signing_enabled: true,
+    status: "enabled",
+  })
+
+  const req = createApiRequest({
+    body: {},
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+      "x-request-id": "passport_siwc_accounts",
+    },
+    url: "/api/siwc/accounts/list",
+  })
+  const res = createApiResponse()
+
+  await siwcAccountListHandler(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.headers["x-request-id"], "passport_siwc_accounts")
+  const accounts = (res.body as DataResponse<Array<Record<string, unknown>>>).data
+  assert.equal(accounts.length, 1)
+  assert.deepEqual(accounts[0], {
+    accountId: "account_visible",
+    accountStatus: "active",
+    chain: "evm",
+    createdAt: "2026-05-01T00:00:00.000Z",
+    custodyEnabled: true,
+    custodyStatus: "cubid_custodied",
+    dappId: "42",
+    dappName: "Wallet App",
+    dappUserAccountId: "link_visible",
+    dappUserUuid: "00000000-0000-4000-8000-000000000061",
+    label: "Primary EVM",
+    linkStatus: "active",
+    policyStatus: "enabled",
+    policyVersion: 3,
+    publicAddress: "0xabc",
+    requiredAcr: "urn:cubid:acr:passkey",
+    sandboxMode: true,
+    signingEnabled: true,
+    updatedAt: "2026-05-02T00:00:00.000Z",
+  })
+  assert.equal(JSON.stringify(res.body).includes("private"), false)
+  assert.equal(JSON.stringify(res.body).includes("ciphertext"), false)
+  assert.equal(JSON.stringify(res.body).includes("wrapped"), false)
+  assert.equal(JSON.stringify(res.body).includes("user_id"), false)
+})
+
+test("Passport SIWC account list returns an empty list for signed-in users without Cubid user ids", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+
+  const req = createApiRequest({
+    body: {},
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/siwc/accounts/list",
+  })
+  const res = createApiResponse()
+
+  await siwcAccountListHandler(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual((res.body as DataResponse<unknown[]>).data, [])
 })
 
 test("Passport actor profile get defaults signed-in users to human", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -3,6 +3,7 @@ import test from "node:test"
 
 import axios from "axios"
 import { hashDappApiKey } from "@cubid/auth/server"
+import { ethers } from "ethers"
 
 import actorProfileGetHandler from "../pages/api/actors/profile/get"
 import actorProfileUpsertHandler from "../pages/api/actors/profile/upsert"
@@ -10,6 +11,9 @@ import appDisclosureGrantListHandler from "../pages/api/disclosures/app-grants/l
 import appDisclosureGrantRevokeHandler from "../pages/api/disclosures/app-grants/revoke"
 import consentListHandler from "../pages/api/oidc/consents/list"
 import siwcAccountListHandler from "../pages/api/siwc/accounts/list"
+import approveSiwcSigningRequestHandler from "../pages/api/siwc/signing/requests/approve"
+import listPassportSiwcSigningRequestsHandler from "../pages/api/siwc/signing/requests/list"
+import rejectSiwcSigningRequestHandler from "../pages/api/siwc/signing/requests/reject"
 import supabaseSelectHandler from "../pages/api/supabase/select"
 import sendOtpHandler from "../pages/api/twillio/send-otp"
 import sendEmailOtpHandler from "../pages/api/v2/email/send_otp"
@@ -18,11 +22,18 @@ import saveSecretV2Handler from "../pages/api/v2/save_secret"
 import generateAccountV3Handler from "../pages/api/v3/accounts/generate"
 import listAccountsV3Handler from "../pages/api/v3/accounts/list"
 import saveSecretV3Handler from "../pages/api/v3/save_secret"
+import cancelSiwcSigningRequestHandler from "../pages/api/v3/signing/requests/cancel"
+import createSiwcSigningRequestHandler from "../pages/api/v3/signing/requests/create"
+import getSiwcSigningRequestHandler from "../pages/api/v3/signing/requests/get"
+import listSiwcSigningRequestsHandler from "../pages/api/v3/signing/requests/list"
 import webhookTriggerHandler from "../pages/api/cubid-webhook/trigger-url"
 import createUserHandler from "../pages/api/v2/create_user"
 import { hashApiV3IdempotencyRequest } from "../lib/server/apiV3Idempotency"
 import { signApiV3WebhookPayload } from "../lib/server/apiV3Webhooks"
-import { decryptBlockchainPrivateKeyWithKey } from "../lib/server/blockchainAccounts"
+import {
+  encryptBlockchainPrivateKeyWithKey,
+  decryptBlockchainPrivateKeyWithKey,
+} from "../lib/server/blockchainAccounts"
 import {
   DAPP_USER_SECRET_LEGACY_SENTINEL,
   decryptDappUserSecretWithKey,
@@ -404,6 +415,340 @@ test("Passport SIWC account list returns an empty list for signed-in users witho
 
   assert.equal(res.statusCode, 200)
   assert.deepEqual((res.body as DataResponse<unknown[]>).data, [])
+})
+
+const addSiwcSigningFixtures = (supabase: MockPassportSupabase) => {
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000071"
+  const userAccountId = "00000000-0000-4000-8000-000000000072"
+  const dappUserAccountId = "00000000-0000-4000-8000-000000000073"
+  const wallet = ethers.Wallet.createRandom()
+
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setDappUser({
+    dapp_id: 42,
+    user_id: 1234,
+    uuid: dappUserUuid,
+  })
+  supabase.userAccounts.push({
+    chain_key: "evm",
+    created_at: "2026-05-01T00:00:00.000Z",
+    custody_status: "cubid_custodied",
+    id: userAccountId,
+    public_address: wallet.address,
+    public_address_normalized: wallet.address.toLowerCase(),
+    status: "active",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    user_id: 1234,
+  })
+  supabase.dappUserAccounts.push({
+    created_at: "2026-05-01T00:00:00.000Z",
+    dapp_id: 42,
+    dapp_user_uuid: dappUserUuid,
+    id: dappUserAccountId,
+    status: "active",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    user_account_id: userAccountId,
+  })
+  supabase.setSiwcSigningPolicy({
+    allowed_chains: ["evm"],
+    allowed_request_types: ["message", "typed_data", "transaction"],
+    custody_enabled: true,
+    dapp_id: 42,
+    policy_version: 2,
+    required_acr: "urn:cubid:acr:passkey",
+    sandbox_mode: true,
+    signing_enabled: true,
+    status: "enabled",
+  })
+  supabase.privateKeys.push({
+    ...encryptBlockchainPrivateKeyWithKey(
+      wallet.privateKey,
+      Buffer.from("fedcba9876543210fedcba9876543210"),
+      {
+        chainKey: "evm",
+        publicAddressNormalized: wallet.address.toLowerCase(),
+        userAccountId,
+        userId: 1234,
+      }
+    ),
+    chain_key: "evm",
+    status: "active",
+    user_account_id: userAccountId,
+  })
+
+  return {
+    apiKey,
+    dappUserAccountId,
+    dappUserUuid,
+    userAccountId,
+    wallet,
+  }
+}
+
+test("Passport API v3 SIWC signing request create/get/list use policy and idempotency", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  const fixtures = addSiwcSigningFixtures(supabase)
+  const body = {
+    apikey: fixtures.apiKey,
+    dapp_user_uuid: fixtures.dappUserUuid,
+    payload: { message: "hello Cubid" },
+    request_type: "message",
+    user_account_id: fixtures.userAccountId,
+  }
+
+  const createReq = createApiRequest({
+    body,
+    headers: {
+      "idempotency-key": "signing-create-1",
+      origin: "https://passport.cubid.me",
+      "x-request-id": "passport_siwc_signing_create",
+    },
+    url: "/api/v3/signing/requests/create",
+  })
+  const createRes = createApiResponse()
+
+  await createSiwcSigningRequestHandler(createReq, createRes)
+
+  assert.equal(createRes.statusCode, 200)
+  assert.equal(supabase.siwcSigningRequests.length, 1)
+  const created = (createRes.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(created.status, "pending_user_approval")
+  assert.equal(created.policyVersion, 2)
+  assert.equal(created.requiredAcr, "urn:cubid:acr:passkey")
+  assert.equal(JSON.stringify(createRes.body).includes('"payload"'), false)
+  assert.equal(JSON.stringify(createRes.body).includes("private"), false)
+
+  const replayRes = createApiResponse()
+  await createSiwcSigningRequestHandler(createReq, replayRes)
+  assert.equal(replayRes.statusCode, 200)
+  assert.equal(supabase.siwcSigningRequests.length, 1)
+  assert.deepEqual(replayRes.body, createRes.body)
+
+  const getReq = createApiRequest({
+    body: {
+      apikey: fixtures.apiKey,
+      signing_request_id: String(created.signingRequestId),
+    },
+    headers: {
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/v3/signing/requests/get",
+  })
+  const getRes = createApiResponse()
+  await getSiwcSigningRequestHandler(getReq, getRes)
+  assert.equal(getRes.statusCode, 200)
+  assert.equal(
+    (getRes.body as DataResponse<Record<string, unknown>>).data
+      .signingRequestId,
+    created.signingRequestId
+  )
+
+  const listReq = createApiRequest({
+    body: {
+      apikey: fixtures.apiKey,
+      dapp_user_uuid: fixtures.dappUserUuid,
+    },
+    headers: {
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/v3/signing/requests/list",
+  })
+  const listRes = createApiResponse()
+  await listSiwcSigningRequestsHandler(listReq, listRes)
+  assert.equal(listRes.statusCode, 200)
+  assert.equal((listRes.body as DataResponse<unknown[]>).data.length, 1)
+})
+
+test("Passport API v3 SIWC signing request policy-denies deferred transactions", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  const fixtures = addSiwcSigningFixtures(supabase)
+  const req = createApiRequest({
+    body: {
+      apikey: fixtures.apiKey,
+      dapp_user_uuid: fixtures.dappUserUuid,
+      payload: { to: "0x0000000000000000000000000000000000000000" },
+      request_type: "transaction",
+      user_account_id: fixtures.userAccountId,
+    },
+    headers: {
+      "idempotency-key": "signing-create-transaction",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/v3/signing/requests/create",
+  })
+  const res = createApiResponse()
+
+  await createSiwcSigningRequestHandler(req, res)
+
+  const data = (res.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(res.statusCode, 200)
+  assert.equal(data.status, "policy_denied")
+  assert.equal(data.errorCode, "transaction_signing_deferred")
+})
+
+test("Passport SIWC signing approval requires passkey step-up then completes EVM message signatures", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+  const fixtures = addSiwcSigningFixtures(supabase)
+
+  const createReq = createApiRequest({
+    body: {
+      apikey: fixtures.apiKey,
+      dapp_user_uuid: fixtures.dappUserUuid,
+      payload: { message: "approve this" },
+      request_type: "message",
+      user_account_id: fixtures.userAccountId,
+    },
+    headers: {
+      "idempotency-key": "signing-approve-1",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/v3/signing/requests/create",
+  })
+  const createRes = createApiResponse()
+  await createSiwcSigningRequestHandler(createReq, createRes)
+  const signingRequestId = String(
+    (createRes.body as DataResponse<Record<string, unknown>>).data
+      .signingRequestId
+  )
+
+  const missingStepUpReq = createApiRequest({
+    body: { signingRequestId },
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+      "x-request-id": "passport_siwc_approve_no_stepup",
+    },
+    url: "/api/siwc/signing/requests/approve",
+  })
+  const missingStepUpRes = createApiResponse()
+  await approveSiwcSigningRequestHandler(missingStepUpReq, missingStepUpRes)
+  assert.equal(missingStepUpRes.statusCode, 403)
+  assert.equal(
+    (missingStepUpRes.body as { error: { code: string } }).error.code,
+    "step_up_required"
+  )
+
+  supabase.setOidcHumanSubject({
+    cubid_user_id: 1234,
+    human_subject_key: "human_subject_1",
+    primary_email: "person@example.com",
+  })
+  supabase.setOidcSession({
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    human_subject_key: "human_subject_1",
+    metadata: {
+      acr: "urn:cubid:acr:passkey",
+      authentication_methods: ["passkey"],
+    },
+    revoked_at: null,
+    session_id: "oidc_session_passkey",
+  })
+
+  const approveReq = createApiRequest({
+    body: { signingRequestId },
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      cookie: "cubid_oidc_session_id=oidc_session_passkey",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/siwc/signing/requests/approve",
+  })
+  const approveRes = createApiResponse()
+  await approveSiwcSigningRequestHandler(approveReq, approveRes)
+
+  assert.equal(approveRes.statusCode, 200)
+  const approved = (approveRes.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(approved.status, "completed")
+  const result = approved.result as { signature: string }
+  assert.equal(
+    ethers.utils.verifyMessage("approve this", result.signature),
+    fixtures.wallet.address
+  )
+  assert.equal(JSON.stringify(approveRes.body).includes(fixtures.wallet.privateKey), false)
+})
+
+test("Passport SIWC signing requests can be listed, rejected, and cancelled", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+  const fixtures = addSiwcSigningFixtures(supabase)
+
+  const createSigning = async (idempotencyKey: string) => {
+    const req = createApiRequest({
+      body: {
+        apikey: fixtures.apiKey,
+        dapp_user_uuid: fixtures.dappUserUuid,
+        payload: { message: idempotencyKey },
+        request_type: "message",
+        user_account_id: fixtures.userAccountId,
+      },
+      headers: {
+        "idempotency-key": idempotencyKey,
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/signing/requests/create",
+    })
+    const res = createApiResponse()
+    await createSiwcSigningRequestHandler(req, res)
+    return String(
+      (res.body as DataResponse<Record<string, unknown>>).data
+        .signingRequestId
+    )
+  }
+
+  const rejectId = await createSigning("signing-reject-1")
+  const cancelId = await createSigning("signing-cancel-1")
+  const listReq = createApiRequest({
+    body: {},
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/siwc/signing/requests/list",
+  })
+  const listRes = createApiResponse()
+  await listPassportSiwcSigningRequestsHandler(listReq, listRes)
+  assert.equal(listRes.statusCode, 200)
+  assert.equal((listRes.body as DataResponse<unknown[]>).data.length, 2)
+
+  const rejectReq = createApiRequest({
+    body: { signingRequestId: rejectId },
+    headers: {
+      authorization: "Bearer firebase-test-token",
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/siwc/signing/requests/reject",
+  })
+  const rejectRes = createApiResponse()
+  await rejectSiwcSigningRequestHandler(rejectReq, rejectRes)
+  assert.equal(rejectRes.statusCode, 200)
+  assert.equal(
+    (rejectRes.body as DataResponse<Record<string, unknown>>).data.status,
+    "rejected"
+  )
+
+  const cancelReq = createApiRequest({
+    body: {
+      apikey: fixtures.apiKey,
+      signing_request_id: cancelId,
+    },
+    headers: {
+      origin: "https://passport.cubid.me",
+    },
+    url: "/api/v3/signing/requests/cancel",
+  })
+  const cancelRes = createApiResponse()
+  await cancelSiwcSigningRequestHandler(cancelReq, cancelRes)
+  assert.equal(cancelRes.statusCode, 200)
+  assert.equal(
+    (cancelRes.body as DataResponse<Record<string, unknown>>).data.status,
+    "cancelled"
+  )
 })
 
 test("Passport actor profile get defaults signed-in users to human", async () => {

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -373,6 +373,21 @@ deliveries use canonical v3 event names:
 - `score_increase` -> `score.increased`
 - `score_decrease` -> `score.decreased`
 
+SIWC custody and signing events are first-class v3 event names:
+
+- `wallet.created`
+- `wallet.signing_request.created`
+- `wallet.policy.denied`
+- `wallet.signing_request.approved`
+- `wallet.signing_request.rejected`
+- `wallet.signing_request.cancelled`
+- `wallet.signing_request.step_up_failed`
+- `wallet.signature.completed`
+- `wallet.signature.failed`
+
+`wallet.transaction.submitted` and `wallet.transaction.failed` remain deferred
+until transaction signing exists.
+
 Delivered payloads use this shape:
 
 ```json
@@ -390,6 +405,14 @@ Delivered payloads use this shape:
 }
 ```
 
+SIWC events use the same envelope. Their `data` object may include account id,
+chain, public address, dapp-user account id, signing request id, request type,
+status, policy version, risk summary, payload hash, and safe result metadata
+such as signature algorithm and public address. SIWC webhook payloads never
+include raw signing payloads, signatures, private keys, encrypted key material,
+Vault wrapping keys, human subject keys, raw Cubid user ids, Firebase uid, or
+webhook signing secrets.
+
 Delivery requests include replay-protection headers:
 
 - `X-Cubid-Event-Id`: stable event id for the dapp, event type, dapp user, and
@@ -406,6 +429,13 @@ include raw Cubid user ids, human subject keys, raw stamp rows, signing secrets,
 or private custody material. Delivery attempts record event id, request body,
 redacted request headers, signature version, status, response code/body, failure
 category, and attempt number in `webhook_event_deliveries`.
+
+SIWC webhook delivery is additionally gated by
+`siwc_signing_policies.webhook_event_subscriptions` and the app's active
+`dapp_webhook_subscriptions` row for the canonical event name. Delivery is
+best-effort for account and signing APIs: failed dapp endpoints are recorded in
+`webhook_event_deliveries`, but they do not roll back generated accounts,
+approvals, rejections, cancellations, or completed signatures.
 
 ## SDK Coordination
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -1,6 +1,6 @@
 # API v3 Developer Platform
 
-Last updated: 2026-05-03
+Last updated: 2026-05-06
 Status: E02.5 canonical contract
 
 ## Purpose
@@ -27,6 +27,14 @@ The current backend-owned API v3 routes are:
   the `private` schema and returning only public account metadata.
 - `POST /api/v3/accounts/list`: dapp-authenticated account metadata listing
   scoped to the target dapp user.
+- `POST /api/v3/signing/requests/create`: dapp-authenticated creation of a
+  Passport-hosted signing request for an app-scoped account.
+- `POST /api/v3/signing/requests/get`: dapp-authenticated signing request
+  status lookup.
+- `POST /api/v3/signing/requests/list`: dapp-authenticated signing request
+  listing for the authenticated app.
+- `POST /api/v3/signing/requests/cancel`: dapp-authenticated cancellation for
+  pending signing requests.
 
 Existing `/api/v2/*` routes remain legacy compatibility surfaces unless a
 future todo explicitly promotes a capability into API v3. New developer-facing
@@ -181,6 +189,115 @@ Success response shape:
 The route returns public metadata only. It must not expose private keys,
 ciphertexts, wrapped keys, internal user ids, or account records not linked to
 the authenticated dapp user.
+
+### `POST /api/v3/signing/requests/create`
+
+Purpose: create a Passport-hosted signing request for a specific app-scoped
+custodial account. The route records the request, evaluates the current Admin
+SIWC policy, and returns a polling-safe state. It does not sign until the
+Passport user approves the request.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "dapp_user_uuid": "00000000-0000-4000-8000-000000000000",
+  "user_account_id": "00000000-0000-4000-8000-000000000001",
+  "request_type": "message",
+  "payload": { "message": "Sign in to Example" },
+  "payload_summary": { "kind": "message", "preview": "Sign in to Example" }
+}
+```
+
+Rules:
+
+- `Idempotency-Key` is required and follows the shared API v3 write-route
+  contract.
+- The dapp user and account link must belong to the authenticated dapp.
+- Admin SIWC policy must be enabled, allow signing, allow the account chain,
+  and allow the requested type.
+- `transaction` requests are recorded as `policy_denied` until SIWC05 risk and
+  transaction-summary controls are implemented.
+- Message signing is supported for EVM, NEAR, Solana, and Sui custody accounts.
+- EVM typed-data signing is supported for `typed_data`.
+- The route stores the raw signing payload in `siwc_signing_requests` for
+  service-role signing, but public responses return only payload hashes and
+  summaries.
+
+Success response shape:
+
+```json
+{
+  "data": {
+    "signingRequestId": "siwc_req_...",
+    "status": "pending_user_approval",
+    "chain": "evm",
+    "requestType": "message",
+    "payloadHash": "64-char sha256 hex",
+    "payloadSummary": { "kind": "message", "preview": "Sign in to Example" },
+    "policyVersion": 2,
+    "requiredAcr": "urn:cubid:acr:passkey",
+    "expiresAt": "2026-05-06T00:10:00.000Z"
+  }
+}
+```
+
+Responses must not include private keys, encrypted custody material, Vault key
+material, raw Cubid user ids, human subject keys, or the raw `payload` field.
+
+### `POST /api/v3/signing/requests/get`
+
+Purpose: let the authenticated dapp poll one signing request that belongs to
+that dapp.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "signing_request_id": "siwc_req_..."
+}
+```
+
+Completed message or typed-data requests include `result` with a signature,
+algorithm, public address, and result type. Failed, rejected, cancelled,
+expired, and policy-denied requests include status plus redacted error metadata
+where available.
+
+### `POST /api/v3/signing/requests/list`
+
+Purpose: list recent signing requests for the authenticated dapp, optionally
+filtered to one dapp user.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "dapp_user_uuid": "00000000-0000-4000-8000-000000000000",
+  "limit": 25
+}
+```
+
+The response is `{ "data": [...] }` using the same redacted signing request
+summary shape as `get`.
+
+### `POST /api/v3/signing/requests/cancel`
+
+Purpose: cancel a pending signing request before the Passport user approves it.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "signing_request_id": "siwc_req_..."
+}
+```
+
+Only `pending_user_approval` requests can be cancelled. Terminal requests are
+idempotently returned in their terminal state.
 
 ## Error Contract
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -217,8 +217,9 @@ Rules:
 - The dapp user and account link must belong to the authenticated dapp.
 - Admin SIWC policy must be enabled, allow signing, allow the account chain,
   and allow the requested type.
-- `transaction` requests are recorded as `policy_denied` until SIWC05 risk and
-  transaction-summary controls are implemented.
+- `transaction` requests are still recorded as `policy_denied`; SIWC05 adds
+  transaction risk summaries and stricter policy evidence, but not transaction
+  signatures.
 - Message signing is supported for EVM, NEAR, Solana, and Sui custody accounts.
 - EVM typed-data signing is supported for `typed_data`.
 - The route stores the raw signing payload in `siwc_signing_requests` for
@@ -236,6 +237,10 @@ Success response shape:
     "requestType": "message",
     "payloadHash": "64-char sha256 hex",
     "payloadSummary": { "kind": "message", "preview": "Sign in to Example" },
+    "riskLevel": "low",
+    "riskReasons": [],
+    "policyDecision": "allowed",
+    "stepUpRequired": true,
     "policyVersion": 2,
     "requiredAcr": "urn:cubid:acr:passkey",
     "expiresAt": "2026-05-06T00:10:00.000Z"
@@ -245,6 +250,13 @@ Success response shape:
 
 Responses must not include private keys, encrypted custody material, Vault key
 material, raw Cubid user ids, human subject keys, or the raw `payload` field.
+
+Transaction responses may include `riskLevel`, `riskReasons`,
+`transactionOperationType`, `transactionRecipient`,
+`transactionContractAddress`, and `transactionDeclaredValueUsd`. These are
+non-secret summaries for SDKs and Passport UI. They are not a transaction
+simulation result, and they do not mean Cubid will sign the transaction in this
+slice.
 
 ### `POST /api/v3/signing/requests/get`
 

--- a/docs/engineering/siwc-custody-signing-runbook.md
+++ b/docs/engineering/siwc-custody-signing-runbook.md
@@ -1,0 +1,346 @@
+# SIWC Custody And Signing Production Runbook
+
+Last updated: 2026-05-06
+Status: Active SIWC08 runbook; transaction signing remains disabled
+
+## Purpose
+
+This runbook defines the operating contract for Sign In With Cubid custody and
+signing. It covers generated app-scoped accounts, Supabase Vault-backed private
+key custody, signing request triage, webhook delivery, incident response, and
+launch blockers.
+
+Use this with:
+
+- `docs/engineering/siwc-v3-signing-architecture.md`
+- `docs/engineering/api-v3-developer-platform.md`
+- `docs/engineering/api-security-operations.md`
+- `docs/engineering/encrypted-database-secrets.md`
+
+## Current Launch Boundary
+
+Current SIWC production boundary:
+
+- app-scoped account generation and listing are available through API v3
+- EVM, NEAR, Solana, and Sui private keys are envelope-encrypted in
+  `private.private_keys`
+- dapps can create message and typed-data signing requests when Admin policy
+  allows them
+- Passport owns user-facing request visibility, approval, rejection, and
+  passkey step-up
+- webhook delivery is best-effort and signed through the API v3 webhook
+  contract
+
+Explicitly not enabled:
+
+- transaction signing
+- transaction submission or broadcast
+- paymasters or gas sponsorship
+- session keys
+- smart-account deployment
+- private-key export or reveal
+
+## Custody Boundaries
+
+Safe to expose to dapps:
+
+- app-scoped account id
+- dapp user UUID for the authenticated dapp
+- chain key
+- public address
+- account label and status
+- signing request status, payload hash, risk summary, policy version, and safe
+  signature result metadata
+
+Safe to expose to Passport users:
+
+- app name and dapp id
+- public app-scoped account metadata
+- signing request summary, request type, chain, account, policy status, risk
+  summary, and approval state
+- whether signing is enabled by Admin policy
+
+Safe to expose to Admin operators:
+
+- SIWC policy configuration
+- dapp/account/signing status
+- public addresses and request summaries
+- audit/security events and webhook delivery state
+
+Never expose:
+
+- raw private keys
+- decrypted key material
+- ciphertext, wrapped data keys, IVs, authentication tags, or Vault material
+- raw signing payloads unless a future explicit operator-only support tool is
+  designed and approved
+- human subject keys, raw Cubid user ids, Firebase UIDs, service-role secrets,
+  or webhook signing secrets
+
+## Required Environment And Vault Inputs
+
+Passport runtime env:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- Firebase Admin credentials for user approval routes
+- `PASSPORT_CORS_ALLOWED_ORIGINS`
+- `PASSPORT_INTERNAL_API_TOKEN`
+
+Supabase Vault secrets:
+
+- `passport_blockchain_private_key_wrapping_key_v1`
+- `passport_webhook_signing_secret_wrapping_key_v1`
+
+OIDC/passkey dependency:
+
+- Login with Cubid OIDC sessions must be available because passkey step-up uses
+  the `cubid_oidc_session_id` cookie and `oidc_sessions` metadata.
+
+Readiness check:
+
+- missing Vault wrapping keys are launch blockers for account generation,
+  signing, and webhook delivery
+- missing Firebase Admin credentials block Passport approval routes
+- missing Supabase service-role config blocks all SIWC server-side custody
+  paths
+
+## Database And Migration Readiness
+
+Required tables and schemas:
+
+- `private.private_keys`
+- `public.ref_chains`
+- `public.user_accounts`
+- `public.dapp_user_accounts`
+- `public.siwc_signing_policies`
+- `public.siwc_signing_requests`
+- `public.dapp_webhook_subscriptions`
+- `public.webhook_events`
+- `public.webhook_event_deliveries`
+- `public.api_security_events`
+
+Migration rollout order:
+
+1. Apply custody schema and Vault helper migrations.
+2. Provision Vault wrapping keys.
+3. Apply SIWC policy and signing request migrations.
+4. Seed SIWC webhook event names.
+5. Configure one internal test dapp policy with sandbox mode enabled.
+6. Run account-generation and signing smoke tests before enabling external
+   dapps.
+
+Rollback posture:
+
+- do not drop custody tables during rollback
+- suspend affected dapp policies instead of deleting records
+- preserve encrypted private-key rows for forensic review and user support
+- disable webhook subscriptions if a delivery bug creates retry storms
+
+## Admin Policy Operations
+
+Default policy posture is fail-closed:
+
+- missing policy row means custody disabled and signing disabled
+- `status = disabled` or `suspended` blocks signing request creation
+- `signing_enabled = false` blocks all signing request types
+- transaction requests remain `policy_denied` even when `transaction` appears
+  in `allowed_request_types`
+
+Before enabling a dapp:
+
+1. Confirm the dapp owner and expected use case.
+2. Keep `sandbox_mode = true` until staging smoke tests pass.
+3. Enable only required chains.
+4. Enable only required request types.
+5. Keep `required_acr = urn:cubid:acr:passkey` for signing.
+6. Configure webhook event subscriptions only for events the dapp will consume.
+7. Set transaction value and contract allowlist fields even though transaction
+   signing remains disabled, so the future policy evidence is explicit.
+
+Emergency app suspension:
+
+1. Set the SIWC policy `status` to `suspended`.
+2. Suspend or rotate the dapp API key if credential abuse is suspected.
+3. Disable relevant webhook subscriptions.
+4. Search `api_security_events`, `siwc_signing_requests`, and webhook delivery
+   rows for the dapp id.
+5. Notify affected operators before reactivation.
+
+## Signing Request Triage
+
+Primary lookup fields:
+
+- `X-Request-Id`
+- signing request id
+- dapp id
+- dapp user UUID
+- user account id
+- chain key
+- payload hash
+
+Common states:
+
+- `pending_user_approval`: waiting for Passport approval
+- `policy_denied`: blocked by Admin policy or transaction-denial rules
+- `approved`: user approval recorded
+- `completed`: message or typed-data signature completed
+- `failed`: server-side signing failed
+- `rejected`: user rejected
+- `cancelled`: dapp cancelled
+
+Triage steps:
+
+1. Capture the `X-Request-Id` from the dapp, Passport UI, or webhook payload.
+2. Inspect `siwc_signing_requests` for status, policy version, risk fields, and
+   expiry.
+3. Inspect `api_security_events` for matching request id or signing request id.
+4. Confirm the current `siwc_signing_policies` row still allows the request.
+5. Confirm the user account and dapp-user link are active.
+6. For approval failures, inspect OIDC session metadata for passkey ACR and
+   freshness without exposing human subject keys.
+
+Policy-denied transaction requests are expected in the current launch boundary.
+They are not incidents unless the dapp expected message or typed-data signing.
+
+## Webhook Operations
+
+SIWC webhook delivery is best-effort. API state changes do not roll back when a
+dapp endpoint is unavailable.
+
+Supported SIWC event names:
+
+- `wallet.created`
+- `wallet.signing_request.created`
+- `wallet.policy.denied`
+- `wallet.signing_request.approved`
+- `wallet.signing_request.rejected`
+- `wallet.signing_request.cancelled`
+- `wallet.signing_request.step_up_failed`
+- `wallet.signature.completed`
+- `wallet.signature.failed`
+
+Delivery requires both:
+
+- an active `dapp_webhook_subscriptions` row for the event
+- the event in `siwc_signing_policies.webhook_event_subscriptions`
+
+Triage:
+
+1. Inspect `webhook_events` by event id, dapp id, or signing request id in the
+   payload data.
+2. Inspect `webhook_event_deliveries` for HTTP status, attempt count, and error
+   metadata.
+3. Verify the subscription has an encrypted signing secret and active status.
+4. Confirm the dapp verifies the API v3 HMAC signature over
+   `eventId.timestamp.rawBody`.
+5. Disable the subscription if it is causing sustained retry noise.
+
+Webhook replay:
+
+- replay only from stored `webhook_events` and delivery metadata
+- never reconstruct payloads from private-key rows or raw signing payloads
+- preserve the original event id when replaying unless a future explicit replay
+  API documents otherwise
+
+## Smoke Tests
+
+Run these in staging before any production enablement:
+
+1. Generate an EVM account for an internal test dapp.
+2. Confirm `/api/v3/accounts/list` returns only public account metadata.
+3. Confirm the Passport Profile app-scoped account card displays the account.
+4. Enable sandbox SIWC policy for `message` signing only.
+5. Create a message signing request with an `Idempotency-Key`.
+6. Approve through Passport with a fresh passkey OIDC session.
+7. Confirm the dapp sees `completed` status and no private/ciphertext fields.
+8. Confirm `wallet.signing_request.created`,
+   `wallet.signing_request.approved`, and `wallet.signature.completed`
+   webhooks are recorded when subscribed.
+9. Create a transaction request and confirm it is `policy_denied`.
+10. Confirm stale or missing passkey step-up records
+    `wallet.signing_request.step_up_failed` when subscribed.
+
+## Monitoring And Abuse Signals
+
+Monitor:
+
+- signing request creation volume by dapp
+- policy-denied and step-up-failed counts
+- failed signing attempts
+- repeated idempotency conflicts
+- webhook delivery failure rates
+- account generation spikes
+- dapp API key failures
+- passkey freshness failures
+
+Escalate when:
+
+- a dapp shows unusual account-generation or signing-request volume
+- signing failures cluster by chain or dapp
+- webhook retry storms affect delivery infrastructure
+- any log or response appears to contain private-key or encrypted custody
+  material
+- a user reports unfamiliar app-scoped accounts or signing requests
+
+## Incident Response
+
+Private-key or custody material exposure:
+
+1. Suspend affected dapp SIWC policies.
+2. Disable affected dapp API keys and webhook subscriptions.
+3. Preserve database rows and request ids for investigation.
+4. Rotate affected Vault wrapping keys only through a planned re-encryption or
+   quarantine procedure; do not blindly rotate without understanding whether
+   stored rows can still be decrypted.
+5. Notify affected users and dapps according to the incident policy.
+
+Suspicious signing request:
+
+1. Suspend the dapp policy.
+2. Search signing requests by dapp id, account id, and payload hash.
+3. Verify whether any request reached `completed`.
+4. Review passkey step-up and approval events.
+5. Keep transaction signing disabled unless a future launch review says
+   otherwise.
+
+Webhook compromise:
+
+1. Rotate the affected webhook subscription secret.
+2. Disable delivery until the dapp confirms receiver integrity.
+3. Replay only safe event envelopes if needed.
+4. Audit recent failed deliveries and signature verification complaints.
+
+## User Support Guidance
+
+Users can be told:
+
+- app-scoped accounts are generated for a specific app
+- public addresses and labels are visible in Profile
+- accounts are not universal wallets by default
+- Cubid does not expose private keys or encrypted custody material
+- signing approval happens in Passport and may require a fresh passkey
+
+Users should not be told:
+
+- that app-scoped accounts are portable wallets
+- that private keys can be exported
+- that transaction signing or gas sponsorship is live
+- that all future apps can correlate or reuse the same account
+
+## Launch Blockers
+
+Do not enable broad SIWC signing if any of these are true:
+
+- required Vault wrapping keys are missing
+- service-role or Firebase Admin configuration is missing
+- Admin SIWC policy UI cannot suspend a dapp
+- Passport approval cannot enforce fresh passkey ACR
+- signing responses expose raw payloads, signatures in webhook payloads,
+  private keys, ciphertext, or internal user identifiers
+- webhook signing secrets are not encrypted
+- monitoring cannot find request ids across API responses, security events,
+  signing requests, and webhook deliveries
+- transaction signing is enabled before chain-specific summaries and risk
+  controls are ready
+- no operator has completed the staging smoke test

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -267,12 +267,33 @@ separate delivery system. Candidate events:
 
 Payloads must be signed, replay-safe, disclosure-filtered, and app-scoped.
 
+## Passport Account Visibility
+
+SIWC03 adds user-facing visibility for generated app-scoped custody accounts.
+Passport exposes `POST /api/siwc/accounts/list` as a Firebase-authenticated user
+route and displays the result in Profile.
+
+The route returns public account metadata only:
+
+- app name and dapp id
+- dapp user UUID and dapp-user-account link id
+- account id, chain, public address, label, account status, custody status, and
+  timestamps
+- current SIWC policy visibility fields: policy status/version, custody enabled,
+  signing enabled, sandbox mode, and required ACR
+
+The route must not expose private keys, ciphertext, wrapped data keys, IVs,
+auth tags, Vault material, human subject keys, raw internal user ids, or
+service-role-only fields. Missing SIWC policy rows are shown fail-closed:
+signing disabled, custody disabled, sandbox mode enabled, and policy version
+`0`. This is visibility only; users cannot sign, export, transfer, revoke, or
+share accounts through SIWC03.
+
 ## Deferred
 
 Deferred until later SIWC slices:
 
 - Admin policy UI and persistence
-- Passport user-facing account visibility
 - implementation of signing request tables and routes
 - transaction simulation and risk scoring
 - smart accounts, session keys, paymasters, and gas sponsorship

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -1,7 +1,7 @@
 # SIWC V3 Signing And Transaction Authorization Architecture
 
 Last updated: 2026-05-06
-Status: SIWC04 implemented lifecycle with transaction-risk controls deferred
+Status: SIWC05 implemented transaction risk controls; transaction signing remains disabled
 
 ## Purpose
 
@@ -314,20 +314,36 @@ type before the request can enter `pending_user_approval`.
 
 Passport approval re-checks policy immediately before signing. If policy has
 changed, the request moves to `policy_denied` instead of signing. If
-`required_acr = urn:cubid:acr:passkey`, approval requires a current
+`required_acr = urn:cubid:acr:passkey`, approval requires a fresh
 `cubid_oidc_session_id` cookie whose OIDC session was authenticated with
-passkey and whose human subject belongs to the signed-in Passport user.
+passkey, whose human subject belongs to the signed-in Passport user, and whose
+passkey assurance is no older than five minutes. Missing, stale, revoked, or
+cross-user passkey sessions are audited as `signing_request.step_up_failed`.
 
 SIWC04 supports message signing for EVM, NEAR, Solana, and Sui generated
-custody accounts, plus EVM typed-data signing. Transaction requests are
-recorded as `policy_denied` with `transaction_signing_deferred` until SIWC05
-adds transaction risk controls and human-readable summaries.
+custody accounts, plus EVM typed-data signing. SIWC05 adds transaction risk
+controls and human-readable summaries, but it still records transaction
+requests as `policy_denied`. Transaction signing remains intentionally
+disabled until a later explicit enablement slice.
+
+Transaction risk controls are conservative:
+
+- EVM transaction payloads are summarized as native transfers or contract calls.
+- Recipient or contract addresses are normalized when possible.
+- Declared USD value is accepted only when supplied by the caller.
+- Admin `transaction_value_limit_usd` and `contract_allowlist` are enforced in
+  the policy decision.
+- NEAR, Solana, and Sui transaction requests fail closed with
+  `transaction_chain_risk_unsupported` until chain-specific summaries exist.
+- All transaction requests include `riskLevel`, `riskReasons`,
+  `transactionOperationType`, recipient/contract fields, declared value, policy
+  decision, and step-up requirement in public response summaries.
 
 Public dapp and Passport responses return request status, payload hash,
-payload summary, policy version, required ACR, expiry, and signing result when
-completed. They never return private keys, decrypted material, ciphertext,
-wrapped keys, IVs, auth tags, human subject keys, raw Cubid user ids, or the
-raw signing `payload` field.
+payload summary, risk summary, policy version, required ACR, expiry, and
+signing result when completed. They never return private keys, decrypted
+material, ciphertext, wrapped keys, IVs, auth tags, human subject keys, raw
+Cubid user ids, or the raw signing `payload` field.
 
 ## Deferred
 

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -1,7 +1,7 @@
 # SIWC V3 Signing And Transaction Authorization Architecture
 
 Last updated: 2026-05-06
-Status: SIWC05 implemented transaction risk controls; transaction signing remains disabled
+Status: SIWC07 completed smart-account, session-key, and paymaster roadmap evaluation; transaction signing remains disabled
 
 ## Purpose
 
@@ -366,12 +366,70 @@ signing result when completed. They never return private keys, decrypted
 material, ciphertext, wrapped keys, IVs, auth tags, human subject keys, raw
 Cubid user ids, or the raw signing `payload` field.
 
+## SIWC07 Smart Accounts, Session Keys, And Paymasters
+
+SIWC07 keeps the current server-side custodial signing model as the near-term
+default. Generated app-scoped accounts remain the base account mode because
+they already match Cubid's privacy posture: every dapp gets its own account
+linkage, approvals happen through Passport, and custody secrets stay behind the
+service-role and Vault boundary.
+
+Smart accounts should be added later as an optional EVM-first custody mode, not
+as a replacement for generated app-scoped accounts. They are useful when an app
+needs programmability, recovery rules, spending limits, batched execution,
+sponsored gas, or account abstraction features that cannot be safely expressed
+with an ordinary generated account. They also add deployment, chain support,
+gas, bundler, paymaster, monitoring, and support complexity, so they should be
+explicitly policy-gated and capability-advertised rather than assumed.
+
+Session keys should be treated as scoped, revocable child capabilities of an
+app-scoped account. A session key must never become a cross-app portable
+identity or wallet credential. A future session-key design should bind each key
+to a dapp, dapp user, account, chain, request type, expiry, policy version, and
+optional spending or contract limits. Creation should require Passport approval
+and passkey step-up, and revocation should be visible to both Admin and the
+user. Session keys should wait until the current signing policy, approval UX,
+webhooks, and production runbook are stable.
+
+Paymasters and gas sponsorship should be treated as a separate app policy and
+billing product. They should remain disabled until transaction signing has a
+safe enablement plan, transaction summaries are human-readable, abuse controls
+are live, and Admin can configure budgets, rate limits, allowed contracts,
+allowed chains, and emergency suspension. Paymaster support should emit
+dedicated audit and webhook events once it exists, but `wallet.transaction.*`
+events remain deferred until transaction signing and submission are available.
+
+Recommended sequence:
+
+1. Finish SIWC08 production readiness for the current custodial signing model.
+2. Add a future EVM smart-account design todo that chooses provider, account
+   standard, deployment timing, recovery model, and capability discovery shape.
+3. Add scoped session keys only after smart-account or transaction-signing
+   semantics define what the delegated key may actually do.
+4. Add paymasters last, after transaction risk, monitoring, billing limits, and
+   emergency app suspension are operational.
+
+Not-yet criteria:
+
+- Do not replace generated app-scoped accounts with smart accounts by default.
+- Do not expose session keys until they have expiry, scope, revocation,
+  approval, and audit semantics.
+- Do not enable paymasters until transaction signing and abuse controls are
+  production-ready.
+- Do not assume Solana, NEAR, or Sui have the same smart-account abstractions as
+  EVM; evaluate chain-native equivalents only after chain-specific transaction
+  signing is safe and user-readable.
+- Do not add SDK APIs that imply all accounts are smart accounts; SDKs should
+  use capability discovery when this roadmap becomes implementation work.
+
 ## Deferred
 
 Deferred until later SIWC slices:
 
 - transaction simulation and risk scoring
-- smart accounts, session keys, paymasters, and gas sponsorship
+- EVM-first smart-account design and optional custody mode implementation
+- scoped session keys with expiry, limits, revocation, and passkey approval
+- paymasters and gas sponsorship after transaction signing is safe
 - public SDK implementation in `Cubid-Me/cubid-sdk`
 
 ## Acceptance Criteria For SIWC01

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -1,7 +1,7 @@
 # SIWC V3 Signing And Transaction Authorization Architecture
 
 Last updated: 2026-05-06
-Status: SIWC07 completed smart-account, session-key, and paymaster roadmap evaluation; transaction signing remains disabled
+Status: SIWC08 production runbook added; transaction signing remains disabled
 
 ## Purpose
 

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -182,8 +182,31 @@ should guide them to create one before approval where policy allows.
 
 ## Policy Evaluation
 
-SIWC02 and SIWC05 should define concrete policy controls, but the architecture
-expects at least:
+SIWC02 adds the first Admin-owned policy contract in
+`public.siwc_signing_policies`. Signing remains unavailable until SIWC04, but
+every future signing request must read and enforce this table before user
+approval and again immediately before signing.
+
+The policy table stores one current policy per dapp:
+
+- `status`: `disabled`, `enabled`, or `suspended`
+- `custody_enabled`: whether the app may request app-scoped account custody
+- `signing_enabled`: whether the app may request message or transaction signing
+- `sandbox_mode`: whether the policy is still treated as non-production
+- `allowed_chains`: `evm`, `near`, `solana`, and/or `sui`
+- `allowed_request_types`: `message`, `typed_data`, and/or `transaction`
+- `required_acr`: `urn:cubid:acr:passkey` whenever signing is enabled
+- `transaction_value_limit_usd`, `contract_allowlist`,
+  `webhook_event_subscriptions`, and `metadata`
+
+Default behavior is fail-closed: missing policy rows mean custody disabled,
+signing disabled, sandbox enabled, no allowed chains, and no allowed request
+types. Admin APIs expose only non-secret policy configuration through
+`POST /api/admin/siwc/policies/list` and
+`POST /api/admin/siwc/policies/upsert`.
+
+SIWC05 should add deeper transaction policy and risk controls, but the
+architecture already expects:
 
 - dapp signing enabled/disabled
 - allowed chains

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -254,18 +254,39 @@ unredacted transaction payloads.
 
 ## Webhooks
 
-SIWC signing events should extend the API v3 webhook contract rather than add a
-separate delivery system. Candidate events:
+SIWC signing events extend the API v3 webhook contract rather than adding a
+separate delivery system. SIWC06 seeds and emits these canonical event names:
 
+- `wallet.created`
 - `wallet.signing_request.created`
-- `wallet.signing_request.policy_denied`
+- `wallet.policy.denied`
 - `wallet.signing_request.approved`
 - `wallet.signing_request.rejected`
+- `wallet.signing_request.cancelled`
+- `wallet.signing_request.step_up_failed`
 - `wallet.signature.completed`
-- `wallet.transaction.submitted`
-- `wallet.transaction.failed`
+- `wallet.signature.failed`
 
-Payloads must be signed, replay-safe, disclosure-filtered, and app-scoped.
+Each event uses the API v3 webhook envelope, HMAC signature headers, replay
+event id, delivery attempt records, and encrypted per-subscription signing
+secret resolution. Delivery requires both an active `dapp_webhook_subscriptions`
+row for the canonical event and the event name in
+`siwc_signing_policies.webhook_event_subscriptions`.
+
+SIWC webhook payloads are app-scoped and custody-safe. They may include account
+id, dapp user uuid, chain, public address, signing request id, request type,
+status, policy version, risk summary, payload hash, and safe signature result
+metadata such as algorithm and public address. They must not include raw
+signing payloads, signatures, private keys, encrypted key material, Vault
+material, human subject keys, raw Cubid user ids, Firebase uid, or webhook
+signing secrets.
+
+Webhook delivery is best-effort for SIWC lifecycle APIs. A dapp endpoint outage
+records a failed delivery attempt but does not roll back account generation,
+approval, rejection, cancellation, or signature completion.
+
+`wallet.transaction.submitted` and `wallet.transaction.failed` remain deferred
+until transaction signing and transaction submission exist.
 
 ## Passport Account Visibility
 

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -1,7 +1,7 @@
 # SIWC V3 Signing And Transaction Authorization Architecture
 
-Last updated: 2026-05-05
-Status: SIWC01 accepted target state
+Last updated: 2026-05-06
+Status: SIWC04 implemented lifecycle with transaction-risk controls deferred
 
 ## Purpose
 
@@ -289,12 +289,50 @@ signing disabled, custody disabled, sandbox mode enabled, and policy version
 `0`. This is visibility only; users cannot sign, export, transfer, revoke, or
 share accounts through SIWC03.
 
+## Signing Request Lifecycle
+
+SIWC04 implements the first backend signing request lifecycle:
+
+- dapps create signing requests with
+  `POST /api/v3/signing/requests/create`
+- dapps poll, list, or cancel with
+  `POST /api/v3/signing/requests/get`,
+  `POST /api/v3/signing/requests/list`, and
+  `POST /api/v3/signing/requests/cancel`
+- signed-in Passport users inspect requests with
+  `POST /api/siwc/signing/requests/list`
+- signed-in Passport users approve or reject with
+  `POST /api/siwc/signing/requests/approve` and
+  `POST /api/siwc/signing/requests/reject`
+
+Request creation requires `Idempotency-Key` and is scoped to the authenticated
+dapp actor. The route checks that the `dapp_user_uuid`, `user_account_id`, and
+`dapp_user_accounts` link all belong to the authenticated dapp. It then
+evaluates the current `public.siwc_signing_policies` row. Missing or disabled
+policy rows fail closed. Enabled policy rows must allow the chain and request
+type before the request can enter `pending_user_approval`.
+
+Passport approval re-checks policy immediately before signing. If policy has
+changed, the request moves to `policy_denied` instead of signing. If
+`required_acr = urn:cubid:acr:passkey`, approval requires a current
+`cubid_oidc_session_id` cookie whose OIDC session was authenticated with
+passkey and whose human subject belongs to the signed-in Passport user.
+
+SIWC04 supports message signing for EVM, NEAR, Solana, and Sui generated
+custody accounts, plus EVM typed-data signing. Transaction requests are
+recorded as `policy_denied` with `transaction_signing_deferred` until SIWC05
+adds transaction risk controls and human-readable summaries.
+
+Public dapp and Passport responses return request status, payload hash,
+payload summary, policy version, required ACR, expiry, and signing result when
+completed. They never return private keys, decrypted material, ciphertext,
+wrapped keys, IVs, auth tags, human subject keys, raw Cubid user ids, or the
+raw signing `payload` field.
+
 ## Deferred
 
 Deferred until later SIWC slices:
 
-- Admin policy UI and persistence
-- implementation of signing request tables and routes
 - transaction simulation and risk scoring
 - smart accounts, session keys, paymasters, and gas sponsorship
 - public SDK implementation in `Cubid-Me/cubid-sdk`

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -1,0 +1,268 @@
+# SIWC V3 Signing And Transaction Authorization Architecture
+
+Last updated: 2026-05-05
+Status: SIWC01 accepted target state
+
+## Purpose
+
+Sign In With Cubid already has the identity, consent, passkey, and app-scoped
+custody foundations needed for a wallet-adjacent product. The missing product
+boundary is explicit signing: a dapp can create and list app-scoped custodial
+accounts, but it cannot yet ask the human to approve a message signature or
+transaction.
+
+This document defines the first SIWC signing architecture for API v3. It is a
+design contract only; it does not add signing endpoints, Admin controls, or SDK
+code.
+
+## Locked Direction
+
+The first SIWC signing implementation should be a phased server-side custodial
+signing system backed by the existing Supabase Vault envelope-encrypted private
+keys in `private.private_keys`.
+
+This is the right first step because:
+
+- API v3 already creates app-scoped accounts and stores private key material
+  under the service-role-only custody boundary.
+- Passport already has passkey ACR semantics that can authorize human intent.
+- Admin already owns policy/control-plane surfaces and can be extended before
+  broad signing is enabled.
+- Smart accounts, session keys, paymasters, and external signers add useful
+  capabilities later, but they should not be prerequisites for a minimal secure
+  signing loop.
+
+The system must preserve a hard separation between authentication credentials
+and blockchain signing keys. Passkeys authenticate and authorize the human's
+intent; chain private keys, smart-account signer keys, or future external
+signers produce the blockchain signature.
+
+## Current Foundation
+
+Already implemented foundations:
+
+- OIDC Login with Cubid, pairwise subjects, passkey ACR, revoke/logout, JWKS,
+  `/token`, and `/userinfo`.
+- Passport passkey UX, device lifecycle, Profile visibility, and recovery
+  framing.
+- App-scoped identity and selective-disclosure grants for Allow Page, OIDC,
+  SDK-facing routes, and webhooks.
+- API v3 account generation/listing for EVM, NEAR, Solana, and Sui.
+- Supabase Vault-backed envelope encryption for retrievable custody secrets.
+
+Important gap:
+
+- Generated accounts cannot sign messages or transactions yet.
+
+## Scope For The First Signing Product
+
+The first SIWC signing product should support:
+
+- dapp-authenticated creation of signing requests through API v3
+- Passport-hosted human review, approval, and rejection
+- passkey step-up for approval when policy requires it
+- server-side signing after approval
+- status polling by the requesting dapp
+- disclosure-safe webhook events for lifecycle changes
+- audit/security events for every state transition
+
+The first implementation should prioritize typed message signing before broad
+transaction submission unless SIWC02/SIWC05 policy work proves a transaction
+class is safe enough for launch. Transaction signing is allowed in the target
+state, but production enablement should be gated by policy evaluation, risk
+display, and passkey step-up.
+
+## Chains
+
+Initial signing eligibility should follow existing v3 custody support:
+
+- `evm`: typed-data and personal-message signing first; transaction signing
+  only after policy/risk controls are present.
+- `solana`: message signing first; transaction signing only after readable
+  transaction summaries and policy controls exist.
+- `near`: transaction/action signing can be considered after action summaries
+  are human-readable and policy-controlled.
+- `sui`: message or transaction signing only after Sui-specific transaction
+  summaries and policy checks are defined.
+
+Each chain package or helper should remain isolated. Do not introduce generic
+cross-chain assumptions that hide chain-specific risk.
+
+## Proposed API V3 Surfaces
+
+Future signing routes should use the existing Passport API v3 baseline:
+structured errors, `X-Request-Id`, dapp API-key auth, ownership checks,
+idempotency on writes, rate limits, and no secret exposure.
+
+Candidate routes:
+
+- `POST /api/v3/signing/requests/create`
+- `POST /api/v3/signing/requests/get`
+- `POST /api/v3/signing/requests/cancel`
+- `POST /api/v3/signing/requests/list`
+
+Passport-hosted approval should use authenticated human routes, not dapp
+credentials:
+
+- `POST /api/siwc/signing/requests/list`
+- `POST /api/siwc/signing/requests/approve`
+- `POST /api/siwc/signing/requests/reject`
+
+Route names can change during implementation, but the ownership boundary should
+not: dapps create and observe requests; humans approve or reject in Passport;
+server-side custody code signs only after policy and approval succeed.
+
+## Request Model
+
+A signing request should include:
+
+- `request_id`: server-generated stable id
+- `dapp_id`: authenticated dapp
+- `dapp_user_uuid`: target app-scoped user
+- `user_account_id`: app-visible account id
+- `chain_key`: `evm`, `near`, `solana`, or `sui`
+- `request_type`: `message`, `typed_data`, `transaction`, or chain-specific
+  subtype
+- `payload_hash`: canonical hash of the signing payload
+- `payload_summary`: redacted human-readable summary for Passport/Admin
+- `policy_version`: Admin signing policy version evaluated at creation
+- `required_acr`: optional `urn:cubid:acr:passkey`
+- `idempotency_key`: write idempotency key for dapp retries
+- `expires_at`: short approval window
+- `status`: state-machine value
+
+The raw signing payload may be stored only if needed for signing and only in a
+server-side table with clear retention rules. Public/Admin/UI responses should
+prefer summaries and hashes over raw payloads whenever possible.
+
+## State Machine
+
+Initial signing request states:
+
+- `pending_policy`: created, awaiting policy evaluation
+- `policy_denied`: rejected by policy before user approval
+- `pending_user_approval`: policy accepted, waiting for Passport approval
+- `approved`: human approved with sufficient auth context
+- `rejected`: human rejected
+- `expired`: approval window closed before completion
+- `signing`: server is performing custody signing
+- `completed`: signature or transaction hash is available
+- `failed`: server-side signing or submission failed
+- `cancelled`: dapp cancelled before completion
+
+Allowed transitions should be explicit. Terminal states should be immutable
+except for metadata fields such as delivery attempts or support notes.
+
+## Authorization Boundary
+
+Dapp API keys authorize only app-side request creation and status reads for
+their own dapp users. They do not authorize signing.
+
+Passport user auth authorizes only the human approval/rejection action. Approval
+must confirm that:
+
+- the user owns or controls the target `dapp_user_uuid` relationship
+- the account is linked to that dapp user
+- the request belongs to the same dapp/account/chain
+- the request has not expired or reached a terminal state
+- the current auth context satisfies required ACR
+
+Custody signing code runs server-side with service-role access and may decrypt
+private-key material only after policy and approval checks pass.
+
+## Passkey Step-Up
+
+Passkey ACR is the default high-risk approval mechanism. Signing policy may set
+`required_acr = urn:cubid:acr:passkey` for all signing, or only for selected
+chains, transaction types, amounts, contracts, or risk tiers.
+
+OTP and OwnID flows remain recovery/bootstrap paths but should not satisfy a
+passkey-required signing request. If the user lacks an active passkey, Passport
+should guide them to create one before approval where policy allows.
+
+## Policy Evaluation
+
+SIWC02 and SIWC05 should define concrete policy controls, but the architecture
+expects at least:
+
+- dapp signing enabled/disabled
+- allowed chains
+- allowed request types
+- optional contract or recipient allowlists
+- amount or value thresholds where chain data supports them
+- required ACR
+- sandbox versus production behavior
+- webhook subscriptions for signing lifecycle events
+
+Policy must be evaluated before user approval and again immediately before
+signing to prevent stale approvals from bypassing policy changes.
+
+## Idempotency, Replay, And Expiry
+
+Dapp-created signing requests should require `Idempotency-Key`, scoped to the
+authenticated dapp and route. Replaying the same key with the same canonical
+request should return the existing request. Reusing the key with a different
+payload should return `409 idempotency_conflict`.
+
+Approval actions should be single-use state transitions. Replaying approval for
+an already terminal request should return the terminal state, not sign twice.
+Signing payloads should include canonical hashes so an operator can verify that
+the approved payload and signed payload match.
+
+## Audit And Observability
+
+Record security or audit events for:
+
+- `signing_request.created`
+- `signing_request.policy_denied`
+- `signing_request.approved`
+- `signing_request.rejected`
+- `signing_request.expired`
+- `signing_request.signing_started`
+- `signing_request.completed`
+- `signing_request.failed`
+- `signing_request.cancelled`
+- `signing_request.step_up_failed`
+
+Events should include request id, dapp id, chain, account id, policy version,
+actor type, request id header, and outcome. They must not include private keys,
+Vault material, ciphertext, raw human subject keys, raw Cubid user ids, or
+unredacted transaction payloads.
+
+## Webhooks
+
+SIWC signing events should extend the API v3 webhook contract rather than add a
+separate delivery system. Candidate events:
+
+- `wallet.signing_request.created`
+- `wallet.signing_request.policy_denied`
+- `wallet.signing_request.approved`
+- `wallet.signing_request.rejected`
+- `wallet.signature.completed`
+- `wallet.transaction.submitted`
+- `wallet.transaction.failed`
+
+Payloads must be signed, replay-safe, disclosure-filtered, and app-scoped.
+
+## Deferred
+
+Deferred until later SIWC slices:
+
+- Admin policy UI and persistence
+- Passport user-facing account visibility
+- implementation of signing request tables and routes
+- transaction simulation and risk scoring
+- smart accounts, session keys, paymasters, and gas sponsorship
+- public SDK implementation in `Cubid-Me/cubid-sdk`
+
+## Acceptance Criteria For SIWC01
+
+SIWC01 is complete when a reviewer can answer:
+
+- what signing architecture Cubid should build first
+- where dapps, Passport, Admin, and custody code each sit
+- which chains are in initial scope
+- how passkeys relate to wallet private keys
+- what the signing request state machine is
+- what audit, idempotency, policy, and webhook boundaries must exist
+- what remains deferred to SIWC02-SIWC08

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -11,9 +11,11 @@ boundary is explicit signing: a dapp can create and list app-scoped custodial
 accounts, but it cannot yet ask the human to approve a message signature or
 transaction.
 
-This document defines the first SIWC signing architecture for API v3. It is a
-design contract only; it does not add signing endpoints, Admin controls, or SDK
-code.
+This document defines the SIWC signing architecture for API v3 and records the
+current implemented backend boundary. Signing request routes, Admin policy
+controls, Passport approval, and message or typed-data signing now exist in
+this repo. Public SDK implementation remains outside this repo, and transaction
+signing remains deferred.
 
 ## Locked Direction
 
@@ -88,29 +90,28 @@ Initial signing eligibility should follow existing v3 custody support:
 Each chain package or helper should remain isolated. Do not introduce generic
 cross-chain assumptions that hide chain-specific risk.
 
-## Proposed API V3 Surfaces
+## API V3 Surfaces
 
-Future signing routes should use the existing Passport API v3 baseline:
-structured errors, `X-Request-Id`, dapp API-key auth, ownership checks,
-idempotency on writes, rate limits, and no secret exposure.
+Signing routes use the existing Passport API v3 baseline: structured errors,
+`X-Request-Id`, dapp API-key auth, ownership checks, idempotency on writes,
+rate limits, and no secret exposure.
 
-Candidate routes:
+Implemented dapp-authenticated routes:
 
 - `POST /api/v3/signing/requests/create`
 - `POST /api/v3/signing/requests/get`
 - `POST /api/v3/signing/requests/cancel`
 - `POST /api/v3/signing/requests/list`
 
-Passport-hosted approval should use authenticated human routes, not dapp
-credentials:
+Passport-hosted approval uses authenticated human routes, not dapp credentials:
 
 - `POST /api/siwc/signing/requests/list`
 - `POST /api/siwc/signing/requests/approve`
 - `POST /api/siwc/signing/requests/reject`
 
-Route names can change during implementation, but the ownership boundary should
-not: dapps create and observe requests; humans approve or reject in Passport;
-server-side custody code signs only after policy and approval succeed.
+The ownership boundary must not change: dapps create and observe requests;
+humans approve or reject in Passport; server-side custody code signs only after
+policy and approval succeed.
 
 ## Request Model
 
@@ -137,9 +138,8 @@ prefer summaries and hashes over raw payloads whenever possible.
 
 ## State Machine
 
-Initial signing request states:
+Signing request states:
 
-- `pending_policy`: created, awaiting policy evaluation
 - `policy_denied`: rejected by policy before user approval
 - `pending_user_approval`: policy accepted, waiting for Passport approval
 - `approved`: human approved with sufficient auth context
@@ -150,8 +150,9 @@ Initial signing request states:
 - `failed`: server-side signing or submission failed
 - `cancelled`: dapp cancelled before completion
 
-Allowed transitions should be explicit. Terminal states should be immutable
-except for metadata fields such as delivery attempts or support notes.
+Policy evaluation happens during request creation, so requests are stored only
+after the policy decision is known. Terminal states should be immutable except
+for metadata fields such as delivery attempts or support notes.
 
 ## Authorization Boundary
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.6
         version: 1.0.7(tailwindcss@3.4.1)
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
       twilio:
         specifier: ^4.19.0
         version: 4.21.0

--- a/supabase/migrations/20260505012000_siwc_signing_policies.sql
+++ b/supabase/migrations/20260505012000_siwc_signing_policies.sql
@@ -1,0 +1,47 @@
+create table if not exists public.siwc_signing_policies (
+  id uuid primary key default extensions.gen_random_uuid(),
+  dapp_id bigint not null references public.dapps(id) on delete cascade,
+  policy_name text not null default 'Default SIWC policy',
+  policy_version integer not null default 1,
+  status text not null default 'disabled',
+  custody_enabled boolean not null default false,
+  signing_enabled boolean not null default false,
+  sandbox_mode boolean not null default true,
+  allowed_chains text[] not null default '{}'::text[],
+  allowed_request_types text[] not null default '{}'::text[],
+  required_acr text,
+  transaction_value_limit_usd numeric(18, 2),
+  contract_allowlist text[] not null default '{}'::text[],
+  webhook_event_subscriptions text[] not null default '{}'::text[],
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint siwc_signing_policies_dapp_unique unique (dapp_id),
+  constraint siwc_signing_policies_version_positive
+    check (policy_version > 0),
+  constraint siwc_signing_policies_status_check
+    check (status in ('disabled', 'enabled', 'suspended')),
+  constraint siwc_signing_policies_chains_check
+    check (allowed_chains <@ array['evm', 'near', 'solana', 'sui']::text[]),
+  constraint siwc_signing_policies_request_types_check
+    check (allowed_request_types <@ array['message', 'typed_data', 'transaction']::text[]),
+  constraint siwc_signing_policies_required_acr_check
+    check (required_acr is null or required_acr = 'urn:cubid:acr:passkey'),
+  constraint siwc_signing_policies_signing_requires_acr
+    check (signing_enabled = false or required_acr = 'urn:cubid:acr:passkey'),
+  constraint siwc_signing_policies_value_limit_positive
+    check (transaction_value_limit_usd is null or transaction_value_limit_usd >= 0)
+);
+
+create index if not exists siwc_signing_policies_status_idx
+  on public.siwc_signing_policies(status);
+
+create index if not exists siwc_signing_policies_updated_idx
+  on public.siwc_signing_policies(updated_at desc);
+
+alter table public.siwc_signing_policies enable row level security;
+
+grant select, insert, update, delete on table public.siwc_signing_policies to service_role;
+revoke all on table public.siwc_signing_policies from anon;
+revoke all on table public.siwc_signing_policies from authenticated;
+revoke all on table public.siwc_signing_policies from public;

--- a/supabase/migrations/20260506083000_siwc_signing_requests.sql
+++ b/supabase/migrations/20260506083000_siwc_signing_requests.sql
@@ -1,0 +1,69 @@
+create table if not exists public.siwc_signing_requests (
+  id uuid primary key default extensions.gen_random_uuid(),
+  signing_request_id text not null unique,
+  dapp_id bigint not null references public.dapps(id) on delete cascade,
+  dapp_user_uuid uuid not null references public.dapp_users(uuid) on delete cascade,
+  dapp_user_account_id uuid not null references public.dapp_user_accounts(id) on delete restrict,
+  user_account_id uuid not null references public.user_accounts(id) on delete restrict,
+  user_id bigint not null references public.users(id) on delete restrict,
+  chain_key text not null references public.ref_chains(chain_key) on delete restrict,
+  request_type text not null,
+  status text not null,
+  payload_hash text not null,
+  payload jsonb not null,
+  payload_summary jsonb not null default '{}'::jsonb,
+  policy_version integer not null default 0,
+  required_acr text,
+  idempotency_key text,
+  result jsonb,
+  error_code text,
+  error_message text,
+  request_id_header text,
+  approved_by_firebase_uid text,
+  approved_at timestamptz,
+  rejected_by_firebase_uid text,
+  rejected_at timestamptz,
+  cancelled_at timestamptz,
+  completed_at timestamptz,
+  expires_at timestamptz not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint siwc_signing_requests_type_check
+    check (request_type in ('message', 'typed_data', 'transaction')),
+  constraint siwc_signing_requests_status_check
+    check (status in (
+      'policy_denied',
+      'pending_user_approval',
+      'approved',
+      'rejected',
+      'expired',
+      'signing',
+      'completed',
+      'failed',
+      'cancelled'
+    )),
+  constraint siwc_signing_requests_required_acr_check
+    check (required_acr is null or required_acr = 'urn:cubid:acr:passkey'),
+  constraint siwc_signing_requests_payload_hash_check
+    check (payload_hash ~ '^[a-f0-9]{64}$')
+);
+
+create index if not exists siwc_signing_requests_dapp_status_idx
+  on public.siwc_signing_requests(dapp_id, status, created_at desc);
+
+create index if not exists siwc_signing_requests_dapp_user_idx
+  on public.siwc_signing_requests(dapp_id, dapp_user_uuid, created_at desc);
+
+create index if not exists siwc_signing_requests_user_status_idx
+  on public.siwc_signing_requests(user_id, status, created_at desc);
+
+create index if not exists siwc_signing_requests_account_idx
+  on public.siwc_signing_requests(user_account_id, created_at desc);
+
+alter table public.siwc_signing_requests enable row level security;
+
+grant select, insert, update, delete on table public.siwc_signing_requests to service_role;
+revoke all on table public.siwc_signing_requests from anon;
+revoke all on table public.siwc_signing_requests from authenticated;
+revoke all on table public.siwc_signing_requests from public;

--- a/supabase/migrations/20260506091000_siwc_transaction_risk_controls.sql
+++ b/supabase/migrations/20260506091000_siwc_transaction_risk_controls.sql
@@ -1,0 +1,30 @@
+alter table public.siwc_signing_requests
+  add column if not exists risk_level text,
+  add column if not exists risk_reasons text[] not null default '{}'::text[],
+  add column if not exists policy_decision text,
+  add column if not exists step_up_required boolean not null default false,
+  add column if not exists transaction_operation_type text,
+  add column if not exists transaction_recipient text,
+  add column if not exists transaction_contract_address text,
+  add column if not exists transaction_declared_value_usd numeric(18, 2);
+
+alter table public.siwc_signing_requests
+  drop constraint if exists siwc_signing_requests_risk_level_check,
+  add constraint siwc_signing_requests_risk_level_check
+    check (risk_level is null or risk_level in ('low', 'medium', 'high'));
+
+alter table public.siwc_signing_requests
+  drop constraint if exists siwc_signing_requests_policy_decision_check,
+  add constraint siwc_signing_requests_policy_decision_check
+    check (policy_decision is null or policy_decision in ('allowed', 'denied'));
+
+alter table public.siwc_signing_requests
+  drop constraint if exists siwc_signing_requests_transaction_value_check,
+  add constraint siwc_signing_requests_transaction_value_check
+    check (
+      transaction_declared_value_usd is null
+      or transaction_declared_value_usd >= 0
+    );
+
+create index if not exists siwc_signing_requests_risk_idx
+  on public.siwc_signing_requests(risk_level, created_at desc);

--- a/supabase/migrations/20260506093000_siwc_webhook_types.sql
+++ b/supabase/migrations/20260506093000_siwc_webhook_types.sql
@@ -1,0 +1,13 @@
+insert into public.webhook_types (name, action_type)
+values
+  ('wallet.created', 'siwc'),
+  ('wallet.policy.denied', 'siwc'),
+  ('wallet.signature.completed', 'siwc'),
+  ('wallet.signature.failed', 'siwc'),
+  ('wallet.signing_request.approved', 'siwc'),
+  ('wallet.signing_request.cancelled', 'siwc'),
+  ('wallet.signing_request.created', 'siwc'),
+  ('wallet.signing_request.rejected', 'siwc'),
+  ('wallet.signing_request.step_up_failed', 'siwc')
+on conflict (name) do update
+set action_type = excluded.action_type;


### PR DESCRIPTION
## Summary
- Adds the SIWC app-scoped custody and signing foundation across Admin, Passport, API v3, webhooks, docs, and roadmap metadata.
- Adds Admin SIWC policy controls for custody/signing enablement, allowed chains/request types, passkey ACR, limits, allowlists, sandbox mode, and wallet webhook subscriptions.
- Adds Passport user visibility for app-scoped accounts and Passport-hosted signing request approval/rejection with passkey freshness checks.
- Adds API v3 signing request lifecycle routes, transaction-risk denial evidence, SIWC wallet webhook events, and the SIWC production runbook.

## Objective
Build the backend/API-contract foundation for Sign In With Cubid custody and message/typed-data signing while preserving Cubid's app-scoped privacy model and keeping transaction signing, smart accounts, session keys, paymasters, and public SDK implementation explicitly deferred.

## Changes
- Added `public.siwc_signing_policies`, `public.siwc_signing_requests`, transaction risk metadata, and canonical SIWC webhook event seed migrations.
- Added Admin SIWC Policy APIs/UI and policy tests.
- Added Passport SIWC account visibility plus signing request create/get/list/cancel/approve/reject routes.
- Added server-side signing support for message/typed-data flows while keeping transaction requests policy-denied with risk evidence.
- Extended API v3 webhook delivery for `wallet.*` and `wallet.signing_request.*` events using existing signed webhook infrastructure.
- Updated SIWC/API v3 docs, added the custody/signing production runbook, and closed SIWC01-SIWC08 roadmap metadata.

## Validation
- `npx -p node@24 node $(which pnpm) --filter @cubid/passport test`
- `pnpm --filter @cubid/passport typecheck`
- `pnpm --filter @cubid/admin test`
- `pnpm --filter @cubid/admin typecheck`
- `npx -p node@24 node $(which pnpm) --filter @cubid/passport build`
- `npx -p node@24 node $(which pnpm) --filter @cubid/admin build`
- `git diff --check`

## Reviewer Notes
- Suggested review order: migrations and policy helpers first, then Passport signing request helper/routes, then Profile/Admin UI, then webhook additions, then docs/roadmap closeout.
- Transaction signing remains intentionally disabled. Transaction requests are summarized and denied with policy/risk evidence.
- Public SDK implementation is intentionally not included in this repo; SDK-impacting notes were written to the SDK repo message inbox during the SIWC slices.
- Build output still includes pre-existing frontend/Tailwind/Celo warnings unrelated to this branch.

## Follow-ups
- Run the normal post-PR CI/review loop and address any review feedback.
- After merge, consider a new transaction-signing readiness track for chain-specific transaction summaries/simulation before enabling transaction signatures.
- Keep smart accounts, session keys, and paymasters deferred until the production-readiness criteria in the SIWC docs are satisfied.
