### PR TITLE
[codex] fix ClearPass migration drift before messaging smoke

### DIFF
--- a/agent-context/repo-status.md
+++ b/agent-context/repo-status.md
@@ -1,6 +1,6 @@
 # Repo Status
 
-Last updated: 2026-05-07T11:29:22Z
+Last updated: 2026-05-16T05:18:00Z
 
 | Requirement | Status |
 | --- | --- |
@@ -8,17 +8,17 @@ Last updated: 2026-05-07T11:29:22Z
 | README accuracy | Partial. README reflects the current platform state, but production readiness still depends on production deployment, secrets, and smoke checks. Staging OIDC and dev/preview Supabase delivery are now represented in the engineering docs. |
 | License | Missing. No root `LICENSE` file is present; add one if this private repo needs an explicit license posture. |
 | Session log | Pass. `agent-context/session-log.md` exists and is current through the latest hosted-readiness reconciliation work. |
-| Roadmap metadata | Partial. Most todos are completed or ingested into `Cubid-Me/cubid-sdk`; `F01` is now complete for CubidDev, while `C04.1.1` remains intentionally not started until hosted smoke validates hashed dapp API keys. |
+| Roadmap metadata | Pass. Most todos are completed or ingested into `Cubid-Me/cubid-sdk`; `F01` is complete for CubidDev, and `C04.1.1` was completed in PR #166 after hosted preflight confirmed active dapps had hashed `dapp_api_keys` rows. |
 | Future ideas guardrail | Pass. `agent-context/future-ideas.md` exists and clearly states it is deferred reference material, not an active roadmap. |
 | SDK boundary | Pass. `AGENTS.md` and README direct public SDK implementation to `Cubid-Me/cubid-sdk` and keep `packages/core` as a historical snapshot only. |
 | Engineering docs | Pass. Current architecture and operating docs live under `docs/engineering/`; no target-state docs were found outside the expected docs area during this pass. |
 | Testing strategy | Partial. Root scripts run lint, typecheck, test, build, and security checks; some chain placeholder packages still have no real tests. |
 | Local acceptance harness | Partial. Unit/server tests cover core route behavior, but there is no single local end-to-end acceptance harness for Passport, Admin, OIDC, API v3, and SIWC together. |
 | CI contract | Pass for repo and dev/preview delivery. CI runs repo validation on PRs and pushes, and `.github/workflows/supabase-deploy.yml` now provides protected check/apply paths for CubidDev migrations. |
-| Supabase migrations | Pass for CubidDev. `supabase migration list --linked` now shows local and remote aligned through `20260506093000`. The protected workflow apply succeeded on 2026-05-06 and a follow-up check reported no pending migrations. |
+| Supabase migrations | Pass for CubidDev through the last verified hosted run. `supabase migration list --linked` previously showed local and remote aligned through `20260506093000`; PR #166 added later flexible messaging and `dapps.apikey` cleanup migrations that still need protected hosted apply/smoke evidence before launch claims. |
 | Supabase functions | Not applicable. This repo has no `supabase/functions` directory and the linked `CubidDev` project reports no deployed functions. |
 | Supabase deployment workflow | Pass for dev/preview. GitHub environment secrets and reviewer protection were configured, `apply` ran successfully against `CubidDev`, and follow-up `check` mode succeeded. Production would need its own protected environment and approval path. |
 | OIDC staging deployment | Pass. `services/oidc` is deployed to Fly as `cubid-oidc-staging`; `https://staging-id.cubid.me` resolves, has an active Fly certificate, and discovery/JWKS smoke checks pass. |
 | Environment and secrets | Partial. OIDC Fly staging runtime secrets are provisioned, and Supabase dev/preview workflow secrets are configured. Broader Vault/runtime secret verification and end-to-end product smoke remain required before launch claims. |
 | Git artifact hygiene | Pass. Build outputs, `.next`, `dist`, coverage, node modules, and local env files are ignored and not tracked. |
-| Production readiness | Blocked for production, improved for staging. CubidDev migrations and OIDC staging are live, but production still requires separate issuer/secrets, production Supabase delivery, SDK sync, TCOIN/client seeding, Vault/runtime secret verification, and full end-to-end smoke tests. |
+| Production readiness | Blocked for production, improved for staging. CubidDev delivery automation and OIDC staging are live, and PR #166 completed the repo-side flexible messaging and legacy API-key cleanup work. Production still requires protected hosted migration apply for the newest migrations, flexible messaging Vault/runtime secret verification, full hosted smoke tests, separate production issuer/secrets, SDK sync, and production Supabase delivery evidence. |

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -6673,6 +6673,38 @@ page blank screen caused by the browser Firebase configuration guard.
 
 - deploy the fix and rerun the hosted ClearPass Dashboard OIDC smoke
 
+### session: v217
+
+- timestamp: 2026-05-16T05:14:28Z
+- agent: **OpenAI Codex**
+- branch: **codex/post-166-status-and-messaging-smoke**
+- head: **`eade36e`**
+- session name: **Reconcile post-166 repo status**
+
+#### Objective
+
+Update repo status truth after PR #166 merged the flexible messaging MVP,
+Vercel app-root cleanup, hosted OIDC smoke fixes, and guarded legacy
+`dapps.apikey` removal.
+
+#### Actions Taken
+
+- updated `agent-context/repo-status.md` to mark `C04.1.1` as completed rather
+  than intentionally pending
+- clarified that PR #166 added newer hosted migrations whose protected apply
+  and smoke evidence are still separate launch-readiness work
+- kept the production-readiness status conservative until flexible messaging
+  Vault/runtime secrets and hosted smoke checks are verified
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- run the hosted flexible messaging smoke checklist from
+  `docs/engineering/flexible-messaging-operations.md`
+
 ### session: v216
 
 - timestamp: 2026-05-16T02:38:19Z

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -6705,6 +6705,38 @@ Vercel app-root cleanup, hosted OIDC smoke fixes, and guarded legacy
 - run the hosted flexible messaging smoke checklist from
   `docs/engineering/flexible-messaging-operations.md`
 
+### session: v218
+
+- timestamp: 2026-05-16T05:18:23Z
+- agent: **OpenAI Codex**
+- branch: **codex/post-166-status-and-messaging-smoke**
+- head: **`3c3783b`**
+- session name: **Fix ClearPass hosted migration apply blocker**
+
+#### Objective
+
+Unblock protected CubidDev migration apply so the flexible messaging hosted
+smoke checklist can proceed against the actual deployed schema.
+
+#### Actions Taken
+
+- ran the protected Supabase migration workflow in `check` mode and confirmed
+  five pending migrations on CubidDev
+- ran the protected `apply` workflow and found it failed on
+  `20260509183000_clearpass_verify_stamp.sql`
+- patched the ClearPass scoring seed migration to handle both schema shapes:
+  use quoted `"is_GP_replacement"` when present, otherwise omit the optional
+  legacy Gitcoin Passport replacement column
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- push the migration fix, rerun the protected Supabase apply workflow, then
+  continue the hosted flexible messaging smoke checklist
+
 ### session: v216
 
 - timestamp: 2026-05-16T02:38:19Z

--- a/supabase/migrations/20260509183000_clearpass_verify_stamp.sql
+++ b/supabase/migrations/20260509183000_clearpass_verify_stamp.sql
@@ -78,27 +78,61 @@ on conflict (id) do update set
   short_description = excluded.short_description,
   "Notes" = excluded."Notes";
 
-insert into public.stampscores_available (
-  schema_id,
-  stamptype_id,
-  is_simple_stamp,
-  description,
-  criteria,
-  is_GP_replacement,
-  score
-)
-select
-  schemas.id,
-  71,
-  true,
-  'High-value ClearPass third-party KYC/personhood verification.',
-  'Active clearpass_verify stamp created from a signed ClearPass completion token.',
-  false,
-  25
-from public.stampscore_schemas schemas
-where not exists (
-  select 1
-  from public.stampscores_available existing
-  where existing.schema_id = schemas.id
-    and existing.stamptype_id = 71
-);
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'stampscores_available'
+      and column_name = 'is_GP_replacement'
+  ) then
+    insert into public.stampscores_available (
+      schema_id,
+      stamptype_id,
+      is_simple_stamp,
+      description,
+      criteria,
+      "is_GP_replacement",
+      score
+    )
+    select
+      schemas.id,
+      71,
+      true,
+      'High-value ClearPass third-party KYC/personhood verification.',
+      'Active clearpass_verify stamp created from a signed ClearPass completion token.',
+      false,
+      25
+    from public.stampscore_schemas schemas
+    where not exists (
+      select 1
+      from public.stampscores_available existing
+      where existing.schema_id = schemas.id
+        and existing.stamptype_id = 71
+    );
+  else
+    insert into public.stampscores_available (
+      schema_id,
+      stamptype_id,
+      is_simple_stamp,
+      description,
+      criteria,
+      score
+    )
+    select
+      schemas.id,
+      71,
+      true,
+      'High-value ClearPass third-party KYC/personhood verification.',
+      'Active clearpass_verify stamp created from a signed ClearPass completion token.',
+      25
+    from public.stampscore_schemas schemas
+    where not exists (
+      select 1
+      from public.stampscores_available existing
+      where existing.schema_id = schemas.id
+        and existing.stamptype_id = 71
+    );
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- Reconciles repo status after PR #166 so C04.1.1 is no longer described as pending.
- Fixes the ClearPass stamp migration so hosted apply tolerates CubidDev schema drift around the optional legacy `is_GP_replacement` column.
- Records the protected migration check/apply blocker in the session log.

## Objective
Unblock the protected CubidDev migration apply needed before the flexible messaging hosted smoke checklist can run.

## Changes
- `agent-context/repo-status.md` now reflects that PR #166 completed the repo-side flexible messaging and legacy dapp API-key cleanup work, while hosted apply/smoke remains launch-readiness work.
- `20260509183000_clearpass_verify_stamp.sql` now conditionally includes quoted `"is_GP_replacement"` only when the column exists, and otherwise seeds ClearPass score rows without that optional legacy column.
- Session log entries capture the status reconciliation and the failed protected apply evidence.

## Validation
- `git diff --check`
- Protected Supabase `check` workflow on `dev` confirmed pending migrations.
- Protected Supabase `apply` workflow on `dev` failed before this patch on missing `stampscores_available.is_gp_replacement`, which this PR addresses.

## Reviewer Notes
Review the migration patch first. It is intentionally defensive because hosted CubidDev no longer has the optional legacy scoring column even though the baseline remote schema snapshot includes it quoted.

## Follow-ups
- Merge this to `dev`.
- Rerun the protected Supabase apply workflow against CubidDev.
- Continue the flexible messaging hosted smoke checklist once migrations and Vault/runtime secrets are verified.
