### PR TITLE
[codex] add protected Supabase delivery workflow

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -43,6 +43,7 @@ jobs:
     env:
       CUBID_SUPABASE_PROJECT_REF: ${{ vars.CUBID_SUPABASE_PROJECT_REF }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,13 +58,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ -z "${SUPABASE_ACCESS_TOKEN}" ]]; then
-            echo "::warning::SUPABASE_ACCESS_TOKEN is not configured; skipping remote migration drift check."
+          if [[ -z "${SUPABASE_ACCESS_TOKEN}" || -z "${SUPABASE_DB_PASSWORD}" ]]; then
+            echo "::warning::SUPABASE_ACCESS_TOKEN or SUPABASE_DB_PASSWORD is not configured; skipping remote migration drift check."
             exit 0
           fi
 
           project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
-          supabase link --project-ref "$project_ref"
+          supabase link --project-ref "$project_ref" --password "$SUPABASE_DB_PASSWORD"
           supabase migration list --linked
           supabase db push --dry-run --linked
 
@@ -74,6 +75,10 @@ jobs:
     env:
       CUBID_SUPABASE_PROJECT_REF: ${{ vars.CUBID_SUPABASE_PROJECT_REF }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      WORKFLOW_MODE: ${{ inputs.mode }}
+      CONFIRM_PROJECT_REF: ${{ inputs.confirm_project_ref }}
+      CONFIRM_RECENT_BACKUP: ${{ inputs.confirm_recent_backup }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,13 +98,18 @@ jobs:
             exit 1
           fi
 
+          if [[ -z "${SUPABASE_DB_PASSWORD}" ]]; then
+            echo "SUPABASE_DB_PASSWORD is required in the selected GitHub Environment." >&2
+            exit 1
+          fi
+
           project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
-          if [[ "${{ inputs.confirm_project_ref }}" != "$project_ref" ]]; then
+          if [[ "$CONFIRM_PROJECT_REF" != "$project_ref" ]]; then
             echo "confirm_project_ref must equal $project_ref for this environment." >&2
             exit 1
           fi
 
-          if [[ "${{ inputs.mode }}" == "apply" && "${{ inputs.confirm_recent_backup }}" != "I confirmed a completed recent backup" ]]; then
+          if [[ "$WORKFLOW_MODE" == "apply" && "$CONFIRM_RECENT_BACKUP" != "I confirmed a completed recent backup" ]]; then
             echo "Apply mode requires confirm_recent_backup to exactly match: I confirmed a completed recent backup" >&2
             exit 1
           fi
@@ -118,7 +128,7 @@ jobs:
         run: |
           set -euo pipefail
           project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
-          supabase link --project-ref "$project_ref"
+          supabase link --project-ref "$project_ref" --password "$SUPABASE_DB_PASSWORD"
           supabase migration list --linked
 
       - name: Check pending migrations

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -25,8 +25,8 @@ on:
           - "Preview – cubid-passport"
           - "Production – cubid-passport"
       confirm_project_ref:
-        description: "Must equal the target Supabase project ref"
-        required: true
+        description: "For apply mode, must equal the target Supabase project ref"
+        required: false
         type: string
       confirm_recent_backup:
         description: "For apply mode, type: I confirmed a completed recent backup"
@@ -58,13 +58,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ -z "${SUPABASE_ACCESS_TOKEN}" || -z "${SUPABASE_DB_PASSWORD}" ]]; then
-            echo "::warning::SUPABASE_ACCESS_TOKEN or SUPABASE_DB_PASSWORD is not configured; skipping remote migration drift check."
+          if [[ -z "${SUPABASE_ACCESS_TOKEN}" || -z "${SUPABASE_DB_PASSWORD}" || -z "${CUBID_SUPABASE_PROJECT_REF}" ]]; then
+            echo "::warning::SUPABASE_ACCESS_TOKEN, SUPABASE_DB_PASSWORD, or CUBID_SUPABASE_PROJECT_REF is not configured; skipping remote migration drift check."
             exit 0
           fi
 
-          project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
-          supabase link --project-ref "$project_ref" --password "$SUPABASE_DB_PASSWORD"
+          supabase link --project-ref "$CUBID_SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
           supabase migration list --linked
           supabase db push --dry-run --linked
 
@@ -103,32 +102,60 @@ jobs:
             exit 1
           fi
 
-          project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
-          if [[ "$CONFIRM_PROJECT_REF" != "$project_ref" ]]; then
-            echo "confirm_project_ref must equal $project_ref for this environment." >&2
+          if [[ -z "${CUBID_SUPABASE_PROJECT_REF}" ]]; then
+            echo "CUBID_SUPABASE_PROJECT_REF is required in the selected GitHub Environment." >&2
             exit 1
           fi
 
-          if [[ "$WORKFLOW_MODE" == "apply" && "$CONFIRM_RECENT_BACKUP" != "I confirmed a completed recent backup" ]]; then
-            echo "Apply mode requires confirm_recent_backup to exactly match: I confirmed a completed recent backup" >&2
-            exit 1
+          if [[ "$WORKFLOW_MODE" == "apply" ]]; then
+            if [[ "$CONFIRM_PROJECT_REF" != "$CUBID_SUPABASE_PROJECT_REF" ]]; then
+              echo "confirm_project_ref must equal $CUBID_SUPABASE_PROJECT_REF for this environment." >&2
+              exit 1
+            fi
+
+            if [[ "$CONFIRM_RECENT_BACKUP" != "I confirmed a completed recent backup" ]]; then
+              echo "Apply mode requires confirm_recent_backup to exactly match: I confirmed a completed recent backup" >&2
+              exit 1
+            fi
           fi
 
-          echo "Confirmed Supabase target project ref: $project_ref"
+          echo "Confirmed Supabase target project ref: $CUBID_SUPABASE_PROJECT_REF"
 
       - name: Show remote backup posture
         shell: bash
         run: |
           set -euo pipefail
-          project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
-          supabase backups list --project-ref "$project_ref"
+          supabase backups list --project-ref "$CUBID_SUPABASE_PROJECT_REF"
+
+      - name: Require recent completed backup before apply
+        if: inputs.mode == 'apply'
+        shell: bash
+        run: |
+          set -euo pipefail
+          backup_json="$(supabase backups list --project-ref "$CUBID_SUPABASE_PROJECT_REF" --output json)"
+
+          BACKUP_JSON="$backup_json" node <<'NODE'
+          const payload = JSON.parse(process.env.BACKUP_JSON ?? "{}");
+          const backups = Array.isArray(payload.backups) ? payload.backups : [];
+          const recentWindowMs = 36 * 60 * 60 * 1000;
+          const now = Date.now();
+          const hasRecentCompleted = backups.some((backup) => {
+            if (backup?.status !== "COMPLETED" || !backup?.inserted_at) return false;
+            const createdAt = Date.parse(backup.inserted_at);
+            return Number.isFinite(createdAt) && now - createdAt <= recentWindowMs;
+          });
+
+          if (!hasRecentCompleted) {
+            console.error("No completed Supabase backup found in the last 36 hours.");
+            process.exit(1);
+          }
+          NODE
 
       - name: Link project and inspect migration status
         shell: bash
         run: |
           set -euo pipefail
-          project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
-          supabase link --project-ref "$project_ref" --password "$SUPABASE_DB_PASSWORD"
+          supabase link --project-ref "$CUBID_SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
           supabase migration list --linked
 
       - name: Check pending migrations

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -1,0 +1,144 @@
+name: Supabase Deploy
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/supabase-deploy.yml"
+      - "supabase/config.toml"
+      - "supabase/migrations/**"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Run a migration check or apply pending migrations"
+        required: true
+        default: "check"
+        type: choice
+        options:
+          - check
+          - apply
+      github_environment:
+        description: "GitHub Environment containing Supabase deploy secrets"
+        required: true
+        default: "Preview – cubid-passport"
+        type: choice
+        options:
+          - "Preview – cubid-passport"
+          - "Production – cubid-passport"
+      confirm_project_ref:
+        description: "Must equal the target Supabase project ref"
+        required: true
+        type: string
+      confirm_recent_backup:
+        description: "For apply mode, type: I confirmed a completed recent backup"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  pull-request-migration-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      CUBID_SUPABASE_PROJECT_REF: ${{ vars.CUBID_SUPABASE_PROJECT_REF }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.84.2
+
+      - name: Check migration drift when secrets are available
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SUPABASE_ACCESS_TOKEN}" ]]; then
+            echo "::warning::SUPABASE_ACCESS_TOKEN is not configured; skipping remote migration drift check."
+            exit 0
+          fi
+
+          project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
+          supabase link --project-ref "$project_ref"
+          supabase migration list --linked
+          supabase db push --dry-run --linked
+
+  hosted-migration-deploy:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.github_environment }}
+    env:
+      CUBID_SUPABASE_PROJECT_REF: ${{ vars.CUBID_SUPABASE_PROJECT_REF }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.84.2
+
+      - name: Confirm target and required secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SUPABASE_ACCESS_TOKEN}" ]]; then
+            echo "SUPABASE_ACCESS_TOKEN is required in the selected GitHub Environment." >&2
+            exit 1
+          fi
+
+          project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
+          if [[ "${{ inputs.confirm_project_ref }}" != "$project_ref" ]]; then
+            echo "confirm_project_ref must equal $project_ref for this environment." >&2
+            exit 1
+          fi
+
+          if [[ "${{ inputs.mode }}" == "apply" && "${{ inputs.confirm_recent_backup }}" != "I confirmed a completed recent backup" ]]; then
+            echo "Apply mode requires confirm_recent_backup to exactly match: I confirmed a completed recent backup" >&2
+            exit 1
+          fi
+
+          echo "Confirmed Supabase target project ref: $project_ref"
+
+      - name: Show remote backup posture
+        shell: bash
+        run: |
+          set -euo pipefail
+          project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
+          supabase backups list --project-ref "$project_ref"
+
+      - name: Link project and inspect migration status
+        shell: bash
+        run: |
+          set -euo pipefail
+          project_ref="${CUBID_SUPABASE_PROJECT_REF:-cggycnbvljcdptzyjpju}"
+          supabase link --project-ref "$project_ref"
+          supabase migration list --linked
+
+      - name: Check pending migrations
+        if: inputs.mode == 'check'
+        shell: bash
+        run: supabase db push --dry-run --linked
+
+      - name: Apply pending migrations
+        if: inputs.mode == 'apply'
+        shell: bash
+        run: supabase db push --linked --yes
+
+      - name: Confirm no Supabase Edge functions are deployed by this repo
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -d supabase/functions ]]; then
+            echo "supabase/functions exists. Add an explicit function deploy step before relying on this workflow."
+            find supabase/functions -maxdepth 2 -type f -print
+            exit 1
+          fi
+
+          echo "No supabase/functions directory found; function deployment is not applicable for this repo."

--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ Passport runtime env files now belong under `apps/passport/`. Use [apps/passport
 
 Admin runtime env files belong under [apps/admin/.env.example](apps/admin/.env.example).
 
-Known Passport env variables include:
+Important Passport env variables include:
 
 - `NEXT_PUBLIC_DAPP_ID`
-- `WLD_CLIENT_ID`
-- `WLD_CLIENT_SECRET`
-- `authToken`
-- `is_allow_token`
-- `private_key_near`
-- `twilio_sid`
-
-Some third-party credentials are still hardcoded in source files and should be moved into environment variables before this app is treated as production-ready.
+- `PASSPORT_PUBLIC_ORIGIN`
+- `PASSPORT_CORS_ALLOWED_ORIGINS`
+- `PASSPORT_INTERNAL_API_TOKEN`
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_CLIENT_EMAIL`
+- `FIREBASE_PRIVATE_KEY`
 
 Known Admin env variables include:
 
@@ -73,6 +73,9 @@ Known Admin env variables include:
 - `FIREBASE_PROJECT_ID`
 - `FIREBASE_CLIENT_EMAIL`
 - `FIREBASE_PRIVATE_KEY`
+
+Operational secret ownership and legacy env aliases are documented in
+[docs/engineering/operational-secret-hardening.md](docs/engineering/operational-secret-hardening.md).
 
 ## Repository Layout
 
@@ -86,11 +89,12 @@ Known Admin env variables include:
 - `.github/`: CI workflows and repo automation
 - `pnpm-workspace.yaml`, `turbo.json`, `tsconfig.base.json`: monorepo workspace and shared tooling contracts
 
-## Current Focus
+## Current Platform Status
 
-- stabilize the two-app monorepo contract across Passport and Admin
-- extract the next layer of shared packages once both apps are running from one workspace graph
-- add the dedicated OIDC service and shared identity packages
+- Repo-side platform foundations are largely complete for Passport, Admin, OIDC, API v3 custody, app-scoped disclosure, and SIWC message/typed-data signing.
+- Public SDK implementation lives in `Cubid-Me/cubid-sdk`; keep SDK-impacting backend changes coordinated through agent messages.
+- Hosted readiness is not complete until Supabase migrations are applied to the target environment, required runtime and Vault secrets are provisioned, and Passport/Admin/OIDC/API v3/SIWC smoke checks pass.
+- The linked `CubidDev` Supabase project currently has only the baseline remote-schema migration recorded, so do not assume hosted dev matches the repo schema.
 
 ## Agent And SDK Guidance
 

--- a/agent-context/repo-status.md
+++ b/agent-context/repo-status.md
@@ -1,6 +1,6 @@
 # Repo Status
 
-Last updated: 2026-05-06T22:48:47Z
+Last updated: 2026-05-06T22:52:17Z
 
 | Requirement | Status |
 | --- | --- |
@@ -14,10 +14,10 @@ Last updated: 2026-05-06T22:48:47Z
 | Engineering docs | Pass. Current architecture and operating docs live under `docs/engineering/`; no target-state docs were found outside the expected docs area during this pass. |
 | Testing strategy | Partial. Root scripts run lint, typecheck, test, build, and security checks; some chain placeholder packages still have no real tests. |
 | Local acceptance harness | Partial. Unit/server tests cover core route behavior, but there is no single local end-to-end acceptance harness for Passport, Admin, OIDC, API v3, and SIWC together. |
-| CI contract | Partial. CI runs repo validation on PRs and pushes to `main`, but it does not validate Supabase migration drift or deployment readiness. |
-| Supabase migrations | Blocked. Local repo has migrations through `20260506093000`; linked `CubidDev` only reports `20260331020028` applied. Do not assume hosted dev is schema-current. |
+| CI contract | Partial. CI runs repo validation on PRs and pushes to `main`; `F01` adds a Supabase deploy workflow, but remote drift checks depend on GitHub environment secrets being configured. |
+| Supabase migrations | Blocked. Local repo has migrations through `20260506093000`; linked `CubidDev` only reports `20260331020028` applied. A local dry-run shows 25 pending migrations would be applied. Do not assume hosted dev is schema-current. |
 | Supabase functions | Not applicable. This repo has no `supabase/functions` directory and the linked `CubidDev` project reports no deployed functions. |
-| Supabase deployment workflow | Missing. There is no GitHub workflow for protected migration dry-run/checks or approved migration apply to `CubidDev`. See `F01`. |
+| Supabase deployment workflow | Partial. `.github/workflows/supabase-deploy.yml` defines check/apply paths for `CubidDev`, but GitHub environment secrets/protection must be configured before it can apply. |
 | Environment and secrets | Partial. Workspace `.env.example` files exist and operational-secret docs exist; live secrets and Supabase Vault values still need environment provisioning and smoke verification. |
 | Git artifact hygiene | Pass. Build outputs, `.next`, `dist`, coverage, node modules, and local env files are ignored and not tracked. |
 | Production readiness | Blocked. Repo-side implementation is strong, but production requires hosted migrations, Vault/runtime secrets, SDK sync, deployment checks, and smoke tests. |

--- a/agent-context/repo-status.md
+++ b/agent-context/repo-status.md
@@ -1,0 +1,23 @@
+# Repo Status
+
+Last updated: 2026-05-06T22:48:47Z
+
+| Requirement | Status |
+| --- | --- |
+| Branch workflow | Pass. `AGENTS.md` requires feature branches, PRs to `dev` by default, and session-log entries before commits. |
+| README accuracy | Partial. README now reflects the current platform state, but live production readiness still depends on hosted deployment and smoke checks. |
+| License | Missing. No root `LICENSE` file is present; add one if this private repo needs an explicit license posture. |
+| Session log | Pass. `agent-context/session-log.md` exists and is current through the latest docs cleanup work. |
+| Roadmap metadata | Partial. Most todos are completed or ingested into `Cubid-Me/cubid-sdk`; `C04.1.1` remains intentionally not started until hosted smoke validates hashed dapp API keys. |
+| Future ideas guardrail | Pass. `agent-context/future-ideas.md` exists and clearly states it is deferred reference material, not an active roadmap. |
+| SDK boundary | Pass. `AGENTS.md` and README direct public SDK implementation to `Cubid-Me/cubid-sdk` and keep `packages/core` as a historical snapshot only. |
+| Engineering docs | Pass. Current architecture and operating docs live under `docs/engineering/`; no target-state docs were found outside the expected docs area during this pass. |
+| Testing strategy | Partial. Root scripts run lint, typecheck, test, build, and security checks; some chain placeholder packages still have no real tests. |
+| Local acceptance harness | Partial. Unit/server tests cover core route behavior, but there is no single local end-to-end acceptance harness for Passport, Admin, OIDC, API v3, and SIWC together. |
+| CI contract | Partial. CI runs repo validation on PRs and pushes to `main`, but it does not validate Supabase migration drift or deployment readiness. |
+| Supabase migrations | Blocked. Local repo has migrations through `20260506093000`; linked `CubidDev` only reports `20260331020028` applied. Do not assume hosted dev is schema-current. |
+| Supabase functions | Not applicable. This repo has no `supabase/functions` directory and the linked `CubidDev` project reports no deployed functions. |
+| Supabase deployment workflow | Missing. There is no GitHub workflow for protected migration dry-run/checks or approved migration apply to `CubidDev`. See `F01`. |
+| Environment and secrets | Partial. Workspace `.env.example` files exist and operational-secret docs exist; live secrets and Supabase Vault values still need environment provisioning and smoke verification. |
+| Git artifact hygiene | Pass. Build outputs, `.next`, `dist`, coverage, node modules, and local env files are ignored and not tracked. |
+| Production readiness | Blocked. Repo-side implementation is strong, but production requires hosted migrations, Vault/runtime secrets, SDK sync, deployment checks, and smoke tests. |

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -5161,3 +5161,41 @@ Supabase delivery follow-up without applying hosted migrations.
 
 - implement `F01` as the next cleanup/release-operations slice before applying
   hosted migrations to `CubidDev`
+
+### session: v181
+
+- timestamp: 2026-05-06T22:52:17Z
+- agent: **OpenAI Codex**
+- branch: **codex/repo-cleanup-delivery-status**
+- head: **`c8e2618`**
+- session name: **Add protected Supabase delivery workflow**
+
+#### Objective
+
+Implement the F01 hosted Supabase delivery mechanism and confirm whether it can
+be safely run against `CubidDev`.
+
+#### Actions Taken
+
+- added `.github/workflows/supabase-deploy.yml` with pull-request migration
+  dry-run support and manual `check` / `apply` dispatch modes
+- added guarded project-ref and backup confirmation checks before apply mode
+- added `docs/engineering/supabase-hosted-delivery.md` documenting target
+  project, required GitHub secrets, backup posture, and operator steps
+- updated repo-status and F01 metadata to reflect the implemented workflow and
+  current deployment blocker
+
+#### Verification
+
+- confirmed linked Supabase project is `CubidDev` / `cggycnbvljcdptzyjpju`
+- confirmed `supabase backups list` shows recent completed physical backups
+- confirmed `supabase db push --dry-run --linked` lists 25 pending migrations
+- confirmed there are no `supabase/functions` to deploy from this repo
+- confirmed no repository or checked GitHub Environment `SUPABASE_ACCESS_TOKEN`
+  secret is currently configured
+
+#### Follow-up
+
+- configure `SUPABASE_ACCESS_TOKEN` and reviewer protection on the selected
+  GitHub Environment, then run the `Supabase Deploy` workflow in `check` mode
+  before running `apply`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -5230,3 +5230,36 @@ workflow before hosted migration checks are run from GitHub.
 #### Follow-up
 
 - push the review fix, reply to the automated comments, and re-check PR 160 CI
+
+### session: v183
+
+- timestamp: 2026-05-06T23:11:36Z
+- agent: **OpenAI Codex**
+- branch: **codex/repo-cleanup-delivery-status**
+- head: **`78d6242`**
+- session name: **Address PR 160 Copilot workflow safeguards**
+
+#### Objective
+
+Address Copilot review feedback on implicit project targeting, check-mode
+friction, and backup enforcement in the Supabase deployment workflow.
+
+#### Actions Taken
+
+- made `confirm_project_ref` optional for check mode and enforced it only for
+  apply mode
+- required `CUBID_SUPABASE_PROJECT_REF` in the selected GitHub Environment
+  instead of falling back implicitly during workflow dispatch
+- added an apply-mode backup assertion that fails when no completed Supabase
+  backup exists in the last 36 hours
+- updated the hosted delivery runbook and F01 metadata with the explicit
+  environment variable and backup-check requirements
+
+#### Verification
+
+- planned validation with workflow YAML parsing and `git diff --check`
+
+#### Follow-up
+
+- push the safeguard fix, reply to and resolve review comments, then re-check
+  PR 160 CI

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -5199,3 +5199,34 @@ be safely run against `CubidDev`.
 - configure `SUPABASE_ACCESS_TOKEN` and reviewer protection on the selected
   GitHub Environment, then run the `Supabase Deploy` workflow in `check` mode
   before running `apply`
+
+### session: v182
+
+- timestamp: 2026-05-06T23:10:06Z
+- agent: **OpenAI Codex**
+- branch: **codex/repo-cleanup-delivery-status**
+- head: **`99736d4`**
+- session name: **Address PR 160 Supabase workflow review**
+
+#### Objective
+
+Address automated review feedback on the protected Supabase deployment
+workflow before hosted migration checks are run from GitHub.
+
+#### Actions Taken
+
+- moved workflow dispatch inputs into environment variables before shell usage
+  so untrusted input is handled as data, not interpolated script text
+- added `SUPABASE_DB_PASSWORD` as a required GitHub Environment secret for
+  hosted deploy runs
+- passed the database password to `supabase link` so CI does not prompt or hang
+- updated the hosted delivery runbook and F01 metadata with the additional
+  secret requirement
+
+#### Verification
+
+- planned validation with workflow YAML parsing and `git diff --check`
+
+#### Follow-up
+
+- push the review fix, reply to the automated comments, and re-check PR 160 CI

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -5129,3 +5129,35 @@ Create a deferred future-ideas reference and repo-local guidance for how agents 
 #### Follow-up
 
 - commit the documentation update and yeet if review is desired
+
+### session: v180
+
+- timestamp: 2026-05-06T22:48:47Z
+- agent: **OpenAI Codex**
+- branch: **codex/repo-cleanup-delivery-status**
+- head: **`2ece33c`**
+- session name: **Record repo cleanup delivery status**
+
+#### Objective
+
+Capture the repo cleanup assessment in durable docs and add a concrete hosted
+Supabase delivery follow-up without applying hosted migrations.
+
+#### Actions Taken
+
+- added `agent-context/repo-status.md` with cleanup status across workflow,
+  docs, tests, CI, Supabase, SDK boundary, and production readiness
+- refreshed README environment/current-status wording so it no longer implies
+  stale pre-monorepo priorities or unverified hardcoded-secret claims
+- added `F01` to `agent-context/todo.md` for protected Supabase dev/preview
+  migration deployment automation
+
+#### Verification
+
+- planned docs validation with `git diff --check`
+- no hosted Supabase mutation or function deployment performed
+
+#### Follow-up
+
+- implement `F01` as the next cleanup/release-operations slice before applying
+  hosted migrations to `CubidDev`

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -833,6 +833,7 @@ Add the missing hosted Supabase delivery path for the linked `CubidDev` preview/
 Implementation status: the workflow and runbook are in place, and `CubidDev`
 backup posture was checked locally with completed physical backups visible
 through 2026-05-06. The workflow requires both `SUPABASE_ACCESS_TOKEN` and
-`SUPABASE_DB_PASSWORD` in the selected GitHub Environment, plus reviewer
-protection before apply. Configure those settings, then dispatch
-`Supabase Deploy` in `check` mode before `apply`.
+`SUPABASE_DB_PASSWORD` in the selected GitHub Environment, an explicit
+`CUBID_SUPABASE_PROJECT_REF` environment variable, plus reviewer protection
+before apply. Configure those settings, then dispatch `Supabase Deploy` in
+`check` mode before `apply`.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -821,11 +821,19 @@ Create the operator runbook for SIWC custody and signing before exposing signing
 
 ### F01. Add protected Supabase dev/preview migration deployment
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Blocked
+- Timestamp started: 2026-05-06T22:52:17Z
 - Timestamp completed: TBD
-- Feature branch: TBD
+- Feature branch: codex/repo-cleanup-delivery-status
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: v181
 
 Add the missing hosted Supabase delivery path for the linked `CubidDev` preview/dev project. The repo currently contains migrations through `20260506093000`, but `supabase migration list --linked` shows only the baseline `20260331020028` migration applied remotely. Create a GitHub workflow that validates migration drift on pull requests and provides a manual, protected apply path for `dev` after approval, using repo or environment secrets rather than local shell mutation. The workflow should identify the target project ref, run a dry-run or remote migration status check before applying, avoid deploying functions when no `supabase/functions` directory exists, and produce logs operators can use for smoke verification. This todo does not itself apply migrations; it creates the safe delivery mechanism.
+
+Implementation status: the workflow and runbook are in place, and `CubidDev`
+backup posture was checked locally with completed physical backups visible
+through 2026-05-06. The hosted apply is blocked because the repo currently has
+no `SUPABASE_ACCESS_TOKEN` configured at the repository or GitHub Environment
+level, and the existing Preview/Production environments do not have reviewer
+protection rules configured. Configure those settings, then dispatch
+`Supabase Deploy` in `check` mode before `apply`.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -832,8 +832,7 @@ Add the missing hosted Supabase delivery path for the linked `CubidDev` preview/
 
 Implementation status: the workflow and runbook are in place, and `CubidDev`
 backup posture was checked locally with completed physical backups visible
-through 2026-05-06. The hosted apply is blocked because the repo currently has
-no `SUPABASE_ACCESS_TOKEN` configured at the repository or GitHub Environment
-level, and the existing Preview/Production environments do not have reviewer
-protection rules configured. Configure those settings, then dispatch
+through 2026-05-06. The workflow requires both `SUPABASE_ACCESS_TOKEN` and
+`SUPABASE_DB_PASSWORD` in the selected GitHub Environment, plus reviewer
+protection before apply. Configure those settings, then dispatch
 `Supabase Deploy` in `check` mode before `apply`.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -816,3 +816,16 @@ Evaluate whether Cubid should support smart accounts, scoped session keys, and p
 - Session-log reference(s): session: v173, session: v174
 
 Create the operator runbook for SIWC custody and signing before exposing signing broadly. The runbook should cover Vault key ownership and rotation, generated-account custody boundaries, migration rollback, audit-log inspection, signing request triage, webhook replay, incident response, abuse monitoring, emergency app suspension, user support, and privacy review for app-scoped account visibility. It should explicitly document what is safe to expose to users and dapps, what is Admin-only, what is service-role-only, and what must never leave server memory. Include local/staging/prod environment requirements, smoke tests, and launch blockers. This todo should close the gap between a technically working signer and an operable platform surface.
+
+## F. Hosted Delivery and Release Operations
+
+### F01. Add protected Supabase dev/preview migration deployment
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add the missing hosted Supabase delivery path for the linked `CubidDev` preview/dev project. The repo currently contains migrations through `20260506093000`, but `supabase migration list --linked` shows only the baseline `20260331020028` migration applied remotely. Create a GitHub workflow that validates migration drift on pull requests and provides a manual, protected apply path for `dev` after approval, using repo or environment secrets rather than local shell mutation. The workflow should identify the target project ref, run a dry-run or remote migration status check before applying, avoid deploying functions when no `supabase/functions` directory exists, and produce logs operators can use for smoke verification. This todo does not itself apply migrations; it creates the safe delivery mechanism.

--- a/docs/engineering/supabase-hosted-delivery.md
+++ b/docs/engineering/supabase-hosted-delivery.md
@@ -1,0 +1,57 @@
+# Supabase Hosted Delivery
+
+This repo owns Supabase migrations for the private Cubid platform backend. Hosted
+database changes must go through the protected GitHub workflow, not ad hoc local
+shell mutation.
+
+## Target
+
+- Preview/dev project: `CubidDev`
+- Project ref: `cggycnbvljcdptzyjpju`
+- Current repo status as of 2026-05-06: local migrations exist through
+  `20260506093000`, while `CubidDev` reports only `20260331020028` applied.
+  A local dry-run lists 25 pending migrations.
+
+There is no `supabase/functions` directory in this repo, so Edge Function
+deployment is currently not applicable.
+
+## Required GitHub Configuration
+
+Configure the selected GitHub Environment, recommended
+`Preview – cubid-passport`, with:
+
+- secret `SUPABASE_ACCESS_TOKEN`
+- optional environment variable `CUBID_SUPABASE_PROJECT_REF`
+
+If `CUBID_SUPABASE_PROJECT_REF` is omitted, the workflow defaults to
+`cggycnbvljcdptzyjpju`. The environment should require reviewer approval before
+`apply` runs.
+
+## Workflow
+
+Use `.github/workflows/supabase-deploy.yml`.
+
+- Pull requests run a migration dry-run when `SUPABASE_ACCESS_TOKEN` is
+  available. If the secret is not configured yet, the workflow emits a warning
+  instead of blocking unrelated docs/setup PRs.
+- Manual dispatch with `mode=check` lists remote migration history and performs
+  `supabase db push --dry-run`.
+- Manual dispatch with `mode=apply` requires:
+  - `confirm_project_ref` equal to the target project ref
+  - `confirm_recent_backup` exactly equal to
+    `I confirmed a completed recent backup`
+  - a completed backup visible from `supabase backups list`
+
+The workflow logs backup posture and migration status before applying pending
+migrations.
+
+## Operator Checklist Before Apply
+
+1. Confirm the workflow environment has `SUPABASE_ACCESS_TOKEN`.
+2. Confirm the GitHub Environment has reviewer protection for applies.
+3. Run workflow dispatch with `mode=check`.
+4. Confirm `supabase backups list` shows a recent `COMPLETED` backup.
+5. Run workflow dispatch with `mode=apply` only after the check output is
+   understood.
+6. After apply, run app smoke checks for Passport, Admin, OIDC, API v3, and
+   SIWC surfaces before enabling broader usage.

--- a/docs/engineering/supabase-hosted-delivery.md
+++ b/docs/engineering/supabase-hosted-delivery.md
@@ -21,6 +21,7 @@ Configure the selected GitHub Environment, recommended
 `Preview – cubid-passport`, with:
 
 - secret `SUPABASE_ACCESS_TOKEN`
+- secret `SUPABASE_DB_PASSWORD`
 - optional environment variable `CUBID_SUPABASE_PROJECT_REF`
 
 If `CUBID_SUPABASE_PROJECT_REF` is omitted, the workflow defaults to
@@ -48,10 +49,11 @@ migrations.
 ## Operator Checklist Before Apply
 
 1. Confirm the workflow environment has `SUPABASE_ACCESS_TOKEN`.
-2. Confirm the GitHub Environment has reviewer protection for applies.
-3. Run workflow dispatch with `mode=check`.
-4. Confirm `supabase backups list` shows a recent `COMPLETED` backup.
-5. Run workflow dispatch with `mode=apply` only after the check output is
+2. Confirm the workflow environment has `SUPABASE_DB_PASSWORD`.
+3. Confirm the GitHub Environment has reviewer protection for applies.
+4. Run workflow dispatch with `mode=check`.
+5. Confirm `supabase backups list` shows a recent `COMPLETED` backup.
+6. Run workflow dispatch with `mode=apply` only after the check output is
    understood.
-6. After apply, run app smoke checks for Passport, Admin, OIDC, API v3, and
+7. After apply, run app smoke checks for Passport, Admin, OIDC, API v3, and
    SIWC surfaces before enabling broader usage.

--- a/docs/engineering/supabase-hosted-delivery.md
+++ b/docs/engineering/supabase-hosted-delivery.md
@@ -22,26 +22,27 @@ Configure the selected GitHub Environment, recommended
 
 - secret `SUPABASE_ACCESS_TOKEN`
 - secret `SUPABASE_DB_PASSWORD`
-- optional environment variable `CUBID_SUPABASE_PROJECT_REF`
+- environment variable `CUBID_SUPABASE_PROJECT_REF`
 
-If `CUBID_SUPABASE_PROJECT_REF` is omitted, the workflow defaults to
-`cggycnbvljcdptzyjpju`. The environment should require reviewer approval before
-`apply` runs.
+Set `CUBID_SUPABASE_PROJECT_REF` to `cggycnbvljcdptzyjpju` for
+`Preview – cubid-passport`. The environment should require reviewer approval
+before `apply` runs.
 
 ## Workflow
 
 Use `.github/workflows/supabase-deploy.yml`.
 
-- Pull requests run a migration dry-run when `SUPABASE_ACCESS_TOKEN` is
-  available. If the secret is not configured yet, the workflow emits a warning
-  instead of blocking unrelated docs/setup PRs.
+- Pull requests run a migration dry-run when `SUPABASE_ACCESS_TOKEN`,
+  `SUPABASE_DB_PASSWORD`, and `CUBID_SUPABASE_PROJECT_REF` are available. If
+  they are not configured yet, the workflow emits a warning instead of blocking
+  unrelated docs/setup PRs.
 - Manual dispatch with `mode=check` lists remote migration history and performs
   `supabase db push --dry-run`.
 - Manual dispatch with `mode=apply` requires:
   - `confirm_project_ref` equal to the target project ref
   - `confirm_recent_backup` exactly equal to
     `I confirmed a completed recent backup`
-  - a completed backup visible from `supabase backups list`
+  - a completed backup visible from `supabase backups list` in the last 36 hours
 
 The workflow logs backup posture and migration status before applying pending
 migrations.
@@ -50,10 +51,11 @@ migrations.
 
 1. Confirm the workflow environment has `SUPABASE_ACCESS_TOKEN`.
 2. Confirm the workflow environment has `SUPABASE_DB_PASSWORD`.
-3. Confirm the GitHub Environment has reviewer protection for applies.
-4. Run workflow dispatch with `mode=check`.
-5. Confirm `supabase backups list` shows a recent `COMPLETED` backup.
-6. Run workflow dispatch with `mode=apply` only after the check output is
+3. Confirm the workflow environment has `CUBID_SUPABASE_PROJECT_REF`.
+4. Confirm the GitHub Environment has reviewer protection for applies.
+5. Run workflow dispatch with `mode=check`.
+6. Confirm `supabase backups list` shows a recent `COMPLETED` backup.
+7. Run workflow dispatch with `mode=apply` only after the check output is
    understood.
-7. After apply, run app smoke checks for Passport, Admin, OIDC, API v3, and
+8. After apply, run app smoke checks for Passport, Admin, OIDC, API v3, and
    SIWC surfaces before enabling broader usage.


### PR DESCRIPTION
## Summary
- Records the current repo cleanup/delivery status in `agent-context/repo-status.md`.
- Refreshes README wording around current platform status and hosted readiness blockers.
- Adds a protected Supabase Deploy workflow for migration dry-run/check/apply paths.
- Documents the `CubidDev` target, backup posture, required GitHub Environment setup, and no-functions boundary.

## Objective
Make the hosted Supabase delivery gap explicit and provide a guarded path for applying dev/preview migrations without ad hoc local shell mutation.

## Changes
- Added `.github/workflows/supabase-deploy.yml` with PR dry-run support and manual `check` / `apply` modes.
- Added project-ref confirmation and exact backup-confirmation gates before apply mode.
- Added `docs/engineering/supabase-hosted-delivery.md` with operator instructions.
- Updated `agent-context/todo.md` with `F01` status and the current blocker state.

## Validation
- `git diff --check`
- Parsed `.github/workflows/supabase-deploy.yml` as YAML
- `supabase backups list --project-ref cggycnbvljcdptzyjpju`
- `supabase db push --dry-run --linked`
- `supabase functions list --project-ref cggycnbvljcdptzyjpju`

## Reviewer Notes
Review the workflow first, then the delivery runbook. The workflow intentionally does not deploy functions because this repo has no `supabase/functions` directory.

## Follow-ups
- Configure/confirm `SUPABASE_ACCESS_TOKEN` and required reviewer protection in `Preview – cubid-passport`.
- Dispatch `Supabase Deploy` in `check` mode after this PR lands.
- Review the check output before dispatching `apply`.
