### PR TITLE
[codex] record hosted messaging smoke status

### DIFF
--- a/agent-context/repo-status.md
+++ b/agent-context/repo-status.md
@@ -1,6 +1,6 @@
 # Repo Status
 
-Last updated: 2026-05-16T05:18:00Z
+Last updated: 2026-05-16T05:30:39Z
 
 | Requirement | Status |
 | --- | --- |
@@ -15,10 +15,11 @@ Last updated: 2026-05-16T05:18:00Z
 | Testing strategy | Partial. Root scripts run lint, typecheck, test, build, and security checks; some chain placeholder packages still have no real tests. |
 | Local acceptance harness | Partial. Unit/server tests cover core route behavior, but there is no single local end-to-end acceptance harness for Passport, Admin, OIDC, API v3, and SIWC together. |
 | CI contract | Pass for repo and dev/preview delivery. CI runs repo validation on PRs and pushes, and `.github/workflows/supabase-deploy.yml` now provides protected check/apply paths for CubidDev migrations. |
-| Supabase migrations | Pass for CubidDev through the last verified hosted run. `supabase migration list --linked` previously showed local and remote aligned through `20260506093000`; PR #166 added later flexible messaging and `dapps.apikey` cleanup migrations that still need protected hosted apply/smoke evidence before launch claims. |
+| Supabase migrations | Pass for CubidDev. Protected apply run `25953794914` succeeded on 2026-05-16, and follow-up check run `25953809761` reported `Remote database is up to date` with local and remote aligned through `20260515175000`. |
 | Supabase functions | Not applicable. This repo has no `supabase/functions` directory and the linked `CubidDev` project reports no deployed functions. |
 | Supabase deployment workflow | Pass for dev/preview. GitHub environment secrets and reviewer protection were configured, `apply` ran successfully against `CubidDev`, and follow-up `check` mode succeeded. Production would need its own protected environment and approval path. |
 | OIDC staging deployment | Pass. `services/oidc` is deployed to Fly as `cubid-oidc-staging`; `https://staging-id.cubid.me` resolves, has an active Fly certificate, and discovery/JWKS smoke checks pass. |
-| Environment and secrets | Partial. OIDC Fly staging runtime secrets are provisioned, and Supabase dev/preview workflow secrets are configured. Broader Vault/runtime secret verification and end-to-end product smoke remain required before launch claims. |
+| Environment and secrets | Partial. OIDC Fly staging runtime secrets are provisioned, and Supabase dev/preview workflow secrets are configured. Passport Preview(dev) has the core Supabase/Firebase/Passport env names, but no `SMTP_*` or `TELEGRAM_BOT_*` variables were visible through Vercel env listing on 2026-05-16, so full flexible-messaging provider smoke remains blocked until provider secrets are provisioned. |
 | Git artifact hygiene | Pass. Build outputs, `.next`, `dist`, coverage, node modules, and local env files are ignored and not tracked. |
-| Production readiness | Blocked for production, improved for staging. CubidDev delivery automation and OIDC staging are live, and PR #166 completed the repo-side flexible messaging and legacy API-key cleanup work. Production still requires protected hosted migration apply for the newest migrations, flexible messaging Vault/runtime secret verification, full hosted smoke tests, separate production issuer/secrets, SDK sync, and production Supabase delivery evidence. |
+| Hosted flexible messaging smoke | Partial. On 2026-05-16, protected Vercel preview smoke reached `/api/v3/notifications/send`, `/api/v3/notifications/status`, and `/api/notifications/history/list`; each returned structured Passport API envelopes with `X-Request-Id` for malformed, invalid dapp key, or missing Firebase bearer-token paths. Full happy-path smoke is still blocked by missing provider env visibility/secrets and lack of a documented hosted test dapp/user credential bundle. |
+| Production readiness | Blocked for production, improved for staging. CubidDev delivery automation, current migrations, and OIDC staging are live, and PR #166 completed the repo-side flexible messaging and legacy API-key cleanup work. Production still requires flexible messaging provider secret provisioning, full hosted happy-path smoke tests, separate production issuer/secrets, SDK sync, and production Supabase delivery evidence. |

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -6673,6 +6673,47 @@ page blank screen caused by the browser Firebase configuration guard.
 
 - deploy the fix and rerun the hosted ClearPass Dashboard OIDC smoke
 
+### session: v219
+
+- timestamp: 2026-05-16T05:30:39Z
+- agent: **OpenAI Codex**
+- branch: **codex/hosted-messaging-smoke-evidence**
+- head: **`05d1949`**
+- session name: **Record hosted flexible messaging smoke status**
+
+#### Objective
+
+Record the hosted migration and flexible messaging smoke evidence after PR #167
+unblocked the ClearPass migration drift.
+
+#### Actions Taken
+
+- reran protected Supabase `apply` for Preview/CubidDev and confirmed it
+  succeeded in run `25953794914`
+- reran protected Supabase `check` and confirmed run `25953809761` reported
+  `Remote database is up to date` through `20260515175000`
+- used Vercel protected preview access to hit flexible messaging API routes and
+  confirmed structured Passport envelopes plus `X-Request-Id` on invalid
+  request, invalid dapp key, and missing Firebase bearer-token paths
+- recorded remaining hosted happy-path blockers: provider secrets are not
+  visible/configured for Passport Preview(dev), and no hosted test
+  dapp/user credential bundle is documented for end-to-end channel and send
+  smoke
+
+#### Verification
+
+- protected Supabase apply run `25953794914`
+- protected Supabase check run `25953809761`
+- Vercel protected preview checks against `/api/v3/notifications/send`,
+  `/api/v3/notifications/status`, and `/api/notifications/history/list`
+- `git diff --check`
+
+#### Follow-up
+
+- provision Preview(dev) `SMTP_*` and `TELEGRAM_BOT_*` runtime secrets
+- document or create a hosted test dapp/user credential bundle for flexible
+  messaging happy-path smoke
+
 ### session: v217
 
 - timestamp: 2026-05-16T05:14:28Z


### PR DESCRIPTION
## Summary
- Records the successful protected CubidDev migration apply/check after PR #167.
- Documents the hosted flexible messaging smoke coverage completed so far.
- Captures the remaining blockers for happy-path provider smoke.

## Objective
Keep repo status aligned with hosted reality after the post-PR #166 migration and smoke pass.

## Changes
- `agent-context/repo-status.md` now says CubidDev is aligned through `20260515175000` with protected run evidence.
- Adds a specific hosted flexible messaging smoke row: send/status/history routes are reachable through Vercel protected preview and return structured request-id envelopes on failure paths.
- Records that full happy-path smoke is blocked by missing Preview(dev) `SMTP_*` / `TELEGRAM_BOT_*` provider secrets and lack of a documented hosted test dapp/user credential bundle.

## Validation
- Protected Supabase apply run `25953794914` succeeded.
- Protected Supabase check run `25953809761` reported `Remote database is up to date`.
- Vercel protected preview smoke reached `/api/v3/notifications/send`, `/api/v3/notifications/status`, and `/api/notifications/history/list`.
- `git diff --check`.

## Reviewer Notes
Docs/status only. This intentionally does not claim flexible messaging production readiness; it records exactly where the hosted smoke stopped.

## Follow-ups
- Add Preview(dev) provider secrets for SMTP and Telegram.
- Create/document a hosted test dapp/user credential bundle.
- Rerun the full happy-path flexible messaging smoke checklist.
