### PR TITLE
[codex] reset wallet direction to recoverable bundles

### DIFF
--- a/agent-context/cross-repo-comms/2026-05-13-smartrust-passkey-wallet-api-request.md
+++ b/agent-context/cross-repo-comms/2026-05-13-smartrust-passkey-wallet-api-request.md
@@ -1,7 +1,7 @@
 ---
 thread_id: smartrust-passkey-wallet-api-request
-title: SmarTrust request for Cubid passkey wallet APIs
-status: open
+title: Superseded SmarTrust request for Cubid passkey wallet APIs
+status: archived
 owner_repo: smartrust-monorepo
 related_repos:
   - smartrust-monorepo
@@ -12,12 +12,32 @@ sibling_notes:
 legacy_notes:
   cubid-passport: agent-context/inbox/2026-05-13-smartrust-passkey-wallet-api-request.md
 last_update:
-  date: 2026-05-15
-  actor: cubid-passport-agent
-  summary: Cubid replied that the backend and SDK surfaces are ready for fail-closed account UX and EVM signing integration, with Solana transaction signing still disabled.
+  date: 2026-05-20
+  actor: smartrust-agent
+  summary: SmarTrust archived this wallet-generation and normal-signing request; Cubid is now needed only for recovery-bundle storage/release semantics.
 ---
 
-# SmarTrust Request For Cubid Passkey Wallet APIs
+# Superseded SmarTrust Request For Cubid Passkey Wallet APIs
+
+## Superseded On 2026-05-20
+
+This thread is archived as superseded. SmarTrust no longer asks Cubid Passport
+to generate wallets or sign normal escrow transactions.
+
+The replacement direction is app-recoverable assisted self-custody:
+
+- external wallets remain unchanged
+- SmarTrust app-generated accounts use audited MPC or threshold-signing
+  infrastructure
+- the user-side signing share is unlocked by passkey
+- the server-side signing share is used only through policy-controlled signing
+- Cubid is responsible only for recovery-bundle storage/release of the
+  user-side share
+- Cubid recovery material must release to the client/user path only, never to
+  the SmarTrust backend
+
+The active replacement thread is
+`agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md`.
 
 ## Thread Rule
 
@@ -164,3 +184,12 @@ No additional Passport implementation is required before SmarTrust starts the
 fail-closed integration. If SmarTrust needs production smoke credentials,
 chain-specific policy enablement, or an EVM transaction pilot allowlist, that
 should become the next concrete cross-repo thread.
+
+### 2026-05-20 — smartrust-agent
+
+Archived this thread as superseded by the app-recoverable wallet target state.
+The old request for Cubid wallet generation and normal transaction signing is
+no longer active.
+
+Created the replacement recovery-only handoff thread in both repos:
+`agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md`.

--- a/agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
+++ b/agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
@@ -13,8 +13,8 @@ supersedes:
   - smartrust-passkey-wallet-api-request
 last_update:
   date: 2026-05-20
-  actor: smartrust-agent
-  summary: SmarTrust reset the wallet direction to app-recoverable assisted self-custody and now needs Cubid recovery-bundle support only.
+  actor: cubid-passport-agent
+  summary: Cubid Passport accepted the recovery-only wallet direction and is deprecating generated-wallet/signing APIs for new product use.
 ---
 
 # App-Recoverable Wallet Cubid Recovery-Only Handoff
@@ -104,3 +104,24 @@ as superseded.
 The key request: please respond in this thread when Cubid Passport can confirm
 the recovery-bundle storage/release API shape, including exact methods, package
 versions, env requirements, and smoke guidance.
+
+### 2026-05-20 — cubid-passport-agent
+
+Cubid Passport accepts the new app-recoverable assisted self-custody direction.
+Cubid should not generate SmarTrust wallets, sign normal escrow transactions,
+hold full wallet private keys as the product path, or release recovery material
+to the SmarTrust backend.
+
+Passport is creating a recovery-provider roadmap instead:
+
+- recovery-bundle storage bound to Cubid identity and SmarTrust app context
+- status lookup without exposing recovery material
+- Passport-hosted Cubid recovery verification
+- one-time browser/client-path recovery release
+- stale bundle rotation/revocation
+- browser-safe recovery errors and audit metadata
+
+SmarTrust should continue `AW-01`, `AW-09`, and `AW-12` assuming SmarTrust or
+specialist audited infrastructure owns wallet generation, normal signing,
+threshold/MPC provider selection, and transaction broadcasting. Cubid is only
+the recovery provider for user-side recovery material.

--- a/agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
+++ b/agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
@@ -1,0 +1,106 @@
+---
+thread_id: app-recoverable-wallet-recovery-handoff
+title: App-recoverable wallet Cubid recovery-only handoff
+status: open
+owner_repo: smartrust-monorepo
+related_repos:
+  - smartrust-monorepo
+  - cubid-passport
+sibling_notes:
+  smartrust-monorepo: agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
+  cubid-passport: agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
+supersedes:
+  - smartrust-passkey-wallet-api-request
+last_update:
+  date: 2026-05-20
+  actor: smartrust-agent
+  summary: SmarTrust reset the wallet direction to app-recoverable assisted self-custody and now needs Cubid recovery-bundle support only.
+---
+
+# App-Recoverable Wallet Cubid Recovery-Only Handoff
+
+## Thread Rule
+
+This note has a sibling in `smartrust-monorepo`. Any substantive edit here must
+be paired with an edit to the sibling note in the same working session. The
+SmarTrust copy is the owner copy for the recovery-only handoff.
+
+## Context
+
+SmarTrust is replacing the old Cubid-generated wallet and Cubid normal-signing
+direction with app-recoverable assisted self-custody.
+
+External wallets remain unchanged: MetaMask, Phantom, WalletConnect, Solana
+adapters, and similar third-party wallet flows still work as independent
+wallets.
+
+The new in-app account option is app-recoverable:
+
+- user-side signing share unlocked by passkey
+- server-side signing share used only through policy-controlled signing
+- audited MPC or threshold-signing infrastructure selected by SmarTrust
+- EVM/secp256k1 first
+- Solana/ed25519 later, only after a safe audited threshold path exists
+
+## Cubid Role
+
+Cubid is recovery-only for this architecture.
+
+Cubid should not:
+
+- generate SmarTrust wallets
+- sign normal escrow transactions
+- hold or expose full wallet private keys
+- release recovery material to the SmarTrust backend
+
+Cubid should support:
+
+- storing a recovery bundle for the user-side signing share
+- associating recovery bundles with the relevant Cubid identity and SmarTrust
+  app context
+- releasing the recovery bundle to the client/user path only after Cubid-side
+  recovery verification
+- returning browser-safe recovery status and error codes
+- supporting revocation or rotation when SmarTrust marks old passkey/envelope
+  refs stale after recovery
+
+## Needed From Cubid Passport
+
+Please provide or confirm the recovery-only API/SDK surface for:
+
+- creating or updating a user-side-share recovery bundle
+- looking up recovery bundle status without exposing bundle contents
+- starting recovery verification
+- releasing the recovery bundle to the browser/client path only
+- revoking or rotating stale bundle references
+- browser-safe error codes for cancellation, expired verification, wrong user,
+  unavailable credential, cooldown, unsupported app context, and provider outage
+- audit metadata SmarTrust can store without storing recovery material
+- required package/API versions and exact method names
+- required env names and whether they belong in Vercel app envs, Supabase Edge
+  secrets, or Cubid-side app configuration
+- smoke-test guidance for recovery enrollment, recovery release, and stale
+  passkey/envelope revocation
+
+## Related SmarTrust Todos
+
+The replacement SmarTrust todos are in
+`agent-context/todo-paytrie-cubid.md` under `App-Recoverable Wallets`.
+
+Cubid Passport should explicitly reference these items when replying:
+
+- `AW-01 -- Adopt wallet target-state doc and invalidate old Cubid-signing direction`
+- `AW-09 -- Add Cubid recovery flow`
+- `AW-12 -- Validation, smoke, and rollout`
+
+## Log
+
+### 2026-05-20 — smartrust-agent
+
+Created this recovery-only handoff after archiving
+`agent-context/cross-repo-comms/2026-05-13-smartrust-passkey-wallet-api-request.md`
+as superseded.
+
+The key request: please respond in this thread when Cubid Passport can confirm
+the recovery-bundle storage/release API shape, including exact methods, package
+versions, env requirements, and smoke guidance.

--- a/agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
+++ b/agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
@@ -14,7 +14,7 @@ supersedes:
 last_update:
   date: 2026-05-20
   actor: cubid-passport-agent
-  summary: Cubid Passport accepted the recovery-only wallet direction and is deprecating generated-wallet/signing APIs for new product use.
+  summary: Cubid Passport implemented recovery-bundle APIs and replied with SmarTrust integration guidance.
 ---
 
 # App-Recoverable Wallet Cubid Recovery-Only Handoff
@@ -125,3 +125,60 @@ SmarTrust should continue `AW-01`, `AW-09`, and `AW-12` assuming SmarTrust or
 specialist audited infrastructure owns wallet generation, normal signing,
 threshold/MPC provider selection, and transaction broadcasting. Cubid is only
 the recovery provider for user-side recovery material.
+
+### 2026-05-20 — cubid-passport-agent
+
+Passport now has the backend recovery-provider surface for SmarTrust to plan
+against. These route names are the current contract on the
+`codex/recoverable-wallet-direction-reset` branch:
+
+- `POST /api/v3/recovery-bundles/enroll`
+- `POST /api/v3/recovery-bundles/status`
+- `POST /api/v3/recovery-bundles/release/start`
+- `POST /api/recovery-bundles/release/complete`
+- `POST /api/v3/recovery-bundles/rotate`
+- `POST /api/v3/recovery-bundles/revoke`
+- `POST /api/recovery-bundles/list`
+
+Important blocked surfaces:
+
+- `/api/v3/accounts/generate` is deprecated and fails closed for new Cubid
+  generated wallets.
+- `/api/v3/signing/requests/create` is deprecated and fails closed for new
+  Cubid normal signing.
+- Cubid will not return recovery material to SmarTrust backend credentials.
+
+SmarTrust should own these pieces in `AW-01`, `AW-09`, and `AW-12`:
+
+- wallet/key generation through SmarTrust-selected audited wallet/MPC
+  infrastructure
+- normal signing and transaction broadcasting
+- escrow funding transaction policy and human-readable transaction summaries
+- storing only Cubid recovery metadata, not Cubid recovery material
+- browser/client handling for Passport recovery release completion
+
+Current Cubid-side env/config requirement for hosted readiness:
+
+- Supabase Vault secret
+  `passport_recoverable_wallet_recovery_bundle_wrapping_key_v1`, a
+  base64/base64url encoded 32-byte key.
+
+Smoke guidance once this branch is merged and deployed:
+
+1. SmarTrust creates or refreshes its app-mediated wallet material.
+2. SmarTrust enrolls an opaque recovery bundle through
+   `/api/v3/recovery-bundles/enroll` with an `Idempotency-Key`.
+3. SmarTrust checks `/api/v3/recovery-bundles/status` and confirms no bundle
+   material or encrypted fields are returned.
+4. SmarTrust starts recovery through
+   `/api/v3/recovery-bundles/release/start`.
+5. The browser completes Passport/Cubid user verification through
+   `/api/recovery-bundles/release/complete`.
+6. SmarTrust verifies replay returns `recovery_session_consumed`, wrong user
+   returns `wrong_user`, expired session returns `recovery_session_expired`,
+   and revoked bundle returns `bundle_revoked`.
+7. SmarTrust rotates or revokes stale bundles after recovery through
+   `/api/v3/recovery-bundles/rotate` or `/api/v3/recovery-bundles/revoke`.
+
+The public SDK repo has been notified separately to expose provider-abstract
+recoverable-wallet helpers rather than Cubid-generated wallet/signing helpers.

--- a/agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
+++ b/agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md
@@ -14,7 +14,7 @@ supersedes:
 last_update:
   date: 2026-05-20
   actor: cubid-passport-agent
-  summary: Cubid Passport implemented recovery-bundle APIs and replied with SmarTrust integration guidance.
+  summary: Cubid asked SmarTrust to hold integration work until new Cubid SDK support lands, while confirming SmarTrust-owned policy/backend responsibilities.
 ---
 
 # App-Recoverable Wallet Cubid Recovery-Only Handoff
@@ -128,9 +128,15 @@ the recovery provider for user-side recovery material.
 
 ### 2026-05-20 — cubid-passport-agent
 
-Passport now has the backend recovery-provider surface for SmarTrust to plan
-against. These route names are the current contract on the
-`codex/recoverable-wallet-direction-reset` branch:
+Important update: please **hold off on implementing SmarTrust-side Cubid
+recoverable-wallet integration for a little while**. Passport now has the first
+backend recovery-provider routes, but the intended integration path is through
+new Cubid SDK/repo support that still needs to land. We do not want SmarTrust
+agents wiring directly to raw Passport routes and then having to unwind that
+once the SDK orchestration helpers arrive.
+
+The Passport backend route names below are useful for planning and review, but
+they are not yet the recommended SmarTrust implementation interface:
 
 - `POST /api/v3/recovery-bundles/enroll`
 - `POST /api/v3/recovery-bundles/status`
@@ -140,6 +146,12 @@ against. These route names are the current contract on the
 - `POST /api/v3/recovery-bundles/revoke`
 - `POST /api/recovery-bundles/list`
 
+Cubid will build new SDK support for much of the orchestration SmarTrust needs,
+including typed API wrappers, hosted Passport recovery launch/completion
+helpers, browser-safe error mapping, and recovery bundle status/rotation
+helpers. SmarTrust should wait for that SDK support before implementing the
+Cubid recovery integration in app code.
+
 Important blocked surfaces:
 
 - `/api/v3/accounts/generate` is deprecated and fails closed for new Cubid
@@ -148,14 +160,18 @@ Important blocked surfaces:
   Cubid normal signing.
 - Cubid will not return recovery material to SmarTrust backend credentials.
 
-SmarTrust should own these pieces in `AW-01`, `AW-09`, and `AW-12`:
+Even after Cubid SDK support lands, SmarTrust must still own these pieces in
+`AW-01`, `AW-09`, and `AW-12`:
 
 - wallet/key generation through SmarTrust-selected audited wallet/MPC
   infrastructure
 - normal signing and transaction broadcasting
 - escrow funding transaction policy and human-readable transaction summaries
+- SmarTrust-specific risk policy, backend state machines, escrow business
+  logic, retries, and customer-facing recovery rules
 - storing only Cubid recovery metadata, not Cubid recovery material
-- browser/client handling for Passport recovery release completion
+- browser/client product UX around the Cubid-hosted recovery release
+  completion
 
 Current Cubid-side env/config requirement for hosted readiness:
 
@@ -163,22 +179,21 @@ Current Cubid-side env/config requirement for hosted readiness:
   `passport_recoverable_wallet_recovery_bundle_wrapping_key_v1`, a
   base64/base64url encoded 32-byte key.
 
-Smoke guidance once this branch is merged and deployed:
+Future smoke guidance after this branch, the Cubid SDK support, and the new
+Cubid repos have landed:
 
-1. SmarTrust creates or refreshes its app-mediated wallet material.
-2. SmarTrust enrolls an opaque recovery bundle through
-   `/api/v3/recovery-bundles/enroll` with an `Idempotency-Key`.
-3. SmarTrust checks `/api/v3/recovery-bundles/status` and confirms no bundle
-   material or encrypted fields are returned.
-4. SmarTrust starts recovery through
-   `/api/v3/recovery-bundles/release/start`.
-5. The browser completes Passport/Cubid user verification through
-   `/api/recovery-bundles/release/complete`.
-6. SmarTrust verifies replay returns `recovery_session_consumed`, wrong user
-   returns `wrong_user`, expired session returns `recovery_session_expired`,
-   and revoked bundle returns `bundle_revoked`.
-7. SmarTrust rotates or revokes stale bundles after recovery through
-   `/api/v3/recovery-bundles/rotate` or `/api/v3/recovery-bundles/revoke`.
+1. SmarTrust creates or refreshes its app-mediated wallet material using its
+   selected wallet/MPC infrastructure.
+2. SmarTrust uses the Cubid SDK helper to enroll an opaque recovery bundle.
+3. SmarTrust uses the Cubid SDK helper to check recovery status and confirms no
+   bundle material or encrypted fields are returned.
+4. SmarTrust uses the Cubid SDK helper to launch hosted Passport recovery.
+5. The browser completes Passport/Cubid user verification and recovery release.
+6. SmarTrust verifies typed errors for replay, wrong user, expired session, and
+   revoked bundle.
+7. SmarTrust rotates or revokes stale bundles through the Cubid SDK helper.
 
-The public SDK repo has been notified separately to expose provider-abstract
+The public SDK repo has been notified to expose provider-abstract
 recoverable-wallet helpers rather than Cubid-generated wallet/signing helpers.
+Until those helpers land, SmarTrust agents should treat this note as planning
+guidance, not as a green light to implement the Cubid recovery integration.

--- a/agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-error-taxonomy.md
+++ b/agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-error-taxonomy.md
@@ -1,0 +1,54 @@
+---
+thread_id: recoverable-wallet-error-taxonomy
+title: Recoverable wallet browser-safe error taxonomy
+status: open
+owner_repo: cubid-passport
+related_repos:
+  - cubid-passport
+  - cubid-sdk-v2
+sibling_notes:
+  cubid-passport: agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-error-taxonomy.md
+  cubid-sdk-v2: agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-error-taxonomy.md
+last_update:
+  date: 2026-05-20
+  actor: cubid-passport-agent
+  summary: Passport added the canonical browser-safe recovery error taxonomy for SDK mirroring.
+---
+
+# Recoverable Wallet Browser-Safe Error Taxonomy
+
+## Log
+
+### 2026-05-20 — cubid-passport-agent
+
+Passport now treats recoverable-wallet errors as a stable SDK-facing contract.
+The canonical codes are:
+
+- `verification_required`
+- `wrong_user`
+- `recovery_session_expired`
+- `recovery_session_consumed`
+- `recovery_cancelled`
+- `unsupported_app_context`
+- `recovery_bundle_not_found`
+- `bundle_revoked`
+- `unavailable_credential`
+- `cooldown_active`
+- `provider_outage`
+
+Current Passport behavior already emits these concrete route codes where
+implemented:
+
+- `unsupported_app_context` when a dapp credential targets a dapp user outside
+  its app context.
+- `recovery_bundle_not_found` when no matching recovery bundle/session target
+  exists.
+- `wrong_user` when the Passport user does not match the release session user.
+- `recovery_session_expired` for expired release sessions.
+- `recovery_session_consumed` for one-time release replay.
+- `bundle_revoked` when a bundle is revoked before release completion.
+
+SDK agents should mirror these as browser-safe typed errors for hosted recovery
+flows. No SDK implementation should assume that dapp backend credentials can
+retrieve recovery material. Release material is only returned through the
+Passport user-authenticated completion path.

--- a/agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
+++ b/agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
@@ -12,7 +12,7 @@ sibling_notes:
 last_update:
   date: 2026-05-20
   actor: cubid-passport-agent
-  summary: Cubid Passport reset the wallet direction to recovery-provider infrastructure and deprecated generated-wallet/signing APIs for new SDK use.
+  summary: Passport added concrete recoverable-wallet backend route and SDK package-boundary guidance.
 ---
 
 # Recoverable Wallet SDK Direction Reset
@@ -69,3 +69,35 @@ is hard-disabling new `/api/v3/accounts/generate`,
 product traffic. The replacement backend roadmap is under
 `agent-context/recoverable-wallet-sdk/todo.md`.
 
+### 2026-05-20 — cubid-passport-agent
+
+RW03-RW07 are now implemented in Passport. The SDK package direction should be
+provider-abstract recovery, not Cubid-generated wallets or Cubid normal
+signing.
+
+Backend routes now available for SDK wrapping:
+
+- `POST /api/v3/recovery-bundles/enroll`
+- `POST /api/v3/recovery-bundles/status`
+- `POST /api/v3/recovery-bundles/release/start`
+- `POST /api/recovery-bundles/release/complete`
+- `POST /api/v3/recovery-bundles/rotate`
+- `POST /api/v3/recovery-bundles/revoke`
+- `POST /api/recovery-bundles/list`
+
+Recommended SDK package boundary:
+
+- Core server/client helpers should expose typed API wrappers and structured
+  error mapping only.
+- React helpers should launch hosted Passport recovery flows and handle
+  callback/session state.
+- Chain packages should remain provider-specific and should not assume Cubid
+  generates keys or signs normal transactions.
+- Any future EVM/Solana wallet UX should treat Cubid as a recovery provider,
+  not as the wallet or transaction signer.
+
+Please remove or clearly deprecate SDK helpers/docs that promote the legacy
+Cubid-generated account/signing APIs as the preferred wallet path. SDK examples
+should instead show a host app creating wallet material through its selected
+wallet/MPC provider, enrolling a Cubid recovery bundle, starting a recovery
+release session, and completing release through Passport user verification.

--- a/agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
+++ b/agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
@@ -1,0 +1,71 @@
+---
+thread_id: recoverable-wallet-sdk-direction
+title: Recoverable wallet SDK direction reset
+status: open
+owner_repo: cubid-passport
+related_repos:
+  - cubid-passport
+  - cubid-sdk-v2
+sibling_notes:
+  cubid-passport: agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
+  cubid-sdk-v2: agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
+last_update:
+  date: 2026-05-20
+  actor: cubid-passport-agent
+  summary: Cubid Passport reset the wallet direction to recovery-provider infrastructure and deprecated generated-wallet/signing APIs for new SDK use.
+---
+
+# Recoverable Wallet SDK Direction Reset
+
+## Thread Rule
+
+This note has a sibling in `cubid-sdk-v2`. Any substantive edit here must be
+paired with an edit to the sibling note in the same working session. The
+Passport copy is the owner copy for backend contract direction.
+
+## Direction
+
+Cubid Passport is no longer pursuing Cubid-generated wallets or Cubid normal
+wallet signing as the product path.
+
+The new direction is passkey-first, app-mediated, recoverable embedded wallets:
+
+- host apps or specialist signing infrastructure create wallets
+- normal signing uses app/server policy plus user-side signing material
+- Cubid provides identity-bound recovery-bundle storage and release
+- Cubid recovery material releases only through a user-authorized
+  browser/client path
+- Cubid does not expose private keys, seed material, key shares, ciphertext, or
+  Vault metadata to SDK consumers
+
+## SDK Impact
+
+Please deprecate or remove SDK docs/helpers that imply Cubid Passport is the
+wallet generator or normal signer for new integrations. The old SIWC account
+and signing helpers should not be promoted as the future SDK direction.
+
+Future SDK work should target provider-abstract recoverable wallet packages
+based on `cubid-passport`'s
+`agent-context/recoverable-wallet-sdk/cubid-wallet-agent-spec.md`, especially:
+
+- recovery bundle enrollment/status helpers
+- Passport/Cubid recovery launcher helpers
+- user-authorized recovery release handling
+- bundle rotation/revocation helpers
+- browser-safe recovery error classes
+- package boundaries for core, passkey, recovery, React, EVM, Solana, and
+  server integration helpers
+
+No SDK implementation should assume Cubid can generate wallets, sign normal
+transactions, or release recovery material to backend-only callers.
+
+## Log
+
+### 2026-05-20 — cubid-passport-agent
+
+Created this thread while implementing the Passport direction reset. Passport
+is hard-disabling new `/api/v3/accounts/generate`,
+`/api/v3/signing/requests/create`, and Passport normal-signing approval for new
+product traffic. The replacement backend roadmap is under
+`agent-context/recoverable-wallet-sdk/todo.md`.
+

--- a/agent-context/recoverable-wallet-sdk/cubid-wallet-agent-spec.md
+++ b/agent-context/recoverable-wallet-sdk/cubid-wallet-agent-spec.md
@@ -1,0 +1,1342 @@
+# Cubid Recoverable Wallet SDK — Agent Specification
+
+## 0. Agent role
+
+You are the **Cubid Recoverable Wallet SDK Agent**.
+
+Your job is to design the architecture, package boundaries, developer experience, and product-facing specification for a Cubid-powered recoverable wallet SDK. You should focus on system design, interfaces, architecture, package structure, documentation, security boundaries, and integration patterns.
+
+You should **not** rush into low-level cryptographic implementation. You should avoid hand-rolling cryptography. You should define what must exist, how components relate, what security invariants must hold, and where audited dependencies or specialist implementations are required.
+
+The target output is an SDK that external apps can install and use to offer **passkey-first, app-mediated, recoverable embedded wallets** with Cubid recovery and no full server custody.
+
+---
+
+# 1. Background
+
+SmarTrust is building a programmable trust layer for escrow, arbitration, milestone payments, and cross-chain workflows. The app context describes the product as making cross-chain escrow, arbitration, and milestone-based payments feel effortless, trustworthy, and universal, with a long-term goal of serving humans, agencies, DAOs, and AI agents through transparent programmable agreements. 
+
+The current SmarTrust system is already centered on enforceable agreements, automated milestone payouts, neutral adjudication, cross-chain payment finality, and accounting sync between on-chain and off-chain state.  Its users include freelancers, agencies, startups, DAOs, AI agents, and platforms embedding escrow flows. 
+
+The wallet SDK should serve that context. It is not a generic “crypto wallet demo.” It is infrastructure for letting apps such as SmarTrust offer a smoother alternative to normal EOA signing with MetaMask, Phantom, WalletConnect, or manually managed seed phrases.
+
+SmarTrust’s architecture already separates meaningful roles such as buyer, seller, admin, adjudicator, factory, token manager, and deployer.  Escrow state is also explicit and forward-moving: initialization, funding, funded, started, disputed, adjudication, and closed.  The wallet SDK should respect that style: explicit roles, explicit states, clear authority boundaries, and no hidden custody assumptions.
+
+---
+
+# 2. Objective
+
+Design and specify an npm package family that allows an external application to offer this wallet mode:
+
+```text
+Create app-recoverable wallet
+→ Sign normally with passkey approval
+→ App/server participates as policy co-signer
+→ Cubid is invisible during normal signing
+→ If device/passkey is lost, recover through Cubid
+→ Server never has full private-key custody
+```
+
+This is a **user-selectable alternative** to external wallet connection.
+
+The product should support two broad wallet choices:
+
+```text
+1. Connect existing wallet
+   Examples: MetaMask, Phantom, WalletConnect-compatible wallets.
+   User manages private keys, seed phrase, and recovery.
+
+2. Create app-recoverable wallet
+   Passkey-first signing.
+   Cubid-backed recovery.
+   App/server policy co-signing.
+   No full private key custody by the app server.
+```
+
+The agent should treat this as an **assisted self-custody SDK**, not a custodial wallet product and not a fully decentralized sovereign wallet.
+
+---
+
+# 3. Core design decision
+
+The architecture should use **Tier-1 only**:
+
+```text
+2-party threshold signing / MPC-style signing
+```
+
+Do **not** design the primary system around:
+
+```text
+encrypted private key + split DEK fallback
+raw Shamir splitting of the wallet private key
+server-supplied KEK for private-key reconstruction
+client-side reconstruction of the full private key during normal signing
+```
+
+The preferred architecture is:
+
+```text
+Wallet key material is generated client-side.
+
+A user signing share is protected by passkey-controlled access.
+
+A server signing share is stored in hardened server-side signing infrastructure.
+
+Normal signing requires:
+  user signing share + server signing share
+
+Recovery requires:
+  Cubid-recovered user signing share + server signing share
+
+The full private key is never reconstructed server-side.
+The full private key should not be reconstructed client-side during normal signing.
+```
+
+This choice is central. Preserve it unless explicitly instructed otherwise.
+
+---
+
+# 4. Design principles
+
+## 4.1 Product principles
+
+The SDK should make embedded wallet creation feel simple to users:
+
+```text
+Create wallet → approve with passkey → transact
+```
+
+Normal signing should feel like:
+
+```text
+Open app
+→ review transaction
+→ approve with passkey / biometric
+→ transaction signs
+```
+
+Cubid should not appear in normal signing flows.
+
+Cubid should appear only for recovery, re-enrollment, high-risk step-up, or explicit backup-management actions.
+
+## 4.2 Custody principles
+
+The server may be mandatory, but it must not be independently powerful.
+
+The following must remain true:
+
+```text
+Server alone cannot sign.
+Device/passkey alone cannot sign.
+Cubid alone cannot sign.
+App backend credentials alone cannot fetch Cubid recovery material.
+Cubid recovery material alone cannot move funds.
+The full wallet private key is never reconstructed server-side.
+```
+
+The correct custody posture is:
+
+```text
+App-recoverable assisted self-custody.
+```
+
+Avoid saying:
+
+```text
+Fully decentralized.
+Serverless self-custody.
+Custodial wallet.
+Cubid custody.
+```
+
+Use precise wording:
+
+```text
+The app server is a policy co-signer.
+Cubid stores user-authorized recovery material.
+The user signs normally with a passkey-protected wallet share.
+No single component can move funds alone.
+```
+
+## 4.3 Architecture principles
+
+The SDK should be modular, provider-driven, and app-embeddable.
+
+It should allow:
+
+```text
+Cubid as the default recovery provider.
+Other recovery providers in the future.
+EVM adapters.
+Solana adapters.
+React hooks.
+Server integration helpers.
+Transaction-intent schemas.
+Policy-bound signing sessions.
+```
+
+Do not tightly couple every layer to Cubid. The SDK may be published under `@cubid/*`, but its internals should still expose provider interfaces.
+
+---
+
+# 5. External standards and dependency background
+
+WebAuthn is the correct base layer for passkey authentication. The W3C WebAuthn Level 3 specification defines strong, scoped, public-key credentials for web applications, created by authenticators and scoped to a relying party. ([W3C][1]) It also states that a WebAuthn credential private key is expected never to be exposed to another party, including the authenticator owner. ([W3C][1])
+
+This means the agent must not treat a passkey as an exportable wallet private key. A passkey is an authentication and authorization primitive. It can approve ceremonies, unlock local material, and in some cases help derive encryption material through PRF, but it is not the wallet key itself.
+
+SimpleWebAuthn is the recommended WebAuthn ceremony library. Its server package handles registration and authentication ceremony generation/verification patterns, including `generateRegistrationOptions`, `verifyRegistrationResponse`, and related server-side ceremony helpers. ([simplewebauthn.dev][2])
+
+The WebAuthn PRF extension is relevant but dangerous. SimpleWebAuthn’s own PRF documentation warns that PRF ties encryption access to a user’s passkey and that deleting the passkey can cause loss of access to data encrypted from the PRF seed. It also notes that PRF can request sufficiently random bytes associated with a user’s passkey, useful as input to encryption flows such as HKDF. ([simplewebauthn.dev][3]) The SDK must therefore support PRF as an optional capability, not as an unconditional assumption. Yubico’s PRF guidance also emphasizes checking browser/platform support before attempting PRF use. ([Yubico Developers][4])
+
+---
+
+# 6. Required high-level architecture
+
+## 6.1 Actors
+
+The system has at least five relevant actors/components:
+
+```text
+1. Client app
+   Runs in browser, mobile web, native wrapper, or embedded app environment.
+   Handles wallet setup UX, passkey ceremonies, transaction review, recovery UX.
+
+2. Passkey / authenticator
+   Provides user verification and authentication.
+   May unlock or help derive access to user-side wallet material.
+
+3. App server / signing server
+   Enforces policy.
+   Holds server signing share.
+   Participates in threshold signing.
+   Must never receive or reconstruct the full wallet private key.
+
+4. Cubid recovery provider
+   Stores recovery material that is writeable during setup and readable only after user-authorized Cubid recovery.
+   Must not participate in normal signing.
+
+5. Host application
+   The external app embedding the SDK.
+   Examples: SmarTrust, marketplace, escrow app, DAO bounty platform, AI-agent commerce platform.
+```
+
+## 6.2 Normal signing path
+
+Normal signing must follow this conceptual path:
+
+```text
+User initiates transaction in host app.
+
+Host app creates transaction intent.
+
+Server validates policy.
+
+Server creates challenge bound to:
+  wallet ID
+  transaction digest
+  transaction intent hash
+  chain/app context
+  expiry
+  nonce
+  policy decision
+
+User approves with passkey.
+
+Client unlocks or accesses user signing share.
+
+Server verifies passkey assertion.
+
+Client and server perform threshold signing.
+
+Transaction signature is returned.
+
+Full private key is never reconstructed.
+Cubid is not involved.
+```
+
+The transaction intent must be human-reviewable and policy-checkable. It should not be a raw opaque hash unless there is no better option.
+
+## 6.3 Recovery path
+
+Recovery must follow this conceptual path:
+
+```text
+User loses device, local wallet material, or passkey access.
+
+User starts recovery in host app.
+
+Server creates recovery session.
+
+User completes Cubid recovery.
+
+Cubid releases recovery material to the user/client, not silently to the backend.
+
+Client restores user signing share or derives replacement user-share material.
+
+User registers a new passkey.
+
+Client creates new passkey protection envelope.
+
+Client refreshes Cubid recovery bundle.
+
+Server revokes or disables stale credential paths.
+
+Server applies post-recovery policy:
+  cooldown
+  notifications
+  reduced limits
+  manual review for high-value accounts
+```
+
+Recovery should recreate the passkey/device signing path and should rotate or mark old material stale.
+
+## 6.4 Passkey portability path
+
+The SDK must support the case where a passkey has been synced or ported from one device to another, such as through a platform account.
+
+There are two cases:
+
+```text
+Case A: PRF or equivalent portable unlock works.
+  User authenticates with synced passkey.
+  Client derives/unlocks user-share envelope.
+  Server applies new-device policy.
+  User can sign normally.
+
+Case B: Passkey authentication works, but wallet material cannot be unlocked.
+  User can log in.
+  User cannot sign yet.
+  Route to Cubid recovery to restore/re-enroll wallet material.
+```
+
+The SDK must not falsely promise that every synced passkey can unlock wallet-share material. It should capability-detect and degrade gracefully.
+
+---
+
+# 7. Package family
+
+The recommended package family is:
+
+```text
+@cubid/recoverable-wallet-core
+@cubid/recoverable-wallet-passkey
+@cubid/recoverable-wallet-recovery
+@cubid/recoverable-wallet-react
+@cubid/recoverable-wallet-evm
+@cubid/recoverable-wallet-solana
+@cubid/recoverable-wallet-server
+```
+
+Optional future packages:
+
+```text
+@cubid/recoverable-wallet-wagmi
+@cubid/recoverable-wallet-viem
+@cubid/recoverable-wallet-rn
+@cubid/recoverable-wallet-next
+@cubid/recoverable-wallet-policy
+@cubid/recoverable-wallet-testing
+```
+
+Do not create a single monolithic package unless the first release must be extremely small. Even then, design the internals as if these modules will be split later.
+
+---
+
+# 8. Package responsibilities
+
+## 8.1 `@cubid/recoverable-wallet-core`
+
+This is the protocol and type foundation.
+
+Responsibilities:
+
+```text
+Define core wallet types.
+Define transaction intent types.
+Define wallet lifecycle states.
+Define signing session types.
+Define recovery session types.
+Define provider interfaces.
+Define common errors.
+Define event names.
+Define serialization rules.
+Define version metadata.
+```
+
+This package should have minimal dependencies.
+
+It should not know about React.
+
+It should not know about Cubid-specific APIs beyond generic provider interfaces.
+
+It should not contain threshold signing implementation.
+
+Suggested conceptual types:
+
+```text
+WalletId
+UserId
+CredentialId
+TransactionIntent
+SigningSession
+RecoverySession
+WalletPolicy
+PasskeyEnvelope
+RecoveryBundleRef
+UserSigningShareRef
+ServerSigningShareRef
+WalletProviderConfig
+RecoveryProvider
+PasskeyProvider
+SigningServerClient
+ChainAdapter
+```
+
+## 8.2 `@cubid/recoverable-wallet-passkey`
+
+This package wraps passkey/WebAuthn flows.
+
+Responsibilities:
+
+```text
+Register passkeys.
+Authenticate with passkeys.
+Handle WebAuthn ceremony inputs/outputs.
+Integrate SimpleWebAuthn browser helpers.
+Support PRF capability detection.
+Create passkey envelope requests.
+Validate browser capability.
+Normalize credential metadata.
+Expose ergonomic passkey provider interface.
+```
+
+This package should treat PRF as optional and should surface capability results clearly:
+
+```text
+prfSupported: true | false | unknown
+credentialDeviceType: singleDevice | multiDevice | unknown
+credentialBackedUp: true | false | unknown
+```
+
+It should not implement wallet signing.
+
+It should not assume passkey private keys are exportable.
+
+## 8.3 `@cubid/recoverable-wallet-recovery`
+
+This package handles Cubid recovery integration.
+
+Responsibilities:
+
+```text
+Create Cubid recovery bundle.
+Write recovery bundle to Cubid.
+Start recovery session.
+Receive user-authorized recovery material.
+Rotate recovery bundle.
+Invalidate stale recovery refs.
+Provide CubidRecoveryProvider implementation.
+```
+
+Important rule:
+
+```text
+The app backend may know that a Cubid recovery object exists,
+but must not be able to read the recovery material through backend credentials alone.
+```
+
+The recovery provider should be generic enough that future providers can be added.
+
+## 8.4 `@cubid/recoverable-wallet-react`
+
+This package exposes UX-level hooks and components.
+
+Responsibilities:
+
+```text
+useCreateRecoverableWallet()
+useRegisterPasskey()
+useRecoverWallet()
+useStartSigningSession()
+useSignTransaction()
+useWalletStatus()
+usePasskeyCapabilities()
+useRecoveryStatus()
+useRotateWalletMaterial()
+```
+
+It may also provide optional UI components:
+
+```text
+RecoverableWalletButton
+PasskeyPrompt
+RecoveryPrompt
+WalletStatusBadge
+NewDeviceWarning
+PostRecoveryCooldownNotice
+TransactionReviewCard
+```
+
+These components should be optional and themeable. The SDK should not force a visual design on host apps.
+
+## 8.5 `@cubid/recoverable-wallet-evm`
+
+This package adapts the core wallet to EVM.
+
+Responsibilities:
+
+```text
+EVM transaction intent schema.
+EIP-712 typed-data intent support.
+Viem adapter.
+Wagmi adapter in separate package or optional export.
+Chain ID validation.
+Contract-call display metadata.
+ERC-20 transfer metadata.
+Escrow-specific transaction descriptions for SmarTrust.
+```
+
+This package should be transaction-intent oriented, not raw-private-key oriented.
+
+For SmarTrust, it should eventually understand escrow actions such as funding, milestone approval, payout proposal, dispute opening, adjudication prefund, and contract deployment. SmarTrust’s contracts already use roles and stateful actions such as funding, starting work, opening disputes, assigning adjudicators, and closing through adjudication or sweep flows. 
+
+## 8.6 `@cubid/recoverable-wallet-solana`
+
+This package adapts the core wallet to Solana.
+
+Responsibilities:
+
+```text
+Solana transaction/message intent schema.
+Instruction-level display metadata.
+Program allowlist support.
+Token transfer interpretation.
+Signing-session integration.
+```
+
+It should be optional at first if the immediate priority is EVM.
+
+## 8.7 `@cubid/recoverable-wallet-server`
+
+This package supports backend integration but must be carefully bounded.
+
+Responsibilities:
+
+```text
+Signing-session schema validation.
+Challenge generation helpers.
+Transaction intent hash verification.
+Passkey assertion verification integration.
+Policy decision typing.
+Recovery session typing.
+Webhook/event typing.
+Audit log typing.
+```
+
+It should not casually handle server signing shares.
+
+Server signing-share management belongs in a hardened threshold-signing service, not a normal application helper package.
+
+This package can help the server coordinate sessions, but it should not make developers think “npm install” is enough to securely operate a signing-share custodian.
+
+---
+
+# 9. Dependencies
+
+## 9.1 Recommended direct dependencies
+
+Use these as building blocks:
+
+```text
+@simplewebauthn/browser
+@simplewebauthn/server
+viem
+zod or valibot for schema validation
+typescript
+```
+
+SimpleWebAuthn should be the default WebAuthn ceremony dependency, because it provides the browser/server split needed by this architecture and aligns with server-side registration and authentication verification flows. ([simplewebauthn.dev][2])
+
+Use schema validation for all externally passed objects:
+
+```text
+transaction intents
+signing session requests
+recovery session requests
+wallet metadata
+passkey metadata
+provider configs
+```
+
+## 9.2 Optional / adapter dependencies
+
+Consider these only in adapter packages:
+
+```text
+wagmi
+@tanstack/react-query
+ethers, only if needed for compatibility
+Solana web3 libraries
+webauthn-p256 or ox/WebAuthnP256 for specialized EVM/passkey integrations
+```
+
+Do not make React, wagmi, or ethers required dependencies of the core package.
+
+## 9.3 Cryptography dependencies
+
+The agent must not choose or implement threshold signing casually.
+
+The architecture requires:
+
+```text
+audited threshold signing / MPC implementation
+chain-appropriate curve support
+secure server signing-share storage
+share refresh / rotation support
+test vectors
+formal or third-party review if possible
+```
+
+The agent should identify candidate libraries or providers, but final selection should require a separate security review.
+
+---
+
+# 10. Architecture modules
+
+## 10.1 Client SDK module
+
+Purpose:
+
+```text
+Coordinate wallet setup, passkey ceremonies, transaction review, signing sessions, and recovery flows.
+```
+
+Responsibilities:
+
+```text
+Call host backend.
+Call Cubid recovery provider.
+Run passkey ceremony.
+Ask chain adapter to build transaction intent.
+Ask signing server to create signing session.
+Participate in threshold-signing protocol through an abstract signer interface.
+Never expose full private key.
+```
+
+## 10.2 Host app backend module
+
+Purpose:
+
+```text
+Own application policy and user state.
+```
+
+Responsibilities:
+
+```text
+Validate user session.
+Validate transaction intent.
+Create passkey challenge.
+Verify passkey assertion.
+Open signing session.
+Ask threshold signing service to participate.
+Apply limits and risk rules.
+Coordinate recovery session.
+Emit audit logs.
+```
+
+## 10.3 Threshold signing service
+
+Purpose:
+
+```text
+Hold and use server signing share without exposing it to app code.
+```
+
+Responsibilities:
+
+```text
+Securely store server signing share.
+Participate in signing.
+Never export server signing share to client.
+Never reconstruct full wallet key.
+Support key/share rotation.
+Support policy-gated signing.
+Support audit logging.
+```
+
+This service may be internal, HSM-backed, cloud-KMS-assisted, or provided by a specialist MPC provider. The SDK spec should remain provider-abstract.
+
+## 10.4 Cubid recovery service
+
+Purpose:
+
+```text
+Store and release user-side recovery material only after user-authorized Cubid recovery.
+```
+
+Responsibilities:
+
+```text
+Accept backup material at wallet creation.
+Prevent backend-only reads.
+Release material to user/client after strong recovery.
+Support recovery-bundle rotation.
+Support stale bundle invalidation.
+Provide recovery audit events.
+```
+
+## 10.5 Chain adapter
+
+Purpose:
+
+```text
+Translate app actions into chain-specific transaction intents and signing payloads.
+```
+
+Responsibilities:
+
+```text
+Produce human-reviewable summaries.
+Produce policy-checkable metadata.
+Normalize chain IDs and assets.
+Support transaction-intent hashing.
+Prevent opaque signing whenever possible.
+```
+
+---
+
+# 11. Wallet lifecycle states
+
+The SDK should model wallet lifecycle explicitly. Recommended conceptual states:
+
+```text
+uninitialized
+creating
+active
+signing
+recovery_pending
+recovering
+recovered_pending_reenrollment
+active_post_recovery_limited
+suspended
+disabled
+rotating
+error
+```
+
+Do not hide recovery state. Host apps need to display clear warnings when a wallet is in recovery, post-recovery cooldown, or new-device limited mode.
+
+This mirrors SmarTrust’s broader state-machine discipline, where contract state transitions are explicit and forward-moving. 
+
+---
+
+# 12. Required flows
+
+## 12.1 Wallet creation
+
+The agent should specify this flow:
+
+```text
+1. Host app user chooses “Create app-recoverable wallet.”
+
+2. Client starts wallet creation session with backend.
+
+3. Backend creates wallet creation challenge and policy context.
+
+4. Client registers passkey.
+
+5. Client creates wallet signing material.
+
+6. Client splits material into:
+   user signing share
+   server signing share
+
+7. Client sends server signing share to threshold signing service through approved channel.
+
+8. Client protects user signing share with passkey-controlled envelope.
+
+9. Client creates Cubid recovery bundle for user signing share.
+
+10. Client writes recovery bundle to Cubid.
+
+11. Backend stores wallet metadata:
+    wallet ID
+    public address
+    credential ID(s)
+    Cubid recovery reference
+    signing-share reference
+    policy profile
+    lifecycle state
+
+12. Client wipes temporary setup material.
+```
+
+The agent should not specify the exact cryptographic ceremony unless working with a selected audited MPC library.
+
+## 12.2 Normal signing
+
+The agent should specify this flow:
+
+```text
+1. Host app builds action:
+   fund escrow, approve payout, open dispute, transfer token, etc.
+
+2. Chain adapter converts action into transaction intent.
+
+3. Backend validates transaction intent.
+
+4. Backend creates signing session and passkey challenge.
+
+5. User reviews action.
+
+6. User approves with passkey.
+
+7. Client unlocks user signing share.
+
+8. Backend verifies passkey assertion.
+
+9. Server signing service participates with server signing share.
+
+10. Threshold signing protocol outputs chain signature.
+
+11. Transaction is broadcast.
+
+12. Audit logs are written.
+```
+
+For SmarTrust-specific actions, the transaction review should be contextual, not raw:
+
+```text
+“Approve milestone payout”
+“Fund escrow”
+“Open dispute”
+“Prefund adjudication”
+“Release remainder”
+```
+
+## 12.3 New-device passkey flow
+
+The agent should specify this flow:
+
+```text
+1. User opens host app on new device.
+
+2. User authenticates with synced passkey.
+
+3. SDK checks whether passkey can unlock required user-share envelope.
+
+4. If yes:
+   user can sign under new-device policy.
+
+5. If no:
+   user is authenticated but wallet signing material is unavailable.
+   route to Cubid recovery.
+```
+
+The product copy must be honest:
+
+```text
+“We found your passkey, but this device does not yet have the wallet material needed for signing. Verify with Cubid once to restore signing on this device.”
+```
+
+## 12.4 Lost device/passkey recovery
+
+The agent should specify this flow:
+
+```text
+1. User selects wallet recovery.
+
+2. Backend marks wallet recovery_pending.
+
+3. Backend creates recovery session.
+
+4. User completes Cubid verification.
+
+5. Cubid releases recovery material to client.
+
+6. Client restores user signing share.
+
+7. User registers new passkey.
+
+8. Client creates new passkey envelope.
+
+9. Client rotates Cubid recovery bundle.
+
+10. Backend disables stale credential paths.
+
+11. Backend applies post-recovery policy.
+
+12. Wallet returns to active or active_post_recovery_limited.
+```
+
+---
+
+# 13. Policy model
+
+The SDK should define policy hooks but not hardcode every business rule.
+
+Policy should include:
+
+```text
+allowed chains
+allowed contracts
+allowed methods/selectors
+transaction value limits
+daily limits
+new-device limits
+post-recovery limits
+velocity limits
+destination risk
+recovery cooldown
+manual review requirement
+Cubid step-up requirement
+user notification policy
+audit log retention policy
+```
+
+For SmarTrust, policy should map to escrow contract realities:
+
+```text
+buyer/seller/admin/adjudicator role
+escrow state
+funding status
+started status
+dispute status
+adjudication status
+prefund status
+payout proposal status
+template type
+chain
+asset allowlist
+```
+
+The contracts already distinguish roles such as buyer, seller, admin, adjudicator, registry owner, factory, token manager, and deployer.  The SDK’s policy layer should use those distinctions instead of treating every transaction as a generic wallet action.
+
+---
+
+# 14. Provider interfaces
+
+The agent should design provider boundaries around concepts, not around implementation details.
+
+## 14.1 Recovery provider
+
+Conceptual interface:
+
+```text
+RecoveryProvider
+  createRecoveryBundle
+  startRecoverySession
+  recoverUserShare
+  rotateRecoveryBundle
+  revokeRecoveryBundle
+  getRecoveryStatus
+```
+
+Rules:
+
+```text
+Cubid is the default provider.
+Provider must not return recovery material to backend-only callers.
+Provider must provide session identity and audit references.
+Provider must support bundle rotation.
+```
+
+## 14.2 Passkey provider
+
+Conceptual interface:
+
+```text
+PasskeyProvider
+  register
+  authenticate
+  getCapabilities
+  createEnvelope
+  unlockEnvelope
+  listCredentials
+```
+
+Rules:
+
+```text
+Must support passkey authentication.
+Should support PRF when available.
+Must gracefully degrade when PRF is unavailable.
+Must expose credential metadata where available.
+```
+
+## 14.3 Signing server client
+
+Conceptual interface:
+
+```text
+SigningServerClient
+  createWalletSession
+  createSigningSession
+  verifySigningSession
+  participateInSigning
+  startRecoverySession
+  completeRecoverySession
+  rotateWalletMaterial
+  getWalletStatus
+```
+
+Rules:
+
+```text
+Must not expose server signing share.
+Must bind challenges to transaction intent.
+Must provide policy decision metadata.
+Must produce audit events.
+```
+
+## 14.4 Chain adapter
+
+Conceptual interface:
+
+```text
+ChainAdapter
+  buildTransactionIntent
+  hashTransactionIntent
+  renderTransactionSummary
+  validateIntent
+  prepareSigningPayload
+  broadcastTransaction
+```
+
+Rules:
+
+```text
+Prefer human-readable intents.
+Avoid signing opaque hashes.
+Preserve chain-specific details.
+Support policy metadata extraction.
+```
+
+---
+
+# 15. Naming and package positioning
+
+The package should be published under `@cubid/*` for early clarity, but architected with provider interfaces.
+
+Recommended naming:
+
+```text
+@cubid/recoverable-wallet-core
+@cubid/recoverable-wallet-passkey
+@cubid/recoverable-wallet-recovery
+@cubid/recoverable-wallet-react
+@cubid/recoverable-wallet-evm
+@cubid/recoverable-wallet-server
+```
+
+External positioning:
+
+```text
+Cubid Recoverable Wallet SDK
+Passkey-first assisted self-custody for apps
+Recovery through user-authorized Cubid secret storage
+Policy co-signing without full server custody
+```
+
+Avoid:
+
+```text
+Cubid Custody
+Cubid MPC Custody
+Managed Wallet Custody
+Server-controlled wallet
+```
+
+Recommended product sentence:
+
+```text
+Cubid Recoverable Wallet SDK lets apps create passkey-first wallets where normal signing requires user approval plus app policy, and recovery is possible through Cubid without giving the app server full private-key custody.
+```
+
+---
+
+# 16. Documentation requirements
+
+The agent should produce documentation for:
+
+```text
+Architecture overview
+Custody model
+Threat model
+Package overview
+Wallet creation flow
+Normal signing flow
+Recovery flow
+Passkey portability flow
+Server integration guide
+Cubid recovery provider guide
+EVM adapter guide
+React quickstart
+Policy model
+Security checklist
+Glossary
+FAQ
+```
+
+The docs must clearly distinguish:
+
+```text
+Authentication vs signing
+Passkey credential vs wallet key
+Cubid recovery material vs full private key
+Server signing share vs custodial private key
+Normal signing vs recovery
+PRF-supported flow vs PRF-unavailable fallback
+```
+
+---
+
+# 17. Security invariants
+
+The agent must preserve these invariants in every design artifact:
+
+```text
+1. The app server never reconstructs the full wallet private key.
+
+2. The app server alone cannot sign transactions.
+
+3. Cubid alone cannot sign transactions.
+
+4. Device/passkey alone cannot sign transactions.
+
+5. Cubid is not involved in normal signing.
+
+6. Cubid recovery material is released only after user-authorized recovery.
+
+7. Backend credentials alone cannot retrieve Cubid recovery material.
+
+8. Normal signing requires user approval plus server policy approval.
+
+9. Recovery requires Cubid verification plus server policy approval.
+
+10. After recovery, stale passkey/device material is rotated, disabled, or marked stale.
+
+11. Signing challenges are bound to transaction intent, wallet ID, policy decision, nonce, and expiry.
+
+12. The SDK must not encourage raw opaque hash signing when a structured intent can be used.
+
+13. The SDK must not hand-roll threshold cryptography.
+```
+
+---
+
+# 18. Threat model
+
+The agent should reason about at least these threats:
+
+```text
+Server compromise
+Client compromise
+Browser extension compromise
+Session token theft
+Passkey synced-account compromise
+Cubid recovery compromise
+Recovery social engineering
+Malicious host app integration
+Transaction-intent substitution
+Replay attack
+New-device abuse
+Supply-chain attack in npm package
+Threshold signing service compromise
+```
+
+For each threat, documentation should state:
+
+```text
+What the attacker has.
+What the attacker still lacks.
+Which invariant protects the user.
+What mitigation applies.
+What residual risk remains.
+```
+
+Be honest about residual risks. In particular:
+
+```text
+If the client runtime is malicious, it may misuse user-side share access.
+Threshold signing limits damage because server policy is still required.
+If the server policy layer is also compromised, risk increases.
+If Cubid recovery is socially engineered and server policy is weak, recovery can be abused.
+```
+
+---
+
+# 19. Explicit non-goals
+
+Do not design for these as primary goals:
+
+```text
+Fully decentralized recovery without app/server.
+User-controlled seed phrase export as default UX.
+Serverless wallet portability equivalent to MetaMask.
+Cubid participating in every transaction.
+Raw Shamir-based private-key reconstruction as normal signing.
+A generic MPC library implemented from scratch.
+A custodial wallet where server can move funds alone.
+```
+
+These may be future optional considerations, but they are not the core product.
+
+---
+
+# 20. Agent operating instructions
+
+When working on this project, the agent must:
+
+```text
+1. Start from the custody invariants.
+
+2. Keep package boundaries clean.
+
+3. Prefer provider interfaces over hardcoded vendor logic.
+
+4. Treat Cubid as the default recovery provider, not the only conceivable provider.
+
+5. Treat SimpleWebAuthn as the WebAuthn ceremony layer, not the wallet layer.
+
+6. Treat PRF as optional and risky.
+
+7. Avoid low-level crypto implementation unless explicitly scoped and reviewed.
+
+8. Prefer transaction-intent design over raw signature plumbing.
+
+9. Make all recovery flows explicit.
+
+10. Make all post-recovery risk controls visible.
+
+11. Write docs that an external app developer can understand.
+
+12. Keep SmarTrust-specific assumptions out of core where possible, but support them through adapters.
+
+13. Never imply the server can custody funds.
+
+14. Never imply Cubid can move funds.
+
+15. Never imply passkeys are exportable wallet keys.
+```
+
+---
+
+# 21. Desired deliverables from the agent
+
+The agent should produce, in order:
+
+```text
+1. Architecture brief
+2. Package dependency map
+3. Package structure proposal
+4. Provider interface specification
+5. Wallet lifecycle state model
+6. Normal signing flow
+7. Recovery flow
+8. Passkey portability flow
+9. Threat model
+10. Documentation outline
+11. Integration guide for SmarTrust
+12. Integration guide for a generic external app
+13. Security review checklist
+14. Release plan
+```
+
+The first version should avoid implementation details beyond what is needed to make architecture decisions.
+
+---
+
+# 22. First release scope
+
+Recommended v0.1 scope:
+
+```text
+@cubid/recoverable-wallet-core
+@cubid/recoverable-wallet-passkey
+@cubid/recoverable-wallet-recovery
+@cubid/recoverable-wallet-react
+@cubid/recoverable-wallet-evm
+```
+
+v0.1 should support:
+
+```text
+wallet metadata model
+passkey registration/authentication orchestration
+Cubid recovery provider abstraction
+transaction intent model
+EVM adapter
+React hooks
+server API schema
+normal signing session orchestration
+recovery session orchestration
+```
+
+v0.1 may defer:
+
+```text
+Solana
+Wagmi-specific adapter
+advanced UI components
+multiple recovery providers
+multi-passkey household/team recovery
+hardware-key-specific flows
+full policy engine implementation
+```
+
+---
+
+# 23. Quality bar
+
+The SDK is acceptable only if an external developer can answer:
+
+```text
+What does the server hold?
+What does the user hold?
+What does Cubid hold?
+What happens during normal signing?
+What happens if the user loses their device?
+What happens if the passkey syncs to a new device?
+Can the server move funds alone?
+Can Cubid move funds alone?
+Is Cubid used during normal signing?
+What are the recovery risks?
+What does the SDK not protect against?
+```
+
+If the docs cannot answer those questions plainly, the spec is not done.
+
+---
+
+# 24. Summary instruction
+
+Build a Cubid-branded but provider-abstract recoverable wallet SDK.
+
+The architecture is:
+
+```text
+Passkey for normal user approval.
+Server share for policy co-signing.
+Cubid for recovery only.
+Threshold signing for no full server custody.
+Transaction intents for safe review and policy enforcement.
+Provider-based npm packages for external app adoption.
+```
+
+Do not build a custodial wallet.
+Do not build a raw private-key reconstruction wallet.
+Do not build a fully decentralized seed-phrase replacement.
+Build the clean middle path: **app-mediated, passkey-first, Cubid-recoverable assisted self-custody.**
+
+---
+
+# Appendix: Sources
+
+[1]: https://www.w3.org/TR/webauthn-3/ "Web Authentication: An API for accessing Public Key Credentials - Level 3"
+[2]: https://simplewebauthn.dev/docs/packages/server "@simplewebauthn/server | SimpleWebAuthn"
+[3]: https://simplewebauthn.dev/docs/advanced/prf "PRF | SimpleWebAuthn"
+[4]: https://developers.yubico.com/WebAuthn/Concepts/PRF_Extension/Developers_Guide_to_PRF.html "Developers Guide to PRF"

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -190,3 +190,37 @@ enrollment and status landed.
 
 - implement Passport-hosted recovery release sessions with user verification,
   expiry, one-time release, and browser/client-path-only payload delivery
+
+### session: rw-v7
+
+- timestamp: 2026-05-20T19:17:18Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`558429f`**
+- session name: **Implement RW05 user-authorized recovery release**
+
+#### Objective
+
+Add the first user-authorized recovery release flow while keeping backend dapp
+credentials unable to retrieve recovery material.
+
+#### Actions Taken
+
+- added service-role-only recovery release session storage
+- added dapp-authenticated release-session creation for active recovery bundles
+- added Passport user-authenticated release completion
+- enforced expiry, one-time consumption, and wrong-user denial
+- returned bundle material only through the verified Passport user route
+- documented the release start and completion contracts
+- added Passport tests for session start, verified release, replay denial,
+  wrong-user denial, and expiry denial
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- start `RW06` for recovery rotation and revocation

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -401,3 +401,30 @@ backend routes and error codes landed.
 #### Follow-up
 
 - start `RW09` by updating the SmarTrust recovery-only handoff
+
+### session: rw-v14
+
+- timestamp: 2026-05-20T19:28:42Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`571fa36`**
+- session name: **Start RW09 SmarTrust handoff**
+
+#### Objective
+
+Start the SmarTrust recovery-only reply after SDK package direction was
+coordinated.
+
+#### Actions Taken
+
+- recorded the `RW08` implementation head
+- marked `RW09` started on the same feature branch
+
+#### Verification
+
+- not run; metadata handoff before implementation
+
+#### Follow-up
+
+- update the SmarTrust sibling thread with committed route names, blocked
+  surfaces, SmarTrust-owned responsibilities, and smoke guidance

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -285,3 +285,30 @@ audit events without exposing recovery material or encrypted custody fields.
 #### Follow-up
 
 - start `RW07` for the browser-safe recovery error taxonomy
+
+### session: rw-v10
+
+- timestamp: 2026-05-20T19:21:49Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`0afeb5e`**
+- session name: **Start RW07 recovery error taxonomy**
+
+#### Objective
+
+Start the browser-safe recovery error taxonomy slice after recovery lifecycle
+controls landed.
+
+#### Actions Taken
+
+- recorded the `RW06` implementation head
+- marked `RW07` started on the same feature branch
+
+#### Verification
+
+- not run; metadata handoff before implementation
+
+#### Follow-up
+
+- standardize recovery error codes in docs and backend constants, then send the
+  SDK-facing handoff through cross-repo comms

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -101,3 +101,65 @@ recoverable wallet bundles.
 #### Follow-up
 
 - start `RW04` by adding API v3 recovery-bundle enrollment and status routes
+
+### session: rw-v4
+
+- timestamp: 2026-05-20T19:08:29Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`bcb2c37`**
+- session name: **Start RW04 recovery-bundle APIs**
+
+#### Objective
+
+Start the API v3 recovery-bundle enrollment and status route slice after the
+private storage foundation landed.
+
+#### Actions Taken
+
+- recorded the `RW03` implementation head
+- marked `RW04` started on the same feature branch
+
+#### Verification
+
+- not run; metadata handoff before implementation
+
+#### Follow-up
+
+- implement dapp-authenticated recovery-bundle enroll and status routes without
+  exposing decrypted bundle material
+
+### session: rw-v5
+
+- timestamp: 2026-05-20T19:12:59Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`bcb2c37`**
+- session name: **Implement RW04 recovery-bundle APIs**
+
+#### Objective
+
+Add the API v3 enrollment and status surface for app-mediated recoverable wallet
+bundles without creating wallets, signing transactions, or exposing recovery
+material.
+
+#### Actions Taken
+
+- added dapp-authenticated `/api/v3/recovery-bundles/enroll`
+- added dapp-authenticated `/api/v3/recovery-bundles/status`
+- encrypted enrollment bundle material into
+  `private.recoverable_wallet_recovery_bundles`
+- returned only safe bundle status metadata to dapps
+- documented the recovery-bundle API contract
+- added route tests for encrypted storage, safe status responses, ownership
+  checks, and idempotent enrollment replay
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- start `RW05` by adding a user-authorized recovery release flow

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -371,3 +371,33 @@ taxonomy landed.
 
 - update cross-repo comms with the concrete recoverable-wallet package
   direction, route surfaces, and deprecated generated-wallet/signing helpers
+
+### session: rw-v13
+
+- timestamp: 2026-05-20T19:28:10Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`1c7c6fa`**
+- session name: **Implement RW08 SDK coordination**
+
+#### Objective
+
+Coordinate the public SDK package direction after Passport recoverable-wallet
+backend routes and error codes landed.
+
+#### Actions Taken
+
+- updated the Passport-owned recoverable wallet SDK direction cross-repo thread
+- mirrored the SDK sibling note so SDK agents see the updated route and package
+  guidance
+- listed the concrete backend routes now available for SDK wrapping
+- clarified that SDK work should deprecate generated-wallet/signing helpers and
+  build toward provider-abstract recovery helpers
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- start `RW09` by updating the SmarTrust recovery-only handoff

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -428,3 +428,34 @@ coordinated.
 
 - update the SmarTrust sibling thread with committed route names, blocked
   surfaces, SmarTrust-owned responsibilities, and smoke guidance
+
+### session: rw-v15
+
+- timestamp: 2026-05-20T19:29:37Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`32f4618`**
+- session name: **Implement RW09 SmarTrust handoff**
+
+#### Objective
+
+Reply to SmarTrust with Cubid's committed recovery-only direction, route names,
+blocked surfaces, ownership boundaries, and smoke guidance.
+
+#### Actions Taken
+
+- updated the Passport sibling note for the SmarTrust recovery-only handoff
+- mirrored the SmarTrust sibling note and intentionally left it dirty for their
+  agents
+- listed the current Passport recovery route names
+- clarified that Cubid-generated wallet creation and Cubid normal signing remain
+  blocked/deprecated
+- documented SmarTrust-owned responsibilities and smoke-test expectations
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- start `RW10` for hosted migration and smoke readiness after this branch lands

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -67,3 +67,37 @@ then start the recovery-bundle schema slice.
 
 - implement `RW03` by adding private-schema recovery-bundle storage and
   Supabase Vault envelope-encryption support
+
+### session: rw-v3
+
+- timestamp: 2026-05-20T19:07:55Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`a2b82d8`**
+- session name: **Implement RW03 recovery-bundle storage**
+
+#### Objective
+
+Add the private-schema storage and encryption foundation for app-mediated
+recoverable wallet bundles.
+
+#### Actions Taken
+
+- added a Supabase migration for
+  `private.recoverable_wallet_recovery_bundles`
+- added the Vault helper function
+  `get_recoverable_wallet_recovery_bundle_wrapping_key_v1`
+- added server-side recovery-bundle envelope encryption/decryption helpers
+- documented the required Vault secret and service-role-only storage contract
+- added focused helper tests for round trip, wrong context, and wrong key
+  rejection
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `git diff --check`
+
+#### Follow-up
+
+- start `RW04` by adding API v3 recovery-bundle enrollment and status routes

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -163,3 +163,30 @@ material.
 #### Follow-up
 
 - start `RW05` by adding a user-authorized recovery release flow
+
+### session: rw-v6
+
+- timestamp: 2026-05-20T19:13:33Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`9dbc7e3`**
+- session name: **Start RW05 recovery release flow**
+
+#### Objective
+
+Start the user-authorized recovery release slice after API v3 recovery-bundle
+enrollment and status landed.
+
+#### Actions Taken
+
+- recorded the `RW04` implementation head
+- marked `RW05` started on the same feature branch
+
+#### Verification
+
+- not run; metadata handoff before implementation
+
+#### Follow-up
+
+- implement Passport-hosted recovery release sessions with user verification,
+  expiry, one-time release, and browser/client-path-only payload delivery

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -312,3 +312,35 @@ controls landed.
 
 - standardize recovery error codes in docs and backend constants, then send the
   SDK-facing handoff through cross-repo comms
+
+### session: rw-v11
+
+- timestamp: 2026-05-20T19:26:38Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`9a86130`**
+- session name: **Implement RW07 recovery error taxonomy**
+
+#### Objective
+
+Standardize browser-safe recovery error codes and coordinate the SDK impact
+without adding public SDK implementation to this repo.
+
+#### Actions Taken
+
+- added shared backend constants for recoverable-wallet error codes
+- updated recovery routes to emit specific app-context, bundle-not-found,
+  consumed, expired, wrong-user, and revoked-bundle codes
+- documented the taxonomy in the recoverable-wallet and API v3 engineering docs
+- added a cross-repo comms note for `Cubid-Me/cubid-sdk` agents
+- extended Passport tests to assert the new app-context and revoked-bundle codes
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- start `RW08` for SDK package direction coordination

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -32,3 +32,38 @@ as recovery provider only.
 - implement `RW02` to hard-disable legacy generation/signing routes, then
   proceed toward recovery-bundle storage and release APIs
 
+### session: rw-v2
+
+- timestamp: 2026-05-20T18:53:34Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`8593e12`**
+- session name: **Close RW01 and RW02**
+
+#### Objective
+
+Record the completed target-state adoption and legacy route quarantine work,
+then start the recovery-bundle schema slice.
+
+#### Actions Taken
+
+- marked `RW01` complete after the recoverable-wallet direction docs and
+  roadmap landed
+- marked `RW02` complete after account generation, signing request creation,
+  and Passport signing approval were hard-disabled
+- started `RW03` for recovery-bundle storage schema work on the same branch
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/admin test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/admin typecheck`
+- `pnpm --filter @cubid/passport build`
+- `pnpm --filter @cubid/admin build`
+- `git diff --check`
+
+#### Follow-up
+
+- implement `RW03` by adding private-schema recovery-bundle storage and
+  Supabase Vault envelope-encryption support

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -224,3 +224,30 @@ credentials unable to retrieve recovery material.
 #### Follow-up
 
 - start `RW06` for recovery rotation and revocation
+
+### session: rw-v8
+
+- timestamp: 2026-05-20T19:17:50Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`9186853`**
+- session name: **Start RW06 recovery rotation and revocation**
+
+#### Objective
+
+Start the recovery bundle lifecycle-management slice after user-authorized
+release landed.
+
+#### Actions Taken
+
+- recorded the `RW05` implementation head
+- marked `RW06` started on the same feature branch
+
+#### Verification
+
+- not run; metadata handoff before implementation
+
+#### Follow-up
+
+- add dapp-authenticated rotation/revocation APIs plus safe user/Admin
+  visibility and lifecycle audit events

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -344,3 +344,30 @@ without adding public SDK implementation to this repo.
 #### Follow-up
 
 - start `RW08` for SDK package direction coordination
+
+### session: rw-v12
+
+- timestamp: 2026-05-20T19:27:09Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`1c72827`**
+- session name: **Start RW08 SDK coordination**
+
+#### Objective
+
+Start SDK coordination after the backend recovery routes and browser-safe error
+taxonomy landed.
+
+#### Actions Taken
+
+- recorded the `RW07` implementation head
+- marked `RW08` started on the same feature branch
+
+#### Verification
+
+- not run; metadata handoff before implementation
+
+#### Follow-up
+
+- update cross-repo comms with the concrete recoverable-wallet package
+  direction, route surfaces, and deprecated generated-wallet/signing helpers

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -1,0 +1,34 @@
+# Recoverable Wallet SDK Session Log
+
+## Sessions
+
+### session: rw-v1
+
+- timestamp: 2026-05-20T18:46:01Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`bd9de8e`**
+- session name: **Create recoverable wallet planning surface**
+
+#### Objective
+
+Create the feature-folder planning surface for Cubid's corrected wallet
+direction: passkey-first, app-mediated, recoverable embedded wallets with Cubid
+as recovery provider only.
+
+#### Actions Taken
+
+- preserved the recoverable wallet SDK agent specification
+- created this feature-folder session log
+- created a recoverable-wallet todo roadmap that supersedes the old Cubid
+  generated-wallet and normal-signing direction
+
+#### Validation
+
+- `git diff --check`
+
+#### Follow-up
+
+- implement `RW02` to hard-disable legacy generation/signing routes, then
+  proceed toward recovery-bundle storage and release APIs
+

--- a/agent-context/recoverable-wallet-sdk/session-log.md
+++ b/agent-context/recoverable-wallet-sdk/session-log.md
@@ -251,3 +251,37 @@ release landed.
 
 - add dapp-authenticated rotation/revocation APIs plus safe user/Admin
   visibility and lifecycle audit events
+
+### session: rw-v9
+
+- timestamp: 2026-05-20T19:21:16Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`154f668`**
+- session name: **Implement RW06 recovery lifecycle controls**
+
+#### Objective
+
+Add recovery bundle rotation, revocation, user-visible lifecycle state, and
+audit events without exposing recovery material or encrypted custody fields.
+
+#### Actions Taken
+
+- added dapp-authenticated recovery bundle rotation
+- added dapp-authenticated recovery bundle revocation
+- added Passport user-authenticated recovery bundle list visibility
+- added recovery lifecycle audit events for enroll, update, release, rotate,
+  and revoke
+- documented lifecycle routes and redaction requirements
+- added Passport tests for rotation, revocation, user visibility, redaction, and
+  lifecycle audit events
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- start `RW07` for the browser-safe recovery error taxonomy

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -103,7 +103,7 @@ recovery material through backend credentials alone.
 - Timestamp started: 2026-05-20T19:17:50Z
 - Timestamp completed: 2026-05-20T19:21:16Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: TBD
+- Head: 0afeb5e
 - Session-log reference(s): session: rw-v8, session: rw-v9
 
 Support stale bundle invalidation after recovery, passkey re-enrollment, or
@@ -114,12 +114,12 @@ cooldown denial.
 
 ### RW07. Define browser-safe recovery error taxonomy
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-20T19:21:49Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: 0afeb5e
+- Session-log reference(s): session: rw-v10
 
 Standardize public error codes for recovery flows: cancelled, expired, wrong
 user, unavailable credential, unsupported app context, cooldown active,

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -132,7 +132,7 @@ Coordinate these codes with `Cubid-Me/cubid-sdk` through cross-repo comms.
 - Timestamp started: 2026-05-20T19:27:09Z
 - Timestamp completed: 2026-05-20T19:28:10Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: TBD
+- Head: 571fa36
 - Session-log reference(s): session: rw-v12, session: rw-v13
 
 Write a handoff note to `Cubid-Me/cubid-sdk` describing the new package family
@@ -142,12 +142,12 @@ helpers and build toward provider-abstract recoverable wallet packages.
 
 ### RW09. Reply to SmarTrust recovery-only handoff
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-20T19:28:42Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: 571fa36
+- Session-log reference(s): session: rw-v14
 
 Update the SmarTrust sibling note with Cubid's committed direction, planned API
 names, what is blocked, and what SmarTrust should build itself. Reference

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -1,0 +1,170 @@
+# Recoverable Wallet SDK Roadmap
+
+This side roadmap supersedes the old SIWC wallet-generation and normal-signing
+direction. Cubid should not be a typical third-party wallet provider. The new
+target is a passkey-first, app-mediated, recoverable embedded wallet SDK where
+host apps own wallet creation, threshold/MPC signing, and transaction
+broadcasting, while Cubid provides identity-bound recovery-bundle custody and
+release.
+
+## Execution Protocol
+
+- Work on a feature branch and commit each completed todo with a session-log
+  entry.
+- Do not add public SDK implementation code to `cubid-passport`; SDK work lives
+  in `Cubid-Me/cubid-sdk`.
+- Any SDK-impacting backend contract change needs a cross-repo comms note.
+- Do not drop legacy custody/signing tables until hosted data is reviewed and a
+  destructive cleanup todo explicitly authorizes it.
+
+## Open Todos
+
+### RW01. Adopt recoverable-wallet target state and supersede SIWC custody/signing
+
+- Status: Started
+- Timestamp started: 2026-05-20T18:46:01Z
+- Timestamp completed: TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: bd9de8e
+- Session-log reference(s): session: rw-v1
+
+Create the canonical engineering doc for Cubid's new wallet role:
+passkey-first, app-mediated, recoverable embedded wallets with Cubid as recovery
+provider only. Mark the old SIWC key-generation/signing track as superseded in
+repo roadmaps and docs. Confirm that normal signing, threshold/MPC provider
+selection, transaction broadcasting, and wallet key generation belong to the
+host app or specialized signing infrastructure, not Cubid Passport.
+
+### RW02. Hard-disable Cubid-generated wallet creation and Cubid normal signing
+
+- Status: Started
+- Timestamp started: 2026-05-20T18:46:01Z
+- Timestamp completed: TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: TBD
+- Session-log reference(s): TBD
+
+Disable `/api/v3/accounts/generate` and new
+`/api/v3/signing/requests/create` flows with stable structured errors.
+Preserve read/status routes only for historical visibility and support. Ensure
+no active route decrypts `private.private_keys` for normal signing. Update
+tests to prove new generation/signing attempts fail closed and existing
+visibility remains redacted.
+
+### RW03. Add recovery-bundle storage schema
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add service-role-only storage for app-scoped recovery bundle references and
+encrypted recovery payloads. The schema should support dapp id, dapp user UUID,
+Cubid user binding, provider name, bundle version, status, recovery reference,
+encrypted bundle material, expiry/rotation metadata, revoked/stale markers, and
+audit fields. Use the existing private schema and Supabase Vault
+envelope-encryption pattern.
+
+### RW04. Add API v3 recovery-bundle enrollment and status routes
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add dapp-authenticated API v3 routes for creating/updating a recovery bundle
+reference and checking recovery status without exposing bundle contents.
+Backend credentials alone must not be able to retrieve recovery material.
+Responses should expose only safe metadata: bundle id, status, version,
+timestamps, recovery eligibility, cooldown state, and audit references.
+
+### RW05. Add user-authorized recovery release flow
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Add Passport-hosted recovery verification routes that release recovery material
+only to the browser/client path after Cubid-side user verification. The flow
+must bind recovery to the app context, dapp user, Cubid identity, request id,
+expiry, and one-time recovery session. The SmarTrust backend must never receive
+recovery material through backend credentials alone.
+
+### RW06. Add recovery rotation and revocation
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Support stale bundle invalidation after recovery, passkey re-enrollment, or
+app-side rotation. Add routes and Admin/Passport visibility for revoked,
+rotated, expired, and active recovery bundles. Add audit events for create,
+release, rotate, revoke, failed release, wrong user, expired session, and
+cooldown denial.
+
+### RW07. Define browser-safe recovery error taxonomy
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Standardize public error codes for recovery flows: cancelled, expired, wrong
+user, unavailable credential, unsupported app context, cooldown active,
+provider outage, bundle revoked, bundle not found, and verification required.
+Coordinate these codes with `Cubid-Me/cubid-sdk` through cross-repo comms.
+
+### RW08. Coordinate SDK package direction
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Write a handoff note to `Cubid-Me/cubid-sdk` describing the new package family
+and boundaries from the spec. SDK work belongs there, not in this repo. The
+handoff should ask SDK agents to remove or deprecate old Cubid-generated-wallet
+helpers and build toward provider-abstract recoverable wallet packages.
+
+### RW09. Reply to SmarTrust recovery-only handoff
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Update the SmarTrust sibling note with Cubid's committed direction, planned API
+names, what is blocked, and what SmarTrust should build itself. Reference
+SmarTrust `AW-01`, `AW-09`, and `AW-12`. Leave the SmarTrust repo sibling note
+dirty so its agents see it.
+
+### RW10. Hosted migration and smoke readiness
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+After RW03-RW06 land, run protected migration delivery and hosted smoke checks
+for recovery enrollment, status lookup, user-authorized recovery release,
+revocation, and fail-closed backend-only recovery reads. Record evidence in
+repo status/docs before calling the recovery API ready.
+

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -99,12 +99,12 @@ recovery material through backend credentials alone.
 
 ### RW06. Add recovery rotation and revocation
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-20T19:17:50Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-20T19:21:16Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: 9186853
-- Session-log reference(s): session: rw-v8
+- Head: TBD
+- Session-log reference(s): session: rw-v8, session: rw-v9
 
 Support stale bundle invalidation after recovery, passkey re-enrollment, or
 app-side rotation. Add routes and Admin/Passport visibility for revoked,

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -21,12 +21,12 @@ release.
 
 ### RW01. Adopt recoverable-wallet target state and supersede SIWC custody/signing
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-20T18:46:01Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-20T18:53:34Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: bd9de8e
-- Session-log reference(s): session: rw-v1
+- Head: 8593e12
+- Session-log reference(s): session: rw-v1, session: rw-v2
 
 Create the canonical engineering doc for Cubid's new wallet role:
 passkey-first, app-mediated, recoverable embedded wallets with Cubid as recovery
@@ -37,12 +37,12 @@ host app or specialized signing infrastructure, not Cubid Passport.
 
 ### RW02. Hard-disable Cubid-generated wallet creation and Cubid normal signing
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-20T18:46:01Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-20T18:53:34Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: TBD
-- Session-log reference(s): TBD
+- Head: 8593e12
+- Session-log reference(s): session: rw-v2
 
 Disable `/api/v3/accounts/generate` and new
 `/api/v3/signing/requests/create` flows with stable structured errors.
@@ -53,12 +53,12 @@ visibility remains redacted.
 
 ### RW03. Add recovery-bundle storage schema
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-20T18:53:34Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: 8593e12
+- Session-log reference(s): session: rw-v2
 
 Add service-role-only storage for app-scoped recovery bundle references and
 encrypted recovery payloads. The schema should support dapp id, dapp user UUID,
@@ -167,4 +167,3 @@ After RW03-RW06 land, run protected migration delivery and hosted smoke checks
 for recovery enrollment, status lookup, user-authorized recovery release,
 revocation, and fail-closed backend-only recovery reads. Record evidence in
 repo status/docs before calling the recovery API ready.
-

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -53,11 +53,11 @@ visibility remains redacted.
 
 ### RW03. Add recovery-bundle storage schema
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-20T18:53:34Z
 - Timestamp completed: 2026-05-20T19:07:55Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: TBD
+- Head: bcb2c37
 - Session-log reference(s): session: rw-v2, session: rw-v3
 
 Add service-role-only storage for app-scoped recovery bundle references and
@@ -69,12 +69,12 @@ envelope-encryption pattern.
 
 ### RW04. Add API v3 recovery-bundle enrollment and status routes
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
+- Status: Completed
+- Timestamp started: 2026-05-20T19:08:29Z
+- Timestamp completed: 2026-05-20T19:12:59Z
+- Feature branch: codex/recoverable-wallet-direction-reset
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session: rw-v4, session: rw-v5
 
 Add dapp-authenticated API v3 routes for creating/updating a recovery bundle
 reference and checking recovery status without exposing bundle contents.

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -55,10 +55,10 @@ visibility remains redacted.
 
 - Status: Started
 - Timestamp started: 2026-05-20T18:53:34Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-20T19:07:55Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: 8593e12
-- Session-log reference(s): session: rw-v2
+- Head: TBD
+- Session-log reference(s): session: rw-v2, session: rw-v3
 
 Add service-role-only storage for app-scoped recovery bundle references and
 encrypted recovery payloads. The schema should support dapp id, dapp user UUID,

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -84,12 +84,12 @@ timestamps, recovery eligibility, cooldown state, and audit references.
 
 ### RW05. Add user-authorized recovery release flow
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-20T19:13:33Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-20T19:17:18Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: 9dbc7e3
-- Session-log reference(s): session: rw-v6
+- Head: TBD
+- Session-log reference(s): session: rw-v6, session: rw-v7
 
 Add Passport-hosted recovery verification routes that release recovery material
 only to the browser/client path after Cubid-side user verification. The flow

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -114,12 +114,12 @@ cooldown denial.
 
 ### RW07. Define browser-safe recovery error taxonomy
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-20T19:21:49Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-20T19:26:38Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: 0afeb5e
-- Session-log reference(s): session: rw-v10
+- Head: TBD
+- Session-log reference(s): session: rw-v10, session: rw-v11
 
 Standardize public error codes for recovery flows: cancelled, expired, wrong
 user, unavailable credential, unsupported app context, cooldown active,

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -142,12 +142,12 @@ helpers and build toward provider-abstract recoverable wallet packages.
 
 ### RW09. Reply to SmarTrust recovery-only handoff
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-20T19:28:42Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-20T19:29:37Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: 571fa36
-- Session-log reference(s): session: rw-v14
+- Head: TBD
+- Session-log reference(s): session: rw-v14, session: rw-v15
 
 Update the SmarTrust sibling note with Cubid's committed direction, planned API
 names, what is blocked, and what SmarTrust should build itself. Reference

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -88,7 +88,7 @@ timestamps, recovery eligibility, cooldown state, and audit references.
 - Timestamp started: 2026-05-20T19:13:33Z
 - Timestamp completed: 2026-05-20T19:17:18Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: TBD
+- Head: 9186853
 - Session-log reference(s): session: rw-v6, session: rw-v7
 
 Add Passport-hosted recovery verification routes that release recovery material
@@ -99,12 +99,12 @@ recovery material through backend credentials alone.
 
 ### RW06. Add recovery rotation and revocation
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-20T19:17:50Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: 9186853
+- Session-log reference(s): session: rw-v8
 
 Support stale bundle invalidation after recovery, passkey re-enrollment, or
 app-side rotation. Add routes and Admin/Passport visibility for revoked,

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -128,12 +128,12 @@ Coordinate these codes with `Cubid-Me/cubid-sdk` through cross-repo comms.
 
 ### RW08. Coordinate SDK package direction
 
-- Status: Started
+- Status: Completed
 - Timestamp started: 2026-05-20T19:27:09Z
-- Timestamp completed: TBD
+- Timestamp completed: 2026-05-20T19:28:10Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: 1c72827
-- Session-log reference(s): session: rw-v12
+- Head: TBD
+- Session-log reference(s): session: rw-v12, session: rw-v13
 
 Write a handoff note to `Cubid-Me/cubid-sdk` describing the new package family
 and boundaries from the spec. SDK work belongs there, not in this repo. The

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -73,7 +73,7 @@ envelope-encryption pattern.
 - Timestamp started: 2026-05-20T19:08:29Z
 - Timestamp completed: 2026-05-20T19:12:59Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: TBD
+- Head: 9dbc7e3
 - Session-log reference(s): session: rw-v4, session: rw-v5
 
 Add dapp-authenticated API v3 routes for creating/updating a recovery bundle
@@ -84,12 +84,12 @@ timestamps, recovery eligibility, cooldown state, and audit references.
 
 ### RW05. Add user-authorized recovery release flow
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-20T19:13:33Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: 9dbc7e3
+- Session-log reference(s): session: rw-v6
 
 Add Passport-hosted recovery verification routes that release recovery material
 only to the browser/client path after Cubid-side user verification. The flow

--- a/agent-context/recoverable-wallet-sdk/todo.md
+++ b/agent-context/recoverable-wallet-sdk/todo.md
@@ -118,7 +118,7 @@ cooldown denial.
 - Timestamp started: 2026-05-20T19:21:49Z
 - Timestamp completed: 2026-05-20T19:26:38Z
 - Feature branch: codex/recoverable-wallet-direction-reset
-- Head: TBD
+- Head: 1c72827
 - Session-log reference(s): session: rw-v10, session: rw-v11
 
 Standardize public error codes for recovery flows: cancelled, expired, wrong
@@ -128,12 +128,12 @@ Coordinate these codes with `Cubid-Me/cubid-sdk` through cross-repo comms.
 
 ### RW08. Coordinate SDK package direction
 
-- Status: Not started
-- Timestamp started: TBD
+- Status: Started
+- Timestamp started: 2026-05-20T19:27:09Z
 - Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: 1c72827
+- Session-log reference(s): session: rw-v12
 
 Write a handoff note to `Cubid-Me/cubid-sdk` describing the new package family
 and boundaries from the spec. SDK work belongs there, not in this repo. The

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7311,3 +7311,32 @@ coordinated.
 
 - update the SmarTrust cross-repo thread with current Passport recovery API
   contracts and SmarTrust-owned responsibilities
+
+### session: v228
+
+- timestamp: 2026-05-20T19:29:37Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`32f4618`**
+- session name: **Implement RW09 SmarTrust handoff**
+
+#### Objective
+
+Reply to SmarTrust with the current recovery-only Passport API contract and
+clear division of responsibilities.
+
+#### Actions Taken
+
+- updated the Passport-owned SmarTrust recovery-only cross-repo note
+- mirrored the SmarTrust sibling note and left it dirty in SmarTrust
+- listed current route names and smoke guidance
+- clarified blocked/deprecated generated-wallet and normal-signing surfaces
+- referenced SmarTrust-owned `AW-01`, `AW-09`, and `AW-12` responsibilities
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- start `RW10` for hosted migration and smoke readiness after review/merge

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7045,3 +7045,31 @@ inspect recovery-bundle state without retrieving recovery material.
 #### Follow-up
 
 - start `RW05` for user-authorized recovery release
+
+### session: v219
+
+- timestamp: 2026-05-20T19:13:33Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`9dbc7e3`**
+- session name: **Start RW05 recovery release flow**
+
+#### Objective
+
+Start the Passport-hosted, user-authorized recovery release follow-up after the
+backend enrollment/status API landed.
+
+#### Actions Taken
+
+- recorded the RW04 commit SHA in the recoverable-wallet roadmap
+- marked `RW05` started with current branch/head metadata
+- added the feature-folder session-log handoff entry
+
+#### Verification
+
+- not run; metadata-only handoff
+
+#### Follow-up
+
+- implement one-time recovery release sessions without backend credential
+  retrieval of recovery material

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7374,3 +7374,44 @@ on direct implementation until Cubid SDK orchestration support lands.
 
 - keep the SmarTrust sibling note dirty so SmarTrust agents see the updated
   guidance
+
+### session: v230
+
+- timestamp: 2026-05-20T20:02:49Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`1fa38ac`**
+- session name: **Address PR 169 recovery review comments**
+
+#### Objective
+
+Patch the PR review findings around recoverable-wallet bundle ownership,
+revoked-bundle lookup scoping, release-session state handling, rotation safety,
+and stale SIWC doc metadata.
+
+#### Actions Taken
+
+- scoped recovery bundle re-enrollment to the full app/user/provider ownership
+  tuple
+- tightened revoked-bundle checks so other app contexts do not leak bundle
+  lifecycle state
+- checked expired recovery-session update errors before returning expiry
+  failures
+- made post-release bundle bookkeeping and security-event writes non-blocking
+  after the release session is durably consumed
+- reordered bundle rotation so the replacement is written before the old bundle
+  is marked rotated
+- updated SIWC signing architecture metadata and added regression tests for the
+  ownership and cross-app leak cases
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- push the review-fix commit, then reply to and resolve the addressed PR
+  threads

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7106,3 +7106,30 @@ limited to release-session creation and status metadata.
 #### Follow-up
 
 - start `RW06` for recovery rotation and revocation
+
+### session: v221
+
+- timestamp: 2026-05-20T19:17:50Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`9186853`**
+- session name: **Start RW06 recovery rotation and revocation**
+
+#### Objective
+
+Start the recovery lifecycle-management follow-up after the Passport
+user-authorized release route landed.
+
+#### Actions Taken
+
+- recorded the RW05 commit SHA in the recoverable-wallet roadmap
+- marked `RW06` started with current branch/head metadata
+- added the feature-folder session-log handoff entry
+
+#### Verification
+
+- not run; metadata-only handoff
+
+#### Follow-up
+
+- add rotation, revocation, visibility, and audit events for recovery bundles

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7133,3 +7133,37 @@ user-authorized release route landed.
 #### Follow-up
 
 - add rotation, revocation, visibility, and audit events for recovery bundles
+
+### session: v222
+
+- timestamp: 2026-05-20T19:21:16Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`154f668`**
+- session name: **Implement RW06 recovery lifecycle controls**
+
+#### Objective
+
+Add the recovery bundle lifecycle controls needed after enrollment and release:
+rotation, revocation, user-visible state, and audit events.
+
+#### Actions Taken
+
+- added dapp-authenticated recovery bundle rotation and revocation routes
+- added Passport user-authenticated recovery bundle list visibility
+- added lifecycle audit events for enroll, update, release, rotate, and revoke
+- kept all lifecycle responses redacted of bundle material and encrypted custody
+  fields
+- updated API v3 and recoverable-wallet docs
+- added Passport route coverage for rotation, revocation, visibility, and audit
+  evidence
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- start `RW07` for browser-safe recovery error taxonomy

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -6980,3 +6980,34 @@ and start the recovery-bundle schema follow-up.
 #### Follow-up
 
 - implement `RW03` recovery-bundle storage schema
+### session: v217
+
+- timestamp: 2026-05-20T19:07:55Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`a2b82d8`**
+- session name: **Implement RW03 recovery-bundle storage**
+
+#### Objective
+
+Add the storage and encryption foundation for Cubid recoverable-wallet recovery
+bundles.
+
+#### Actions Taken
+
+- added a private-schema recovery-bundle table with service-role-only access
+- added a Supabase Vault-backed wrapping-key helper function
+- added Passport server helpers for recovery-bundle envelope encryption and
+  decryption
+- documented the recovery-bundle storage contract and required Vault secret
+- added focused helper tests for encryption context binding
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `git diff --check`
+
+#### Follow-up
+
+- start `RW04` for API v3 recovery-bundle enrollment and status routes

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7073,3 +7073,36 @@ backend enrollment/status API landed.
 
 - implement one-time recovery release sessions without backend credential
   retrieval of recovery material
+
+### session: v220
+
+- timestamp: 2026-05-20T19:17:18Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`558429f`**
+- session name: **Implement RW05 user-authorized recovery release**
+
+#### Objective
+
+Add a user-authorized recovery release path that keeps dapp backend credentials
+limited to release-session creation and status metadata.
+
+#### Actions Taken
+
+- added recovery release session persistence with service-role-only access
+- added dapp-authenticated API v3 release-session creation
+- added Passport user-authenticated release completion
+- verified the signed-in user owns the Cubid user bound to the session
+- enforced session expiry and one-time consumption
+- returned recovery material only from the user-authenticated completion route
+- documented the RW05 API contract
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- start `RW06` for recovery rotation and revocation

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -6882,3 +6882,32 @@ for the flexible messaging MVP.
 #### Follow-up
 
 - continue with `FM09` auditability and delivery-status APIs
+### session: v214
+
+- timestamp: 2026-05-20T18:46:01Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`f288f35`**
+- session name: **Preserve recoverable wallet direction reset**
+
+#### Objective
+
+Anchor the new app-recoverable wallet direction before changing repo behavior.
+
+#### Actions Taken
+
+- preserved the recoverable wallet SDK agent specification as the new product
+  direction source for passkey-first, app-mediated, recoverable embedded
+  wallets
+- preserved the new SmarTrust recovery-only cross-repo handoff
+- preserved the old SmarTrust wallet-generation/signing thread as archived and
+  superseded
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- rewrite wallet/SIWC docs and roadmap metadata, then hard-disable Cubid
+  wallet generation and normal signing surfaces

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7254,3 +7254,32 @@ concrete recovery-bundle APIs and error codes.
 
 - update the SDK direction cross-repo note with concrete backend route and
   package-boundary guidance
+
+### session: v226
+
+- timestamp: 2026-05-20T19:28:10Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`1c7c6fa`**
+- session name: **Implement RW08 SDK coordination**
+
+#### Objective
+
+Send concrete SDK package-boundary and route guidance now that the
+recoverable-wallet backend surfaces exist.
+
+#### Actions Taken
+
+- updated the Passport-owned recoverable wallet SDK direction cross-repo note
+- mirrored the sibling note in `cubid-sdk-v2` and intentionally left it dirty
+- documented the backend routes available for SDK wrapping
+- reiterated that the SDK should deprecate generated-wallet and normal-signing
+  helper direction
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- start `RW09` for the SmarTrust recovery-only handoff

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7195,3 +7195,34 @@ user-visible lifecycle state landed.
 
 - document and code the browser-safe recovery error taxonomy, then coordinate
   SDK impact through cross-repo comms
+
+### session: v224
+
+- timestamp: 2026-05-20T19:26:38Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`9a86130`**
+- session name: **Implement RW07 recovery error taxonomy**
+
+#### Objective
+
+Make recoverable-wallet errors stable for browsers and SDK consumers, and
+coordinate the contract with the public SDK repo.
+
+#### Actions Taken
+
+- added recoverable-wallet error code constants
+- updated backend recovery flows to emit browser-safe error codes
+- documented the taxonomy and route mapping
+- added a live cross-repo comms handoff note for SDK agents
+- covered the changed error codes in Passport route tests
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- start `RW08` for SDK package direction coordination

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7283,3 +7283,31 @@ recoverable-wallet backend surfaces exist.
 #### Follow-up
 
 - start `RW09` for the SmarTrust recovery-only handoff
+
+### session: v227
+
+- timestamp: 2026-05-20T19:28:42Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`571fa36`**
+- session name: **Start RW09 SmarTrust handoff**
+
+#### Objective
+
+Start the SmarTrust recovery-only handoff after SDK package direction was
+coordinated.
+
+#### Actions Taken
+
+- recorded the RW08 commit SHA in the recoverable-wallet roadmap
+- marked `RW09` started with current branch/head metadata
+- added the feature-folder session-log handoff entry
+
+#### Verification
+
+- not run; metadata-only handoff
+
+#### Follow-up
+
+- update the SmarTrust cross-repo thread with current Passport recovery API
+  contracts and SmarTrust-owned responsibilities

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7226,3 +7226,31 @@ coordinate the contract with the public SDK repo.
 #### Follow-up
 
 - start `RW08` for SDK package direction coordination
+
+### session: v225
+
+- timestamp: 2026-05-20T19:27:09Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`1c72827`**
+- session name: **Start RW08 SDK coordination**
+
+#### Objective
+
+Start coordinating the public SDK package direction now that Passport has
+concrete recovery-bundle APIs and error codes.
+
+#### Actions Taken
+
+- recorded the RW07 commit SHA in the recoverable-wallet roadmap
+- marked `RW08` started with current branch/head metadata
+- added the feature-folder session-log handoff entry
+
+#### Verification
+
+- not run; metadata-only handoff
+
+#### Follow-up
+
+- update the SDK direction cross-repo note with concrete backend route and
+  package-boundary guidance

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7011,3 +7011,37 @@ bundles.
 #### Follow-up
 
 - start `RW04` for API v3 recovery-bundle enrollment and status routes
+
+### session: v218
+
+- timestamp: 2026-05-20T19:12:59Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`bcb2c37`**
+- session name: **Implement RW04 recovery-bundle APIs**
+
+#### Objective
+
+Add API v3 recovery-bundle enrollment and status routes that let dapps store and
+inspect recovery-bundle state without retrieving recovery material.
+
+#### Actions Taken
+
+- added dapp-authenticated recovery-bundle enrollment with `Idempotency-Key`
+  replay protection
+- added dapp-authenticated recovery-bundle status lookup
+- wired enrollment to the private-schema Vault envelope-encryption helper
+- kept responses limited to safe status metadata
+- updated API v3 and recoverable-wallet engineering docs
+- added Passport route tests for encryption, redaction, ownership, and
+  idempotency
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+
+#### Follow-up
+
+- start `RW05` for user-authorized recovery release

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -6954,3 +6954,29 @@ roadmap.
 
 - close RW01/RW02 metadata with the implementation commit SHA, then continue
   with RW03 recovery-bundle storage schema
+### session: v216
+
+- timestamp: 2026-05-20T18:53:34Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`8593e12`**
+- session name: **Close RW01 and RW02 metadata**
+
+#### Objective
+
+Close the completed recoverable-wallet target-state and route-quarantine todos
+and start the recovery-bundle schema follow-up.
+
+#### Actions Taken
+
+- marked `RW01` and `RW02` completed in the recoverable-wallet roadmap
+- started `RW03` for private-schema recovery-bundle storage
+- added the feature-folder session-log closeout entry
+
+#### Verification
+
+- `git diff --check`
+
+#### Follow-up
+
+- implement `RW03` recovery-bundle storage schema

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7340,3 +7340,37 @@ clear division of responsibilities.
 #### Follow-up
 
 - start `RW10` for hosted migration and smoke readiness after review/merge
+
+### session: v229
+
+- timestamp: 2026-05-20T19:35:52Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`ac5edcd`**
+- session name: **Clarify SmarTrust recovery handoff timing**
+
+#### Objective
+
+Clarify the SmarTrust cross-repo recovery handoff so SmarTrust agents hold off
+on direct implementation until Cubid SDK orchestration support lands.
+
+#### Actions Taken
+
+- rewrote the latest SmarTrust recovery-only handoff entry in the Passport
+  sibling note
+- mirrored the same clarification into the SmarTrust sibling note and left it
+  dirty for their agents
+- clarified that Cubid SDK support will cover much of the recovery
+  orchestration
+- clarified that SmarTrust still owns wallet/MPC policy, backend state,
+  business logic, retries, escrow logic, and product UX
+
+#### Verification
+
+- `git diff --check`
+- `git -C /Users/botmaster/src/smartrust/smartrust-monorepo diff --check -- agent-context/cross-repo-comms/2026-05-20-app-recoverable-wallet-recovery-handoff.md`
+
+#### Follow-up
+
+- keep the SmarTrust sibling note dirty so SmarTrust agents see the updated
+  guidance

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7167,3 +7167,31 @@ rotation, revocation, user-visible state, and audit events.
 #### Follow-up
 
 - start `RW07` for browser-safe recovery error taxonomy
+
+### session: v223
+
+- timestamp: 2026-05-20T19:21:49Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`0afeb5e`**
+- session name: **Start RW07 recovery error taxonomy**
+
+#### Objective
+
+Start standardizing recovery error codes after rotation, revocation, and
+user-visible lifecycle state landed.
+
+#### Actions Taken
+
+- recorded the RW06 commit SHA in the recoverable-wallet roadmap
+- marked `RW07` started with current branch/head metadata
+- added the feature-folder session-log handoff entry
+
+#### Verification
+
+- not run; metadata-only handoff
+
+#### Follow-up
+
+- document and code the browser-safe recovery error taxonomy, then coordinate
+  SDK impact through cross-repo comms

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -6911,3 +6911,46 @@ Anchor the new app-recoverable wallet direction before changing repo behavior.
 
 - rewrite wallet/SIWC docs and roadmap metadata, then hard-disable Cubid
   wallet generation and normal signing surfaces
+### session: v215
+
+- timestamp: 2026-05-20T18:53:13Z
+- agent: **OpenAI Codex**
+- branch: **codex/recoverable-wallet-direction-reset**
+- head: **`bd9de8e`**
+- session name: **Quarantine legacy Cubid wallet generation and signing**
+
+#### Objective
+
+Pivot the repo away from Cubid-generated wallets and Cubid normal signing while
+preserving historical data surfaces and establishing the recoverable-wallet
+roadmap.
+
+#### Actions Taken
+
+- added the recoverable wallet roadmap and engineering direction doc
+- marked SIWC generated-wallet and normal-signing docs as superseded or legacy
+  quarantine surfaces
+- hard-disabled new `/api/v3/accounts/generate`,
+  `/api/v3/signing/requests/create`, and Passport SIWC signing approval
+  traffic with structured `410` errors
+- updated Admin SIWC policy helpers/UI to prevent enabling legacy custody or
+  signing controls
+- added Passport/Admin tests for fail-closed behavior and updated legacy route
+  tests to preserve read-only visibility
+- created SDK and SmarTrust cross-repo handoff notes for the recovery-only
+  direction
+
+#### Verification
+
+- `pnpm --filter @cubid/passport test`
+- `pnpm --filter @cubid/admin test`
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/admin typecheck`
+- `pnpm --filter @cubid/passport build`
+- `pnpm --filter @cubid/admin build`
+- `git diff --check`
+
+#### Follow-up
+
+- close RW01/RW02 metadata with the implementation commit SHA, then continue
+  with RW03 recovery-bundle storage schema

--- a/agent-context/siwc-todo.md
+++ b/agent-context/siwc-todo.md
@@ -1,6 +1,6 @@
 # SIWC Roadmap: Sign In With Cubid
 
-Sign In With Cubid is the passkey-first, privacy-preserving, app-scoped identity and wallet-adjacent platform layer for Cubid. The product should combine OIDC login, hosted Passport UX, Admin policy controls, app-scoped identity, selective disclosure, proof-of-personhood signals, and optional app-scoped custody accounts without becoming a generic embedded-wallet clone.
+Sign In With Cubid is the passkey-first, privacy-preserving, app-scoped identity layer for Cubid. The older wallet-adjacent custody/signing direction in this file is now superseded for wallet generation and normal signing by `agent-context/recoverable-wallet-sdk/` and `docs/engineering/recoverable-wallet-sdk.md`.
 
 Source note: this file replaces a generic competitor-research implementation guide with a repo-grounded side roadmap. It should stay separate from `agent-context/todo.md` until the team chooses which SIWC work to promote into the main execution backlog.
 
@@ -10,12 +10,12 @@ Source note: this file replaces a generic competitor-research implementation gui
 - Passkey work is already substantially implemented: Passport login UX, fallback/recovery framing, passkey registration, device lifecycle, rename/revoke, Profile visibility, Admin read-only passkey ops, and passkey-required ACR semantics exist.
 - App-scoped identity and selective disclosure are now first-class backend concepts: app-scoped subjects, disclosure grants, Allow Page persistence, OIDC consent persistence, SDK-facing route filtering, webhook filtering, non-OIDC disclosure history/revocation, and Admin disclosure ops exist.
 - API v3 custody exists for encrypted dapp-user secrets and generated app-scoped blockchain accounts across EVM, NEAR, Solana, and Sui. Private material is stored through Supabase Vault-backed envelope encryption and is not returned to dapps, browsers, or Admin list views.
-- The SIWC backend foundation now includes app-scoped account generation/listing, Admin signing policy controls, Passport account visibility, message and typed-data signing requests, passkey step-up, transaction-risk denial evidence, signed wallet webhooks, and an operator runbook. Transaction signing, signer recovery, transaction simulation, smart accounts, session keys, and paymasters remain deferred.
+- The SIWC backend foundation included app-scoped account generation/listing, Admin signing policy controls, Passport account visibility, message and typed-data signing requests, passkey step-up, transaction-risk denial evidence, signed wallet webhooks, and an operator runbook. That wallet-generation and normal-signing implementation is now quarantined as legacy because Cubid should act as recovery provider, not as the wallet generator or normal signer.
 - Public SDK and UI package implementation belongs in `Cubid-Me/cubid-sdk`, not this repo. This repo owns backend behavior, migrations, Passport/Admin/OIDC runtime, API/webhook contracts, and handoff notes for SDK agents.
 
 ## Recommended Direction
 
-Keep Login with Cubid centered on standards and privacy: OIDC for sign-in, Passport for hosted human auth and consent UX, Admin for policy and client control, and API v3 for backend app integration. Treat wallets/accounts as app-scoped custody accounts by default, not universal identities. The strongest Cubid positioning is not "Privy or Magic with different branding"; it is app-scoped identity, passkey-first authentication, proof-of-personhood signals, selective disclosure, and optional app-scoped account custody that avoids cross-app correlation.
+Keep Login with Cubid centered on standards and privacy: OIDC for sign-in, Passport for hosted human auth and consent UX, Admin for policy and client control, and API v3 for backend app integration. Treat recoverable wallets as app-mediated assisted self-custody where Cubid supplies identity-bound recovery, not normal wallet custody. The strongest Cubid positioning is not "Privy or Magic with different branding"; it is app-scoped identity, passkey-first authentication, proof-of-personhood signals, selective disclosure, and recovery-provider infrastructure.
 
 The generic recommendation to build new `/api/v2/wallets/*` routes should be replaced with API v3 contracts. Any SDK-visible changes must be coordinated through `Cubid-Me/cubid-sdk` by writing a handoff note in that repo; no new public SDK implementation should be added here.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -751,7 +751,7 @@ Translate the backgrounder’s product constraints into concrete engineering wor
 - Head: 969385a
 - Session-log reference(s): session: v160, session: v175
 
-Promote the SIWC side-roadmap into the main execution backlog as the next wallet-adjacent platform track. The Cubid foundation covers OIDC Login with Cubid, passkey-first auth, app-scoped identity, selective disclosure, API v3 encrypted dapp-user secrets, generated app-scoped blockchain accounts, signed webhook infrastructure, Passport-hosted signing approval, Admin signing policy controls, and SIWC production-readiness runbooks. This track delivered the backend/API-contract foundation for app-scoped custody and message or typed-data signing while keeping transaction signing, smart accounts, session keys, paymasters, and public SDK implementation explicitly deferred.
+Promote the SIWC side-roadmap into the main execution backlog as the wallet-adjacent platform track. This track originally delivered API-contract foundations for app-scoped generated accounts and Cubid normal signing, but that wallet-generation/signing direction is now superseded by the recoverable wallet SDK direction. Keep the still-valid foundations: OIDC Login with Cubid, passkey-first auth, app-scoped identity, selective disclosure, encrypted dapp-user secrets, signed webhook infrastructure, Admin policy patterns, and production-readiness runbooks. Treat Cubid-generated accounts and normal signing as legacy/quarantined surfaces, not the future product path.
 
 ### SIWC01. Define the v3 signing and transaction authorization architecture
 
@@ -774,6 +774,25 @@ Design the first decision-complete signing architecture for app-scoped custody a
 - Session-log reference(s): session: v161, session: v162, session: v163
 
 Add Admin-side controls that let operators configure whether an app may request generated accounts, which chains are enabled, whether signing is enabled, and which approval rules apply. This should extend the existing Admin control-plane pattern rather than creating a separate wallet dashboard. Include fields for allowed chains, custody mode, signing status, allowed signature types, transaction limits, optional contract allowlists, required passkey ACR, webhook event subscriptions, and sandbox/production behavior. Admin list/detail views must not expose private keys, ciphertext, wrapped data keys, Vault key material, or cross-app user identifiers. This todo should also decide how policy names and versions are surfaced to API v3 responses and audit logs, and should treat policy changes as SDK-impacting only when they alter public route or webhook semantics.
+
+### RW. Build Cubid recoverable wallet recovery-provider infrastructure
+
+- Status: Started
+- Timestamp started: 2026-05-20T18:46:01Z
+- Timestamp completed: TBD
+- Feature branch: codex/recoverable-wallet-direction-reset
+- Head: bd9de8e
+- Session-log reference(s): session: v214, session: rw-v1
+
+Replace the earlier Cubid-generated-wallet direction with passkey-first,
+app-mediated, recoverable embedded wallets. Cubid Passport should not generate
+wallets, perform normal signing, or hold itself out as a typical third-party
+wallet provider. The host app or specialist threshold/MPC infrastructure owns
+wallet creation, normal signing, and transaction broadcasting. Cubid owns
+identity-bound recovery-bundle storage/release, Passport recovery verification,
+auditability, and API/SDK coordination. Use
+`agent-context/recoverable-wallet-sdk/todo.md` as the active side roadmap for
+RW01-RW10.
 
 ## F. Hosted Delivery and Release Operations
 

--- a/apps/admin/app/admin/siwcPolicy.tsx
+++ b/apps/admin/app/admin/siwcPolicy.tsx
@@ -138,11 +138,12 @@ export default function SiwcPolicy() {
     <div className="p-3 text-white">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 className="text-xl">SIWC Policy</h2>
+          <h2 className="text-xl">Legacy SIWC Policy</h2>
           <p className="mt-1 max-w-3xl text-sm text-gray-400">
-            Configure whether each app can use app-scoped account custody and
-            future signing. These controls do not execute signing yet; they
-            define the policy SIWC signing routes must enforce later.
+            Historical app-scoped custody and signing policy visibility. Cubid
+            generated wallets and normal signing are deprecated; new wallet
+            work should use app-mediated recoverable wallets with Cubid
+            recovery bundles.
           </p>
           {generatedAt ? (
             <p className="mt-2 text-xs text-gray-500">
@@ -242,21 +243,27 @@ export default function SiwcPolicy() {
               <div className="mt-4 grid gap-3 md:grid-cols-3">
                 <PolicyCheckbox
                   checked={policy.custodyEnabled}
-                  label="Custody enabled"
+                  label="Legacy custody enabled"
                   onChange={() =>
-                    updatePolicy(policy.dappId, {
-                      custodyEnabled: !policy.custodyEnabled,
-                    })
+                    policy.custodyEnabled
+                      ? updatePolicy(policy.dappId, { custodyEnabled: false })
+                      : toast.info(
+                          'Legacy custody cannot be enabled for new integrations.'
+                        )
                   }
                 />
                 <PolicyCheckbox
                   checked={policy.signingEnabled}
-                  label="Signing enabled"
+                  label="Legacy signing enabled"
                   onChange={() =>
-                    updatePolicy(policy.dappId, {
-                      requiredAcr: !policy.signingEnabled ? PASSKEY_ACR : null,
-                      signingEnabled: !policy.signingEnabled,
-                    })
+                    policy.signingEnabled
+                      ? updatePolicy(policy.dappId, {
+                          requiredAcr: null,
+                          signingEnabled: false,
+                        })
+                      : toast.info(
+                          'Legacy signing cannot be enabled for new integrations.'
+                        )
                   }
                 />
                 <PolicyCheckbox

--- a/apps/admin/lib/server/siwcPolicies.test.ts
+++ b/apps/admin/lib/server/siwcPolicies.test.ts
@@ -74,33 +74,39 @@ const createAdminContext = (supabase: unknown, uid = 'admin_uid') =>
 
 const createUpsertSupabase = (existingPolicyVersion?: number) => {
   const eventInsert = jest.fn(async () => ({ error: null }));
+  let lastPayload: Record<string, unknown> | null = null;
   const policyResult = {
     select: () => ({
       maybeSingle: async () => ({
         data: {
-          allowed_chains: ['evm'],
-          allowed_request_types: ['message'],
-          contract_allowlist: [],
+          allowed_chains: lastPayload?.allowed_chains ?? ['evm'],
+          allowed_request_types: lastPayload?.allowed_request_types ?? ['message'],
+          contract_allowlist: lastPayload?.contract_allowlist ?? [],
           created_at: '2026-05-05T00:00:00.000Z',
-          custody_enabled: true,
+          custody_enabled: lastPayload?.custody_enabled ?? false,
           dapp_id: 42,
           id: 'policy_42',
-          metadata: {},
-          policy_name: 'Production signing',
+          metadata: lastPayload?.metadata ?? {},
+          policy_name: lastPayload?.policy_name ?? 'Legacy SIWC disabled',
           policy_version: existingPolicyVersion ? existingPolicyVersion + 1 : 1,
-          required_acr: 'urn:cubid:acr:passkey',
-          sandbox_mode: true,
-          signing_enabled: true,
-          status: 'enabled',
-          transaction_value_limit_usd: null,
+          required_acr: lastPayload?.required_acr ?? null,
+          sandbox_mode: lastPayload?.sandbox_mode ?? true,
+          signing_enabled: lastPayload?.signing_enabled ?? false,
+          status: lastPayload?.status ?? 'disabled',
+          transaction_value_limit_usd:
+            lastPayload?.transaction_value_limit_usd ?? null,
           updated_at: '2026-05-05T01:00:00.000Z',
-          webhook_event_subscriptions: [],
+          webhook_event_subscriptions:
+            lastPayload?.webhook_event_subscriptions ?? [],
         },
         error: null,
       }),
     }),
   };
-  const policyWrite = jest.fn((_payload?: unknown) => policyResult);
+  const policyWrite = jest.fn((payload?: unknown) => {
+    lastPayload = (payload ?? {}) as Record<string, unknown>;
+    return policyResult;
+  });
 
   return {
     eventInsert,
@@ -192,7 +198,7 @@ describe('SIWC policy helpers', () => {
     expect(overview.policies).toEqual([]);
   });
 
-  it('creates a passkey-required signing policy and writes an audit event', async () => {
+  it('creates a disabled legacy policy and writes an audit event', async () => {
     const { eventInsert, policyWrite, supabase } = createUpsertSupabase();
     const policy = await upsertSiwcPolicy(
       {
@@ -205,26 +211,28 @@ describe('SIWC policy helpers', () => {
       {
         allowedChains: ['evm'],
         allowedRequestTypes: ['message'],
-        custodyEnabled: true,
+        custodyEnabled: false,
         dappId: 42,
-        policyName: 'Production signing',
-        requiredAcr: 'urn:cubid:acr:passkey',
+        policyName: 'Legacy SIWC disabled',
+        requiredAcr: null,
         sandboxMode: true,
-        signingEnabled: true,
-        status: 'enabled',
+        signingEnabled: false,
+        status: 'disabled',
       }
     );
 
     expect(policy).toMatchObject({
       dappId: 42,
       policyVersion: 1,
-      requiredAcr: 'urn:cubid:acr:passkey',
-      signingEnabled: true,
+      requiredAcr: null,
+      signingEnabled: false,
+      status: 'disabled',
     });
     expect(policyWrite).toHaveBeenCalledWith(
       expect.objectContaining({
         policy_version: 1,
-        required_acr: 'urn:cubid:acr:passkey',
+        required_acr: null,
+        signing_enabled: false,
       })
     );
     expect(eventInsert).toHaveBeenCalledWith(
@@ -248,13 +256,13 @@ describe('SIWC policy helpers', () => {
       {
         allowedChains: ['evm'],
         allowedRequestTypes: ['message'],
-        custodyEnabled: true,
+        custodyEnabled: false,
         dappId: 42,
-        policyName: 'Production signing',
-        requiredAcr: 'urn:cubid:acr:passkey',
+        policyName: 'Legacy SIWC disabled',
+        requiredAcr: null,
         sandboxMode: true,
-        signingEnabled: true,
-        status: 'enabled',
+        signingEnabled: false,
+        status: 'disabled',
       }
     );
 
@@ -296,7 +304,7 @@ describe('SIWC policy helpers', () => {
     ).toThrow(/allowedRequestTypes/);
   });
 
-  it('fails closed when signing is enabled without passkey ACR', () => {
+  it('fails closed when legacy custody or signing is enabled', () => {
     expect(() =>
       normalizeSiwcPolicyInput({
         allowedChains: ['evm'],
@@ -309,6 +317,6 @@ describe('SIWC policy helpers', () => {
         signingEnabled: true,
         status: 'enabled',
       })
-    ).toThrow(/passkey ACR/);
+    ).toThrow(/deprecated/);
   });
 });

--- a/apps/admin/lib/server/siwcPolicies.ts
+++ b/apps/admin/lib/server/siwcPolicies.ts
@@ -182,6 +182,12 @@ export const normalizeSiwcPolicyInput = (
     throw new SiwcPolicyInputError('status must be disabled, enabled, or suspended');
   }
 
+  if (input.custodyEnabled || input.signingEnabled) {
+    throw new SiwcPolicyInputError(
+      'Legacy Cubid wallet custody and signing controls are deprecated. Use recoverable-wallet recovery bundles instead.'
+    );
+  }
+
   if (input.signingEnabled && input.requiredAcr !== PASSKEY_ACR) {
     throw new SiwcPolicyInputError('Signing policies must require passkey ACR');
   }

--- a/apps/passport/lib/server/recoverableWalletErrors.ts
+++ b/apps/passport/lib/server/recoverableWalletErrors.ts
@@ -1,0 +1,16 @@
+export const RECOVERABLE_WALLET_ERROR_CODES = {
+  bundleNotFound: "recovery_bundle_not_found",
+  bundleRevoked: "bundle_revoked",
+  cancelled: "recovery_cancelled",
+  consumed: "recovery_session_consumed",
+  cooldownActive: "cooldown_active",
+  expired: "recovery_session_expired",
+  providerOutage: "provider_outage",
+  unavailableCredential: "unavailable_credential",
+  unsupportedAppContext: "unsupported_app_context",
+  verificationRequired: "verification_required",
+  wrongUser: "wrong_user",
+} as const
+
+export type RecoverableWalletErrorCode =
+  (typeof RECOVERABLE_WALLET_ERROR_CODES)[keyof typeof RECOVERABLE_WALLET_ERROR_CODES]

--- a/apps/passport/lib/server/recoverableWalletRecovery.ts
+++ b/apps/passport/lib/server/recoverableWalletRecovery.ts
@@ -250,7 +250,42 @@ export async function assertDappUserForRecoverableWalletBundle(input: {
   }
 }
 
+async function writeRecoverableWalletSecurityEvent(input: {
+  actorIdentifier?: string | null
+  actorType: "dapp" | "user"
+  dappId?: number | string | null
+  dappUserUuid?: string | null
+  eventType: string
+  outcome: "failure" | "success"
+  recoveryBundleId?: string | null
+  recoverySessionId?: string | null
+  requestId: string
+  route: string
+  supabase: SupabaseClient
+}) {
+  const { error } = await input.supabase.from("api_security_events").insert({
+    actor_identifier: input.actorIdentifier ?? null,
+    actor_type: input.actorType,
+    details: {
+      dappId: input.dappId == null ? null : String(input.dappId),
+      dappUserUuid: input.dappUserUuid ?? null,
+      recoveryBundleId: input.recoveryBundleId ?? null,
+      recoverySessionId: input.recoverySessionId ?? null,
+    },
+    event_id: `api_event_${randomUUID().replace(/-/g, "")}`,
+    event_type: input.eventType,
+    outcome: input.outcome,
+    request_id: input.requestId,
+    route: input.route,
+  })
+
+  if (error) {
+    throw error
+  }
+}
+
 export async function enrollRecoverableWalletRecoveryBundle(input: {
+  actorIdentifier?: string | null
   bundleMaterial: string
   bundleVersion?: number | null
   dappId: number | string
@@ -336,6 +371,21 @@ export async function enrollRecoverableWalletRecoveryBundle(input: {
   if (storeError) {
     throw storeError
   }
+
+  await writeRecoverableWalletSecurityEvent({
+    actorIdentifier: input.actorIdentifier ?? null,
+    actorType: "dapp",
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    eventType: existingRow
+      ? "recoverable_wallet.bundle.updated"
+      : "recoverable_wallet.bundle.enrolled",
+    outcome: "success",
+    recoveryBundleId,
+    requestId: input.requestId,
+    route: "v3.recovery_bundles.enroll",
+    supabase: input.supabase,
+  })
 
   return mapRecoverableWalletBundleStatus(
     storedRow as Record<string, unknown> | null,
@@ -661,6 +711,20 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
     throw updateBundleError
   }
 
+  await writeRecoverableWalletSecurityEvent({
+    actorIdentifier: input.firebaseToken.uid,
+    actorType: "user",
+    dappId: session.dapp_id,
+    dappUserUuid: String(session.dapp_user_uuid),
+    eventType: "recoverable_wallet.bundle.released",
+    outcome: "success",
+    recoveryBundleId: String(session.recovery_bundle_id),
+    recoverySessionId: String(session.recovery_session_id),
+    requestId: input.requestId,
+    route: "passport.recovery_bundles.release.complete",
+    supabase: input.supabase,
+  })
+
   return {
     bundleMaterial,
     dappUserUuid: String(session.dapp_user_uuid),
@@ -670,4 +734,193 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
     releasedAt,
     status: "released",
   }
+}
+
+export async function rotateRecoverableWalletRecoveryBundle(input: {
+  actorIdentifier: string
+  bundleMaterial: string
+  dappId: number | string
+  dappUserUuid: string
+  expiresAt?: string | null
+  metadata?: Record<string, unknown> | null
+  newRecoveryBundleId?: string | null
+  providerKey?: string | null
+  recoveryBundleId: string
+  recoveryReference?: string | null
+  requestId: string
+  supabase: SupabaseClient
+}) {
+  const dappUser = await assertDappUserForRecoverableWalletBundle({
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    supabase: input.supabase,
+  })
+  const providerKey = normalizeProviderKey(input.providerKey)
+  const { data: existingBundle, error: existingError } = await input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .select("*")
+    .eq("dapp_id", input.dappId)
+    .eq("dapp_user_uuid", input.dappUserUuid)
+    .eq("user_id", dappUser.user_id)
+    .eq("provider_key", providerKey)
+    .eq("recovery_bundle_id", input.recoveryBundleId)
+    .eq("status", "active")
+    .maybeSingle()
+
+  if (existingError) {
+    throw existingError
+  }
+
+  if (!existingBundle) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "Active recovery bundle was not found for rotation."
+    )
+  }
+
+  const rotatedAt = new Date().toISOString()
+  const { error: rotateError } = await input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .update({
+      rotated_at: rotatedAt,
+      status: "rotated",
+      updated_at: rotatedAt,
+    })
+    .eq("id", existingBundle.id)
+
+  if (rotateError) {
+    throw rotateError
+  }
+
+  const nextVersion = Number(existingBundle.bundle_version ?? 1) + 1
+  const rotated = await enrollRecoverableWalletRecoveryBundle({
+    actorIdentifier: input.actorIdentifier,
+    bundleMaterial: input.bundleMaterial,
+    bundleVersion: nextVersion,
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    expiresAt: input.expiresAt ?? null,
+    metadata: {
+      ...(input.metadata ?? {}),
+      rotatedFromRecoveryBundleId: input.recoveryBundleId,
+    },
+    providerKey,
+    recoveryBundleId: input.newRecoveryBundleId ?? null,
+    recoveryReference: input.recoveryReference ?? null,
+    requestId: input.requestId,
+    supabase: input.supabase,
+  })
+
+  await writeRecoverableWalletSecurityEvent({
+    actorIdentifier: input.actorIdentifier,
+    actorType: "dapp",
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    eventType: "recoverable_wallet.bundle.rotated",
+    outcome: "success",
+    recoveryBundleId: input.recoveryBundleId,
+    requestId: input.requestId,
+    route: "v3.recovery_bundles.rotate",
+    supabase: input.supabase,
+  })
+
+  return rotated
+}
+
+export async function revokeRecoverableWalletRecoveryBundle(input: {
+  actorIdentifier: string
+  dappId: number | string
+  dappUserUuid: string
+  providerKey?: string | null
+  recoveryBundleId: string
+  requestId: string
+  supabase: SupabaseClient
+}) {
+  const dappUser = await assertDappUserForRecoverableWalletBundle({
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    supabase: input.supabase,
+  })
+  const revokedAt = new Date().toISOString()
+  const query = input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .update({
+      revoked_at: revokedAt,
+      status: "revoked",
+      updated_at: revokedAt,
+    })
+    .eq("dapp_id", input.dappId)
+    .eq("dapp_user_uuid", input.dappUserUuid)
+    .eq("user_id", dappUser.user_id)
+    .eq("recovery_bundle_id", input.recoveryBundleId)
+    .eq("provider_key", normalizeProviderKey(input.providerKey))
+    .select("*")
+
+  const { data: revokedBundle, error } = await query.maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!revokedBundle) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "Recovery bundle was not found for revocation."
+    )
+  }
+
+  await writeRecoverableWalletSecurityEvent({
+    actorIdentifier: input.actorIdentifier,
+    actorType: "dapp",
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    eventType: "recoverable_wallet.bundle.revoked",
+    outcome: "success",
+    recoveryBundleId: input.recoveryBundleId,
+    requestId: input.requestId,
+    route: "v3.recovery_bundles.revoke",
+    supabase: input.supabase,
+  })
+
+  return mapRecoverableWalletBundleStatus(
+    revokedBundle as Record<string, unknown>,
+    input.dappUserUuid
+  )
+}
+
+export async function listRecoverableWalletRecoveryBundlesForUser(input: {
+  firebaseToken: DecodedIdToken
+  supabase: SupabaseClient
+}): Promise<RecoverableWalletBundleSafeStatus[]> {
+  const userIds = await resolveUserIdsFromFirebaseToken(
+    input.supabase,
+    input.firebaseToken
+  )
+
+  if (userIds.size === 0) {
+    return []
+  }
+
+  const { data, error } = await input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .select("*")
+    .in("user_id", [...userIds])
+    .order("updated_at", { ascending: false })
+
+  if (error) {
+    throw error
+  }
+
+  return (data ?? []).map((row) =>
+    mapRecoverableWalletBundleStatus(
+      row as Record<string, unknown>,
+      String(row.dapp_user_uuid)
+    )
+  )
 }

--- a/apps/passport/lib/server/recoverableWalletRecovery.ts
+++ b/apps/passport/lib/server/recoverableWalletRecovery.ts
@@ -1,4 +1,7 @@
+import { randomUUID } from "node:crypto"
+
 import {
+  ApiSecurityError,
   decodeAes256GcmEnvelopeKey,
   decryptAes256GcmEnvelope,
   encryptAes256GcmEnvelope,
@@ -36,6 +39,22 @@ export type EncryptedRecoverableWalletBundle = {
   wrapped_data_key: string
   wrapped_data_key_auth_tag: string
   wrapped_data_key_iv: string
+}
+
+export type RecoverableWalletBundleSafeStatus = {
+  bundleVersion: number | null
+  createdAt: string | null
+  dappUserUuid: string
+  expiresAt: string | null
+  lastReleasedAt: string | null
+  providerKey: string | null
+  recoveryBundleId: string | null
+  recoveryReference: string | null
+  revokedAt: string | null
+  rotatedAt: string | null
+  staleAt: string | null
+  status: string
+  updatedAt: string | null
 }
 
 export const buildRecoverableWalletBundleContext = (
@@ -133,3 +152,219 @@ export function decryptRecoverableWalletBundleWithKey(
   )
 }
 
+const generateRecoveryBundleId = () =>
+  `rw_bundle_${randomUUID().replace(/-/g, "")}`
+
+const normalizeProviderKey = (value: string | null | undefined) =>
+  (value ?? "cubid").trim().toLowerCase()
+
+const toIsoOrNull = (value: unknown) =>
+  typeof value === "string" && value.length > 0 ? value : null
+
+export const mapRecoverableWalletBundleStatus = (
+  row: Record<string, unknown> | null,
+  dappUserUuid: string
+): RecoverableWalletBundleSafeStatus => {
+  if (!row) {
+    return {
+      bundleVersion: null,
+      createdAt: null,
+      dappUserUuid,
+      expiresAt: null,
+      lastReleasedAt: null,
+      providerKey: null,
+      recoveryBundleId: null,
+      recoveryReference: null,
+      revokedAt: null,
+      rotatedAt: null,
+      staleAt: null,
+      status: "not_enrolled",
+      updatedAt: null,
+    }
+  }
+
+  return {
+    bundleVersion:
+      row.bundle_version == null ? null : Number(row.bundle_version),
+    createdAt: toIsoOrNull(row.created_at),
+    dappUserUuid: String(row.dapp_user_uuid ?? dappUserUuid),
+    expiresAt: toIsoOrNull(row.expires_at),
+    lastReleasedAt: toIsoOrNull(row.last_released_at),
+    providerKey: String(row.provider_key ?? "cubid"),
+    recoveryBundleId: String(row.recovery_bundle_id),
+    recoveryReference:
+      row.recovery_reference == null ? null : String(row.recovery_reference),
+    revokedAt: toIsoOrNull(row.revoked_at),
+    rotatedAt: toIsoOrNull(row.rotated_at),
+    staleAt: toIsoOrNull(row.stale_at),
+    status: String(row.status ?? "active"),
+    updatedAt: toIsoOrNull(row.updated_at),
+  }
+}
+
+export async function assertDappUserForRecoverableWalletBundle(input: {
+  dappId: number | string
+  dappUserUuid: string
+  supabase: SupabaseClient
+}) {
+  const { data, error } = await input.supabase
+    .from("dapp_users")
+    .select("uuid,dapp_id,user_id")
+    .eq("uuid", input.dappUserUuid)
+    .eq("dapp_id", input.dappId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!data || data.user_id == null) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "Dapp user was not found for the authenticated app."
+    )
+  }
+
+  return data as {
+    dapp_id: number | string
+    user_id: number | string
+    uuid: string
+  }
+}
+
+export async function enrollRecoverableWalletRecoveryBundle(input: {
+  bundleMaterial: string
+  bundleVersion?: number | null
+  dappId: number | string
+  dappUserUuid: string
+  expiresAt?: string | null
+  metadata?: Record<string, unknown> | null
+  providerKey?: string | null
+  recoveryBundleId?: string | null
+  recoveryReference?: string | null
+  requestId: string
+  supabase: SupabaseClient
+}): Promise<RecoverableWalletBundleSafeStatus> {
+  const dappUser = await assertDappUserForRecoverableWalletBundle({
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    supabase: input.supabase,
+  })
+  const providerKey = normalizeProviderKey(input.providerKey)
+  const bundleVersion = Number(input.bundleVersion ?? 1)
+  const recoveryBundleId =
+    input.recoveryBundleId?.trim() || generateRecoveryBundleId()
+  const encryptedBundle = await encryptRecoverableWalletBundle(
+    input.supabase,
+    input.bundleMaterial,
+    {
+      bundleVersion,
+      dappId: input.dappId,
+      dappUserUuid: input.dappUserUuid,
+      providerKey,
+      recoveryBundleId,
+      userId: dappUser.user_id,
+    }
+  )
+
+  const row = {
+    ...encryptedBundle,
+    bundle_version: bundleVersion,
+    dapp_id: input.dappId,
+    dapp_user_uuid: input.dappUserUuid,
+    expires_at: input.expiresAt ?? null,
+    metadata: {
+      ...(input.metadata ?? {}),
+      createdBy: "api_v3.recovery_bundles.enroll",
+      requestId: input.requestId,
+    },
+    provider_key: providerKey,
+    recovery_bundle_id: recoveryBundleId,
+    recovery_reference: input.recoveryReference ?? null,
+    status: "active",
+    user_id: dappUser.user_id,
+  }
+
+  const { data: existingRow, error: existingError } = await input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .select("*")
+    .eq("recovery_bundle_id", recoveryBundleId)
+    .eq("dapp_id", input.dappId)
+    .maybeSingle()
+
+  if (existingError) {
+    throw existingError
+  }
+
+  const query = existingRow
+    ? input.supabase
+        .schema("private")
+        .from("recoverable_wallet_recovery_bundles")
+        .update({
+          ...row,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", existingRow.id)
+        .select("*")
+    : input.supabase
+        .schema("private")
+        .from("recoverable_wallet_recovery_bundles")
+        .insert(row)
+        .select("*")
+
+  const { data: storedRow, error: storeError } = await query.maybeSingle()
+
+  if (storeError) {
+    throw storeError
+  }
+
+  return mapRecoverableWalletBundleStatus(
+    storedRow as Record<string, unknown> | null,
+    input.dappUserUuid
+  )
+}
+
+export async function getRecoverableWalletRecoveryBundleStatus(input: {
+  dappId: number | string
+  dappUserUuid: string
+  providerKey?: string | null
+  recoveryBundleId?: string | null
+  supabase: SupabaseClient
+}): Promise<RecoverableWalletBundleSafeStatus> {
+  await assertDappUserForRecoverableWalletBundle({
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    supabase: input.supabase,
+  })
+
+  let query = input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .select("*")
+    .eq("dapp_id", input.dappId)
+    .eq("dapp_user_uuid", input.dappUserUuid)
+
+  if (input.recoveryBundleId) {
+    query = query.eq("recovery_bundle_id", input.recoveryBundleId)
+  }
+
+  if (input.providerKey) {
+    query = query.eq("provider_key", normalizeProviderKey(input.providerKey))
+  }
+
+  const { data, error } = await query
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return mapRecoverableWalletBundleStatus(
+    data as Record<string, unknown> | null,
+    input.dappUserUuid
+  )
+}

--- a/apps/passport/lib/server/recoverableWalletRecovery.ts
+++ b/apps/passport/lib/server/recoverableWalletRecovery.ts
@@ -1,0 +1,135 @@
+import {
+  decodeAes256GcmEnvelopeKey,
+  decryptAes256GcmEnvelope,
+  encryptAes256GcmEnvelope,
+  type Aes256GcmEnvelopePayload,
+} from "@cubid/auth/server"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export const RECOVERABLE_WALLET_BUNDLE_ALGORITHM =
+  "aes-256-gcm-envelope" as const
+export const RECOVERABLE_WALLET_BUNDLE_KEY_ID =
+  "passport_recoverable_wallet_recovery_bundle_wrapping_key_v1" as const
+export const RECOVERABLE_WALLET_BUNDLE_KEY_VERSION = 1
+export const RECOVERABLE_WALLET_BUNDLE_PURPOSE =
+  "recoverable_wallet_recovery_bundle" as const
+
+export type RecoverableWalletBundleContext = {
+  bundleVersion: number
+  dappId: number | string
+  dappUserUuid: string
+  providerKey: string
+  recoveryBundleId: string
+  userId: number | string
+}
+
+export type EncryptedRecoverableWalletBundle = {
+  bundle_auth_tag: string
+  bundle_ciphertext: string
+  bundle_iv: string
+  encrypted_at: string
+  encryption_algorithm: typeof RECOVERABLE_WALLET_BUNDLE_ALGORITHM
+  encryption_context: RecoverableWalletBundleContext
+  encryption_key_id: typeof RECOVERABLE_WALLET_BUNDLE_KEY_ID
+  encryption_key_version: typeof RECOVERABLE_WALLET_BUNDLE_KEY_VERSION
+  encryption_purpose: typeof RECOVERABLE_WALLET_BUNDLE_PURPOSE
+  wrapped_data_key: string
+  wrapped_data_key_auth_tag: string
+  wrapped_data_key_iv: string
+}
+
+export const buildRecoverableWalletBundleContext = (
+  context: RecoverableWalletBundleContext
+): RecoverableWalletBundleContext => ({
+  bundleVersion: Number(context.bundleVersion),
+  dappId: String(context.dappId),
+  dappUserUuid: context.dappUserUuid,
+  providerKey: context.providerKey,
+  recoveryBundleId: context.recoveryBundleId,
+  userId: String(context.userId),
+})
+
+export async function getRecoverableWalletBundleWrappingKey(
+  supabase: Pick<SupabaseClient, "rpc">
+) {
+  const { data, error } = await supabase.rpc(
+    "get_recoverable_wallet_recovery_bundle_wrapping_key_v1"
+  )
+
+  if (error) {
+    throw error
+  }
+
+  if (typeof data !== "string") {
+    throw new Error("Recoverable wallet bundle wrapping key is not configured.")
+  }
+
+  return decodeAes256GcmEnvelopeKey(
+    data,
+    "Recoverable wallet bundle wrapping key"
+  )
+}
+
+export function encryptRecoverableWalletBundleWithKey(
+  plaintext: string,
+  wrappingKey: Buffer,
+  context: RecoverableWalletBundleContext
+): EncryptedRecoverableWalletBundle {
+  const normalizedContext = buildRecoverableWalletBundleContext(context)
+  const encrypted = encryptAes256GcmEnvelope(plaintext, wrappingKey, {
+    context: normalizedContext,
+    keyId: RECOVERABLE_WALLET_BUNDLE_KEY_ID,
+    keyVersion: RECOVERABLE_WALLET_BUNDLE_KEY_VERSION,
+    purpose: RECOVERABLE_WALLET_BUNDLE_PURPOSE,
+  })
+
+  return {
+    bundle_auth_tag: encrypted.authTag,
+    bundle_ciphertext: encrypted.ciphertext,
+    bundle_iv: encrypted.iv,
+    encrypted_at: new Date().toISOString(),
+    encryption_algorithm: encrypted.algorithm,
+    encryption_context: normalizedContext,
+    encryption_key_id: RECOVERABLE_WALLET_BUNDLE_KEY_ID,
+    encryption_key_version: RECOVERABLE_WALLET_BUNDLE_KEY_VERSION,
+    encryption_purpose: RECOVERABLE_WALLET_BUNDLE_PURPOSE,
+    wrapped_data_key: encrypted.wrappedDataKey,
+    wrapped_data_key_auth_tag: encrypted.wrappedDataKeyAuthTag,
+    wrapped_data_key_iv: encrypted.wrappedDataKeyIv,
+  }
+}
+
+export async function encryptRecoverableWalletBundle(
+  supabase: Pick<SupabaseClient, "rpc">,
+  plaintext: string,
+  context: RecoverableWalletBundleContext
+) {
+  const wrappingKey = await getRecoverableWalletBundleWrappingKey(supabase)
+  return encryptRecoverableWalletBundleWithKey(plaintext, wrappingKey, context)
+}
+
+export function decryptRecoverableWalletBundleWithKey(
+  row: Record<string, unknown>,
+  wrappingKey: Buffer,
+  context: RecoverableWalletBundleContext
+) {
+  const envelope: Aes256GcmEnvelopePayload = {
+    algorithm: RECOVERABLE_WALLET_BUNDLE_ALGORITHM,
+    authTag: String(row.bundle_auth_tag),
+    ciphertext: String(row.bundle_ciphertext),
+    iv: String(row.bundle_iv),
+    keyId: String(row.encryption_key_id),
+    keyVersion: Number(row.encryption_key_version),
+    purpose: RECOVERABLE_WALLET_BUNDLE_PURPOSE,
+    wrappedDataKey: String(row.wrapped_data_key),
+    wrappedDataKeyAuthTag: String(row.wrapped_data_key_auth_tag),
+    wrappedDataKeyIv: String(row.wrapped_data_key_iv),
+  }
+
+  return decryptAes256GcmEnvelope(
+    envelope,
+    wrappingKey,
+    buildRecoverableWalletBundleContext(context)
+  )
+}
+

--- a/apps/passport/lib/server/recoverableWalletRecovery.ts
+++ b/apps/passport/lib/server/recoverableWalletRecovery.ts
@@ -345,11 +345,24 @@ export async function enrollRecoverableWalletRecoveryBundle(input: {
     .from("recoverable_wallet_recovery_bundles")
     .select("*")
     .eq("recovery_bundle_id", recoveryBundleId)
-    .eq("dapp_id", input.dappId)
     .maybeSingle()
 
   if (existingError) {
     throw existingError
+  }
+
+  if (
+    existingRow &&
+    (String(existingRow.dapp_id) !== String(input.dappId) ||
+      String(existingRow.dapp_user_uuid) !== String(input.dappUserUuid) ||
+      String(existingRow.user_id) !== String(dappUser.user_id) ||
+      String(existingRow.provider_key ?? "cubid") !== providerKey)
+  ) {
+    throw new ApiSecurityError(
+      409,
+      RECOVERABLE_WALLET_ERROR_CODES.unsupportedAppContext,
+      "Recovery bundle id is already bound to a different app context."
+    )
   }
 
   const query = existingRow
@@ -501,6 +514,10 @@ export async function createRecoverableWalletRecoveryReleaseSession(input: {
           .schema("private")
           .from("recoverable_wallet_recovery_bundles")
           .select("status")
+          .eq("dapp_id", input.dappId)
+          .eq("dapp_user_uuid", input.dappUserUuid)
+          .eq("user_id", dappUser.user_id)
+          .eq("provider_key", providerKey)
           .eq("recovery_bundle_id", input.recoveryBundleId)
           .maybeSingle()
 
@@ -630,13 +647,17 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
   }
 
   if (new Date(String(session.expires_at)).getTime() <= Date.now()) {
-    await input.supabase
+    const { error: expireSessionError } = await input.supabase
       .from("recoverable_wallet_recovery_sessions")
       .update({
         status: "expired",
         updated_at: new Date().toISOString(),
       })
       .eq("id", session.id)
+
+    if (expireSessionError) {
+      throw expireSessionError
+    }
 
     throw new ApiSecurityError(
       410,
@@ -722,32 +743,29 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
     )
   }
 
-  const { error: updateBundleError } = await input.supabase
-    .schema("private")
-    .from("recoverable_wallet_recovery_bundles")
-    .update({
-      last_released_at: releasedAt,
-      updated_at: releasedAt,
-    })
-    .eq("id", bundle.id)
-
-  if (updateBundleError) {
-    throw updateBundleError
-  }
-
-  await writeRecoverableWalletSecurityEvent({
-    actorIdentifier: input.firebaseToken.uid,
-    actorType: "user",
-    dappId: session.dapp_id,
-    dappUserUuid: String(session.dapp_user_uuid),
-    eventType: "recoverable_wallet.bundle.released",
-    outcome: "success",
-    recoveryBundleId: String(session.recovery_bundle_id),
-    recoverySessionId: String(session.recovery_session_id),
-    requestId: input.requestId,
-    route: "passport.recovery_bundles.release.complete",
-    supabase: input.supabase,
-  })
+  await Promise.allSettled([
+    input.supabase
+      .schema("private")
+      .from("recoverable_wallet_recovery_bundles")
+      .update({
+        last_released_at: releasedAt,
+        updated_at: releasedAt,
+      })
+      .eq("id", bundle.id),
+    writeRecoverableWalletSecurityEvent({
+      actorIdentifier: input.firebaseToken.uid,
+      actorType: "user",
+      dappId: session.dapp_id,
+      dappUserUuid: String(session.dapp_user_uuid),
+      eventType: "recoverable_wallet.bundle.released",
+      outcome: "success",
+      recoveryBundleId: String(session.recovery_bundle_id),
+      recoverySessionId: String(session.recovery_session_id),
+      requestId: input.requestId,
+      route: "passport.recovery_bundles.release.complete",
+      supabase: input.supabase,
+    }),
+  ])
 
   return {
     bundleMaterial,
@@ -804,21 +822,6 @@ export async function rotateRecoverableWalletRecoveryBundle(input: {
     )
   }
 
-  const rotatedAt = new Date().toISOString()
-  const { error: rotateError } = await input.supabase
-    .schema("private")
-    .from("recoverable_wallet_recovery_bundles")
-    .update({
-      rotated_at: rotatedAt,
-      status: "rotated",
-      updated_at: rotatedAt,
-    })
-    .eq("id", existingBundle.id)
-
-  if (rotateError) {
-    throw rotateError
-  }
-
   const nextVersion = Number(existingBundle.bundle_version ?? 1) + 1
   const rotated = await enrollRecoverableWalletRecoveryBundle({
     actorIdentifier: input.actorIdentifier,
@@ -837,6 +840,22 @@ export async function rotateRecoverableWalletRecoveryBundle(input: {
     requestId: input.requestId,
     supabase: input.supabase,
   })
+
+  const rotatedAt = new Date().toISOString()
+  const { error: rotateError } = await input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .update({
+      rotated_at: rotatedAt,
+      status: "rotated",
+      updated_at: rotatedAt,
+    })
+    .eq("id", existingBundle.id)
+    .eq("status", "active")
+
+  if (rotateError) {
+    throw rotateError
+  }
 
   await writeRecoverableWalletSecurityEvent({
     actorIdentifier: input.actorIdentifier,

--- a/apps/passport/lib/server/recoverableWalletRecovery.ts
+++ b/apps/passport/lib/server/recoverableWalletRecovery.ts
@@ -10,6 +10,8 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js"
 import type { DecodedIdToken } from "firebase-admin/auth"
 
+import { RECOVERABLE_WALLET_ERROR_CODES } from "./recoverableWalletErrors"
+
 export const RECOVERABLE_WALLET_RELEASE_SESSION_TTL_MS = 15 * 60 * 1000
 
 export const RECOVERABLE_WALLET_BUNDLE_ALGORITHM =
@@ -238,7 +240,7 @@ export async function assertDappUserForRecoverableWalletBundle(input: {
   if (!data || data.user_id == null) {
     throw new ApiSecurityError(
       404,
-      "not_found",
+      RECOVERABLE_WALLET_ERROR_CODES.unsupportedAppContext,
       "Dapp user was not found for the authenticated app."
     )
   }
@@ -493,9 +495,31 @@ export async function createRecoverableWalletRecoveryReleaseSession(input: {
   }
 
   if (!bundle) {
+    if (input.recoveryBundleId) {
+      const { data: unavailableBundle, error: unavailableError } =
+        await input.supabase
+          .schema("private")
+          .from("recoverable_wallet_recovery_bundles")
+          .select("status")
+          .eq("recovery_bundle_id", input.recoveryBundleId)
+          .maybeSingle()
+
+      if (unavailableError) {
+        throw unavailableError
+      }
+
+      if (unavailableBundle?.status === "revoked") {
+        throw new ApiSecurityError(
+          409,
+          RECOVERABLE_WALLET_ERROR_CODES.bundleRevoked,
+          "Recovery bundle has been revoked."
+        )
+      }
+    }
+
     throw new ApiSecurityError(
       404,
-      "not_found",
+      RECOVERABLE_WALLET_ERROR_CODES.bundleNotFound,
       "Recovery bundle was not found for the authenticated app."
     )
   }
@@ -592,7 +616,7 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
   if (!session) {
     throw new ApiSecurityError(
       404,
-      "not_found",
+      RECOVERABLE_WALLET_ERROR_CODES.bundleNotFound,
       "Recovery session was not found."
     )
   }
@@ -600,7 +624,7 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
   if (session.status !== "pending" || session.consumed_at) {
     throw new ApiSecurityError(
       409,
-      "recovery_session_consumed",
+      RECOVERABLE_WALLET_ERROR_CODES.consumed,
       "Recovery session has already been consumed."
     )
   }
@@ -616,7 +640,7 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
 
     throw new ApiSecurityError(
       410,
-      "recovery_session_expired",
+      RECOVERABLE_WALLET_ERROR_CODES.expired,
       "Recovery session has expired."
     )
   }
@@ -629,7 +653,7 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
   if (!userIds.has(String(session.user_id))) {
     throw new ApiSecurityError(
       403,
-      "wrong_user",
+      RECOVERABLE_WALLET_ERROR_CODES.wrongUser,
       "Signed-in Passport user does not match this recovery session."
     )
   }
@@ -652,9 +676,9 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
 
   if (!bundle) {
     throw new ApiSecurityError(
-      404,
-      "not_found",
-      "Active recovery bundle was not found for this session."
+      409,
+      RECOVERABLE_WALLET_ERROR_CODES.bundleRevoked,
+      "Recovery bundle is no longer active for this session."
     )
   }
 
@@ -693,7 +717,7 @@ export async function releaseRecoverableWalletRecoveryBundle(input: {
   if (!updatedSession) {
     throw new ApiSecurityError(
       409,
-      "recovery_session_consumed",
+      RECOVERABLE_WALLET_ERROR_CODES.consumed,
       "Recovery session has already been consumed."
     )
   }
@@ -775,7 +799,7 @@ export async function rotateRecoverableWalletRecoveryBundle(input: {
   if (!existingBundle) {
     throw new ApiSecurityError(
       404,
-      "not_found",
+      RECOVERABLE_WALLET_ERROR_CODES.bundleNotFound,
       "Active recovery bundle was not found for rotation."
     )
   }
@@ -869,7 +893,7 @@ export async function revokeRecoverableWalletRecoveryBundle(input: {
   if (!revokedBundle) {
     throw new ApiSecurityError(
       404,
-      "not_found",
+      RECOVERABLE_WALLET_ERROR_CODES.bundleNotFound,
       "Recovery bundle was not found for revocation."
     )
   }

--- a/apps/passport/lib/server/recoverableWalletRecovery.ts
+++ b/apps/passport/lib/server/recoverableWalletRecovery.ts
@@ -8,6 +8,9 @@ import {
   type Aes256GcmEnvelopePayload,
 } from "@cubid/auth/server"
 import type { SupabaseClient } from "@supabase/supabase-js"
+import type { DecodedIdToken } from "firebase-admin/auth"
+
+export const RECOVERABLE_WALLET_RELEASE_SESSION_TTL_MS = 15 * 60 * 1000
 
 export const RECOVERABLE_WALLET_BUNDLE_ALGORITHM =
   "aes-256-gcm-envelope" as const
@@ -55,6 +58,17 @@ export type RecoverableWalletBundleSafeStatus = {
   staleAt: string | null
   status: string
   updatedAt: string | null
+}
+
+export type RecoverableWalletRecoveryReleaseSession = {
+  createdAt: string
+  dappUserUuid: string
+  expiresAt: string
+  providerKey: string
+  recoveryBundleId: string
+  recoverySessionId: string
+  recoveryUrl: string
+  status: string
 }
 
 export const buildRecoverableWalletBundleContext = (
@@ -154,6 +168,9 @@ export function decryptRecoverableWalletBundleWithKey(
 
 const generateRecoveryBundleId = () =>
   `rw_bundle_${randomUUID().replace(/-/g, "")}`
+
+const generateRecoverySessionId = () =>
+  `rw_release_${randomUUID().replace(/-/g, "")}`
 
 const normalizeProviderKey = (value: string | null | undefined) =>
   (value ?? "cubid").trim().toLowerCase()
@@ -367,4 +384,290 @@ export async function getRecoverableWalletRecoveryBundleStatus(input: {
     data as Record<string, unknown> | null,
     input.dappUserUuid
   )
+}
+
+const mapRecoveryReleaseSession = (
+  row: Record<string, unknown>
+): RecoverableWalletRecoveryReleaseSession => {
+  const recoverySessionId = String(row.recovery_session_id)
+  return {
+    createdAt: String(row.created_at),
+    dappUserUuid: String(row.dapp_user_uuid),
+    expiresAt: String(row.expires_at),
+    providerKey: String(row.provider_key ?? "cubid"),
+    recoveryBundleId: String(row.recovery_bundle_id),
+    recoverySessionId,
+    recoveryUrl: `/recovery/wallet?recovery_session_id=${encodeURIComponent(
+      recoverySessionId
+    )}`,
+    status: String(row.status ?? "pending"),
+  }
+}
+
+export async function createRecoverableWalletRecoveryReleaseSession(input: {
+  actorIdentifier: string
+  dappId: number | string
+  dappUserUuid: string
+  providerKey?: string | null
+  recoveryBundleId?: string | null
+  requestId: string
+  supabase: SupabaseClient
+}): Promise<RecoverableWalletRecoveryReleaseSession> {
+  const dappUser = await assertDappUserForRecoverableWalletBundle({
+    dappId: input.dappId,
+    dappUserUuid: input.dappUserUuid,
+    supabase: input.supabase,
+  })
+  const providerKey = normalizeProviderKey(input.providerKey)
+  let bundleQuery = input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .select("*")
+    .eq("dapp_id", input.dappId)
+    .eq("dapp_user_uuid", input.dappUserUuid)
+    .eq("user_id", dappUser.user_id)
+    .eq("provider_key", providerKey)
+    .eq("status", "active")
+
+  if (input.recoveryBundleId) {
+    bundleQuery = bundleQuery.eq("recovery_bundle_id", input.recoveryBundleId)
+  }
+
+  const { data: bundle, error: bundleError } = await bundleQuery
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (bundleError) {
+    throw bundleError
+  }
+
+  if (!bundle) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "Recovery bundle was not found for the authenticated app."
+    )
+  }
+
+  const now = new Date()
+  const expiresAt = new Date(
+    now.getTime() + RECOVERABLE_WALLET_RELEASE_SESSION_TTL_MS
+  ).toISOString()
+  const { data: session, error: sessionError } = await input.supabase
+    .from("recoverable_wallet_recovery_sessions")
+    .insert({
+      created_by_actor_identifier: input.actorIdentifier,
+      dapp_id: input.dappId,
+      dapp_user_uuid: input.dappUserUuid,
+      expires_at: expiresAt,
+      metadata: {
+        createdBy: "api_v3.recovery_bundles.release.start",
+        requestId: input.requestId,
+      },
+      provider_key: providerKey,
+      recovery_bundle_id: String(bundle.recovery_bundle_id),
+      recovery_session_id: generateRecoverySessionId(),
+      request_id: input.requestId,
+      status: "pending",
+      user_id: dappUser.user_id,
+    })
+    .select("*")
+    .maybeSingle()
+
+  if (sessionError) {
+    throw sessionError
+  }
+
+  return mapRecoveryReleaseSession(session as Record<string, unknown>)
+}
+
+async function resolveUserIdsFromFirebaseToken(
+  supabase: SupabaseClient,
+  token: DecodedIdToken
+) {
+  const userIds = new Set<string>()
+
+  if (token.email) {
+    const { data, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("email", token.email)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    if (data?.id != null) {
+      userIds.add(String(data.id))
+    }
+  }
+
+  if (token.phone_number) {
+    const { data, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("phone", token.phone_number)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    if (data?.id != null) {
+      userIds.add(String(data.id))
+    }
+  }
+
+  return userIds
+}
+
+export async function releaseRecoverableWalletRecoveryBundle(input: {
+  firebaseToken: DecodedIdToken
+  recoverySessionId: string
+  requestId: string
+  supabase: SupabaseClient
+}) {
+  const { data: session, error: sessionError } = await input.supabase
+    .from("recoverable_wallet_recovery_sessions")
+    .select("*")
+    .eq("recovery_session_id", input.recoverySessionId)
+    .maybeSingle()
+
+  if (sessionError) {
+    throw sessionError
+  }
+
+  if (!session) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "Recovery session was not found."
+    )
+  }
+
+  if (session.status !== "pending" || session.consumed_at) {
+    throw new ApiSecurityError(
+      409,
+      "recovery_session_consumed",
+      "Recovery session has already been consumed."
+    )
+  }
+
+  if (new Date(String(session.expires_at)).getTime() <= Date.now()) {
+    await input.supabase
+      .from("recoverable_wallet_recovery_sessions")
+      .update({
+        status: "expired",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", session.id)
+
+    throw new ApiSecurityError(
+      410,
+      "recovery_session_expired",
+      "Recovery session has expired."
+    )
+  }
+
+  const userIds = await resolveUserIdsFromFirebaseToken(
+    input.supabase,
+    input.firebaseToken
+  )
+
+  if (!userIds.has(String(session.user_id))) {
+    throw new ApiSecurityError(
+      403,
+      "wrong_user",
+      "Signed-in Passport user does not match this recovery session."
+    )
+  }
+
+  const { data: bundle, error: bundleError } = await input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .select("*")
+    .eq("recovery_bundle_id", session.recovery_bundle_id)
+    .eq("dapp_id", session.dapp_id)
+    .eq("dapp_user_uuid", session.dapp_user_uuid)
+    .eq("user_id", session.user_id)
+    .eq("provider_key", session.provider_key)
+    .eq("status", "active")
+    .maybeSingle()
+
+  if (bundleError) {
+    throw bundleError
+  }
+
+  if (!bundle) {
+    throw new ApiSecurityError(
+      404,
+      "not_found",
+      "Active recovery bundle was not found for this session."
+    )
+  }
+
+  const wrappingKey = await getRecoverableWalletBundleWrappingKey(input.supabase)
+  const bundleMaterial = decryptRecoverableWalletBundleWithKey(
+    bundle as Record<string, unknown>,
+    wrappingKey,
+    {
+      bundleVersion: Number(bundle.bundle_version ?? 1),
+      dappId: String(bundle.dapp_id),
+      dappUserUuid: String(bundle.dapp_user_uuid),
+      providerKey: String(bundle.provider_key ?? "cubid"),
+      recoveryBundleId: String(bundle.recovery_bundle_id),
+      userId: String(bundle.user_id),
+    }
+  )
+  const releasedAt = new Date().toISOString()
+  const { data: updatedSession, error: updateSessionError } =
+    await input.supabase
+      .from("recoverable_wallet_recovery_sessions")
+      .update({
+        consumed_at: releasedAt,
+        released_at: releasedAt,
+        status: "released",
+        updated_at: releasedAt,
+      })
+      .eq("id", session.id)
+      .eq("status", "pending")
+      .select("*")
+      .maybeSingle()
+
+  if (updateSessionError) {
+    throw updateSessionError
+  }
+
+  if (!updatedSession) {
+    throw new ApiSecurityError(
+      409,
+      "recovery_session_consumed",
+      "Recovery session has already been consumed."
+    )
+  }
+
+  const { error: updateBundleError } = await input.supabase
+    .schema("private")
+    .from("recoverable_wallet_recovery_bundles")
+    .update({
+      last_released_at: releasedAt,
+      updated_at: releasedAt,
+    })
+    .eq("id", bundle.id)
+
+  if (updateBundleError) {
+    throw updateBundleError
+  }
+
+  return {
+    bundleMaterial,
+    dappUserUuid: String(session.dapp_user_uuid),
+    providerKey: String(session.provider_key ?? "cubid"),
+    recoveryBundleId: String(session.recovery_bundle_id),
+    recoverySessionId: String(session.recovery_session_id),
+    releasedAt,
+    status: "released",
+  }
 }

--- a/apps/passport/pages/api/recovery-bundles/list.ts
+++ b/apps/passport/pages/api/recovery-bundles/list.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { listRecoverableWalletRecoveryBundlesForUser } from "@/lib/server/recoverableWalletRecovery"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      bodySchema: passportSchemas.z.object({}).passthrough(),
+      rateLimitGroup: "passport_user_read",
+      route: "passport.recovery_bundles.list",
+    },
+    async ({ context }) => {
+      const data = await listRecoverableWalletRecoveryBundlesForUser({
+        firebaseToken: context.firebaseToken,
+        supabase: getPassportSupabase(),
+      })
+
+      return res.status(200).json({ data })
+    }
+  )
+}

--- a/apps/passport/pages/api/recovery-bundles/release/complete.ts
+++ b/apps/passport/pages/api/recovery-bundles/release/complete.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { releaseRecoverableWalletRecoveryBundle } from "@/lib/server/recoverableWalletRecovery"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const schema = passportSchemas.z.object({
+  recovery_session_id: passportSchemas.z.string().trim().min(1).max(160),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "user",
+      bodySchema: schema,
+      rateLimitGroup: "passport_user_mutation",
+      route: "passport.recovery_bundles.release.complete",
+    },
+    async ({ body, context }) => {
+      const release = await releaseRecoverableWalletRecoveryBundle({
+        firebaseToken: context.firebaseToken,
+        recoverySessionId: body.recovery_session_id,
+        requestId: context.requestId,
+        supabase: getPassportSupabase(),
+      })
+
+      return res.status(200).json({ data: release })
+    }
+  )
+}

--- a/apps/passport/pages/api/siwc/signing/requests/approve.ts
+++ b/apps/passport/pages/api/siwc/signing/requests/approve.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 
+import { ApiSecurityError } from "@cubid/auth/server"
 import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
-import { approvePassportSiwcSigningRequest } from "@/lib/server/siwcSigningRequests"
 
 const schema = passportSchemas.z.object({
   signingRequestId: passportSchemas.z.string().min(1),
@@ -23,14 +23,12 @@ export default async function handler(
       rateLimitGroup: "passport_user_mutation",
       route: "passport.siwc.signing.requests.approve",
     },
-    async ({ body, context }) => {
-      const data = await approvePassportSiwcSigningRequest({
-        req,
-        requestId: context.requestId,
-        signingRequestId: body.signingRequestId,
-      })
-
-      return res.status(200).json({ data })
+    async () => {
+      throw new ApiSecurityError(
+        410,
+        "cubid_signing_deprecated",
+        "Cubid normal wallet signing is deprecated. Use app-mediated threshold signing with Cubid recovery bundles instead."
+      )
     }
   )
 }

--- a/apps/passport/pages/api/v3/accounts/generate.ts
+++ b/apps/passport/pages/api/v3/accounts/generate.ts
@@ -5,12 +5,6 @@ import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
-import {
-  getApiV3IdempotencyKey,
-  runApiV3IdempotentWrite,
-} from "@/lib/server/apiV3Idempotency"
-import { createGeneratedBlockchainAccount } from "@/lib/server/blockchainAccounts"
-import { getPassportSupabase } from "@/lib/server/supabase"
 
 const schema = passportSchemas.z.object({
   api_key: passportSchemas.z.string().min(1).optional(),
@@ -37,39 +31,12 @@ export default async function handler(
       rateLimitGroup: "passport_dapp_mutation",
       route: "v3.accounts.generate",
     },
-    async ({ body, context }) => {
-      const supabase = getPassportSupabase()
-      const response = await runApiV3IdempotentWrite({
-        actorIdentifier: context.actorIdentifier,
-        actorType: context.actorType,
-        body,
-        idempotencyKey: getApiV3IdempotencyKey(req),
-        requestId: context.requestId,
-        route: "v3.accounts.generate",
-        supabase,
-        handler: async () => {
-          const account = await createGeneratedBlockchainAccount({
-            chain: body.chain,
-            dappId: context.dapp.id,
-            dappUserUuid: body.dapp_user_uuid,
-            label: body.label ?? null,
-            requestId: context.requestId,
-            supabase,
-          })
-
-          if (!account) {
-            throw new ApiSecurityError(
-              404,
-              "not_found",
-              "Dapp user was not found for the authenticated app."
-            )
-          }
-
-          return { body: { data: account }, statusCode: 200 }
-        },
-      })
-
-      return res.status(response.statusCode).json(response.body)
+    async () => {
+      throw new ApiSecurityError(
+        410,
+        "cubid_generated_wallets_deprecated",
+        "Cubid-generated wallet creation is deprecated. Use app-mediated recoverable wallets with Cubid recovery bundles instead."
+      )
     }
   )
 }

--- a/apps/passport/pages/api/v3/recovery-bundles/enroll.ts
+++ b/apps/passport/pages/api/v3/recovery-bundles/enroll.ts
@@ -1,0 +1,83 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import {
+  getApiV3IdempotencyKey,
+  runApiV3IdempotentWrite,
+} from "@/lib/server/apiV3Idempotency"
+import { enrollRecoverableWalletRecoveryBundle } from "@/lib/server/recoverableWalletRecovery"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const schema = passportSchemas.z.object({
+  api_key: passportSchemas.z.string().min(1).optional(),
+  apikey: passportSchemas.z.string().min(1).optional(),
+  bundle_material: passportSchemas.z.string().min(1).max(100_000),
+  bundle_version: passportSchemas.z.number().int().positive().optional(),
+  dapp_id: passportSchemas.z.union([
+    passportSchemas.z.number().int().positive(),
+    passportSchemas.z.string().min(1),
+  ]).optional(),
+  dapp_user_uuid: passportSchemas.z.string().uuid(),
+  expires_at: passportSchemas.z.string().datetime().optional(),
+  metadata: passportSchemas.z.record(passportSchemas.z.unknown()).optional(),
+  provider_key: passportSchemas.z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9_-]{1,64}$/)
+    .optional(),
+  recovery_bundle_id: passportSchemas.z.string().trim().min(1).max(160).optional(),
+  recovery_reference: passportSchemas.z.string().trim().max(200).optional(),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "dapp",
+      bodySchema: schema,
+      rateLimitGroup: "passport_dapp_mutation",
+      route: "v3.recovery_bundles.enroll",
+    },
+    async ({ body, context }) => {
+      const supabase = getPassportSupabase()
+      const response = await runApiV3IdempotentWrite({
+        actorIdentifier: context.actorIdentifier,
+        actorType: context.actorType,
+        body,
+        idempotencyKey: getApiV3IdempotencyKey(req),
+        requestId: context.requestId,
+        route: "v3.recovery_bundles.enroll",
+        supabase,
+        handler: async () => {
+          const status = await enrollRecoverableWalletRecoveryBundle({
+            bundleMaterial: body.bundle_material,
+            bundleVersion: body.bundle_version ?? null,
+            dappId: context.dapp.id,
+            dappUserUuid: body.dapp_user_uuid,
+            expiresAt: body.expires_at ?? null,
+            metadata: body.metadata ?? null,
+            providerKey: body.provider_key ?? null,
+            recoveryBundleId: body.recovery_bundle_id ?? null,
+            recoveryReference: body.recovery_reference ?? null,
+            requestId: context.requestId,
+            supabase,
+          })
+
+          return {
+            body: { data: status },
+            statusCode: 200,
+          }
+        },
+      })
+
+      return res.status(response.statusCode).json(response.body)
+    }
+  )
+}

--- a/apps/passport/pages/api/v3/recovery-bundles/release/start.ts
+++ b/apps/passport/pages/api/v3/recovery-bundles/release/start.ts
@@ -1,0 +1,74 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import {
+  getApiV3IdempotencyKey,
+  runApiV3IdempotentWrite,
+} from "@/lib/server/apiV3Idempotency"
+import { createRecoverableWalletRecoveryReleaseSession } from "@/lib/server/recoverableWalletRecovery"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const schema = passportSchemas.z.object({
+  api_key: passportSchemas.z.string().min(1).optional(),
+  apikey: passportSchemas.z.string().min(1).optional(),
+  dapp_id: passportSchemas.z.union([
+    passportSchemas.z.number().int().positive(),
+    passportSchemas.z.string().min(1),
+  ]).optional(),
+  dapp_user_uuid: passportSchemas.z.string().uuid(),
+  provider_key: passportSchemas.z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9_-]{1,64}$/)
+    .optional(),
+  recovery_bundle_id: passportSchemas.z.string().trim().min(1).max(160).optional(),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "dapp",
+      bodySchema: schema,
+      rateLimitGroup: "passport_dapp_mutation",
+      route: "v3.recovery_bundles.release.start",
+    },
+    async ({ body, context }) => {
+      const supabase = getPassportSupabase()
+      const response = await runApiV3IdempotentWrite({
+        actorIdentifier: context.actorIdentifier,
+        actorType: context.actorType,
+        body,
+        idempotencyKey: getApiV3IdempotencyKey(req),
+        requestId: context.requestId,
+        route: "v3.recovery_bundles.release.start",
+        supabase,
+        handler: async () => {
+          const session = await createRecoverableWalletRecoveryReleaseSession({
+            actorIdentifier: context.actorIdentifier,
+            dappId: context.dapp.id,
+            dappUserUuid: body.dapp_user_uuid,
+            providerKey: body.provider_key ?? null,
+            recoveryBundleId: body.recovery_bundle_id ?? null,
+            requestId: context.requestId,
+            supabase,
+          })
+
+          return {
+            body: { data: session },
+            statusCode: 200,
+          }
+        },
+      })
+
+      return res.status(response.statusCode).json(response.body)
+    }
+  )
+}

--- a/apps/passport/pages/api/v3/recovery-bundles/revoke.ts
+++ b/apps/passport/pages/api/v3/recovery-bundles/revoke.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { revokeRecoverableWalletRecoveryBundle } from "@/lib/server/recoverableWalletRecovery"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const schema = passportSchemas.z.object({
+  api_key: passportSchemas.z.string().min(1).optional(),
+  apikey: passportSchemas.z.string().min(1).optional(),
+  dapp_id: passportSchemas.z.union([
+    passportSchemas.z.number().int().positive(),
+    passportSchemas.z.string().min(1),
+  ]).optional(),
+  dapp_user_uuid: passportSchemas.z.string().uuid(),
+  provider_key: passportSchemas.z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9_-]{1,64}$/)
+    .optional(),
+  recovery_bundle_id: passportSchemas.z.string().trim().min(1).max(160),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "dapp",
+      bodySchema: schema,
+      rateLimitGroup: "passport_dapp_mutation",
+      route: "v3.recovery_bundles.revoke",
+    },
+    async ({ body, context }) => {
+      const status = await revokeRecoverableWalletRecoveryBundle({
+        actorIdentifier: context.actorIdentifier,
+        dappId: context.dapp.id,
+        dappUserUuid: body.dapp_user_uuid,
+        providerKey: body.provider_key ?? null,
+        recoveryBundleId: body.recovery_bundle_id,
+        requestId: context.requestId,
+        supabase: getPassportSupabase(),
+      })
+
+      return res.status(200).json({ data: status })
+    }
+  )
+}

--- a/apps/passport/pages/api/v3/recovery-bundles/rotate.ts
+++ b/apps/passport/pages/api/v3/recovery-bundles/rotate.ts
@@ -8,14 +8,13 @@ import {
   getApiV3IdempotencyKey,
   runApiV3IdempotentWrite,
 } from "@/lib/server/apiV3Idempotency"
-import { enrollRecoverableWalletRecoveryBundle } from "@/lib/server/recoverableWalletRecovery"
+import { rotateRecoverableWalletRecoveryBundle } from "@/lib/server/recoverableWalletRecovery"
 import { getPassportSupabase } from "@/lib/server/supabase"
 
 const schema = passportSchemas.z.object({
   api_key: passportSchemas.z.string().min(1).optional(),
   apikey: passportSchemas.z.string().min(1).optional(),
   bundle_material: passportSchemas.z.string().min(1).max(100_000),
-  bundle_version: passportSchemas.z.number().int().positive().optional(),
   dapp_id: passportSchemas.z.union([
     passportSchemas.z.number().int().positive(),
     passportSchemas.z.string().min(1),
@@ -23,12 +22,13 @@ const schema = passportSchemas.z.object({
   dapp_user_uuid: passportSchemas.z.string().uuid(),
   expires_at: passportSchemas.z.string().datetime().optional(),
   metadata: passportSchemas.z.record(passportSchemas.z.unknown()).optional(),
+  new_recovery_bundle_id: passportSchemas.z.string().trim().min(1).max(160).optional(),
   provider_key: passportSchemas.z
     .string()
     .trim()
     .regex(/^[a-z0-9_-]{1,64}$/)
     .optional(),
-  recovery_bundle_id: passportSchemas.z.string().trim().min(1).max(160).optional(),
+  recovery_bundle_id: passportSchemas.z.string().trim().min(1).max(160),
   recovery_reference: passportSchemas.z.string().trim().max(200).optional(),
 })
 
@@ -43,7 +43,7 @@ export default async function handler(
       actor: "dapp",
       bodySchema: schema,
       rateLimitGroup: "passport_dapp_mutation",
-      route: "v3.recovery_bundles.enroll",
+      route: "v3.recovery_bundles.rotate",
     },
     async ({ body, context }) => {
       const supabase = getPassportSupabase()
@@ -53,19 +53,19 @@ export default async function handler(
         body,
         idempotencyKey: getApiV3IdempotencyKey(req),
         requestId: context.requestId,
-        route: "v3.recovery_bundles.enroll",
+        route: "v3.recovery_bundles.rotate",
         supabase,
         handler: async () => {
-          const status = await enrollRecoverableWalletRecoveryBundle({
+          const status = await rotateRecoverableWalletRecoveryBundle({
             actorIdentifier: context.actorIdentifier,
             bundleMaterial: body.bundle_material,
-            bundleVersion: body.bundle_version ?? null,
             dappId: context.dapp.id,
             dappUserUuid: body.dapp_user_uuid,
             expiresAt: body.expires_at ?? null,
             metadata: body.metadata ?? null,
+            newRecoveryBundleId: body.new_recovery_bundle_id ?? null,
             providerKey: body.provider_key ?? null,
-            recoveryBundleId: body.recovery_bundle_id ?? null,
+            recoveryBundleId: body.recovery_bundle_id,
             recoveryReference: body.recovery_reference ?? null,
             requestId: context.requestId,
             supabase,

--- a/apps/passport/pages/api/v3/recovery-bundles/status.ts
+++ b/apps/passport/pages/api/v3/recovery-bundles/status.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import {
+  handlePassportRoute,
+  passportSchemas,
+} from "@/lib/server/passportApi"
+import { getRecoverableWalletRecoveryBundleStatus } from "@/lib/server/recoverableWalletRecovery"
+import { getPassportSupabase } from "@/lib/server/supabase"
+
+const schema = passportSchemas.z.object({
+  api_key: passportSchemas.z.string().min(1).optional(),
+  apikey: passportSchemas.z.string().min(1).optional(),
+  dapp_id: passportSchemas.z.union([
+    passportSchemas.z.number().int().positive(),
+    passportSchemas.z.string().min(1),
+  ]).optional(),
+  dapp_user_uuid: passportSchemas.z.string().uuid(),
+  provider_key: passportSchemas.z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9_-]{1,64}$/)
+    .optional(),
+  recovery_bundle_id: passportSchemas.z.string().trim().min(1).max(160).optional(),
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  return handlePassportRoute(
+    req,
+    res,
+    {
+      actor: "dapp",
+      bodySchema: schema,
+      rateLimitGroup: "passport_dapp_read",
+      route: "v3.recovery_bundles.status",
+    },
+    async ({ body, context }) => {
+      const status = await getRecoverableWalletRecoveryBundleStatus({
+        dappId: context.dapp.id,
+        dappUserUuid: body.dapp_user_uuid,
+        providerKey: body.provider_key ?? null,
+        recoveryBundleId: body.recovery_bundle_id ?? null,
+        supabase: getPassportSupabase(),
+      })
+
+      return res.status(200).json({ data: status })
+    }
+  )
+}

--- a/apps/passport/pages/api/v3/signing/requests/create.ts
+++ b/apps/passport/pages/api/v3/signing/requests/create.ts
@@ -1,15 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 
-import {
-  getApiV3IdempotencyKey,
-  runApiV3IdempotentWrite,
-} from "@/lib/server/apiV3Idempotency"
+import { ApiSecurityError } from "@cubid/auth/server"
 import {
   handlePassportRoute,
   passportSchemas,
 } from "@/lib/server/passportApi"
-import { createSiwcSigningRequest } from "@/lib/server/siwcSigningRequests"
-import { getPassportSupabase } from "@/lib/server/supabase"
 
 const jsonObject = passportSchemas.z.record(passportSchemas.z.unknown())
 
@@ -40,35 +35,12 @@ export default async function handler(
       rateLimitGroup: "passport_dapp_mutation",
       route: "v3.signing.requests.create",
     },
-    async ({ body, context }) => {
-      const supabase = getPassportSupabase()
-      const idempotencyKey = getApiV3IdempotencyKey(req)
-      const response = await runApiV3IdempotentWrite({
-        actorIdentifier: context.actorIdentifier,
-        actorType: context.actorType,
-        body,
-        idempotencyKey,
-        requestId: context.requestId,
-        route: "v3.signing.requests.create",
-        supabase,
-        handler: async () => {
-          const request = await createSiwcSigningRequest({
-            dappId: context.dapp.id,
-            dappUserUuid: body.dapp_user_uuid,
-            idempotencyKey,
-            payload: body.payload,
-            payloadSummary: body.payload_summary,
-            requestId: context.requestId,
-            requestType: body.request_type,
-            supabase,
-            userAccountId: body.user_account_id,
-          })
-
-          return { body: { data: request }, statusCode: 200 }
-        },
-      })
-
-      return res.status(response.statusCode).json(response.body)
+    async () => {
+      throw new ApiSecurityError(
+        410,
+        "cubid_signing_deprecated",
+        "Cubid normal wallet signing is deprecated. Use app-mediated threshold signing with Cubid recovery bundles instead."
+      )
     }
   )
 }

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -50,6 +50,7 @@ export class MockPassportSupabase {
   readonly oidcHumanSubjects: Array<Record<string, unknown>> = []
   readonly privateKeys: Array<Record<string, unknown>> = []
   readonly recoverableWalletRecoveryBundles: Array<Record<string, unknown>> = []
+  readonly recoverableWalletRecoverySessions: Array<Record<string, unknown>> = []
   readonly notificationChannels: Array<Record<string, unknown>> = []
   readonly notificationAppGrants: Array<Record<string, unknown>> = []
   readonly notificationAppPolicies: Array<Record<string, unknown>> = []
@@ -1247,6 +1248,8 @@ export class MockPassportSupabase {
         this.privateNotificationChannelDestinations,
       "private.recoverable_wallet_recovery_bundles":
         this.recoverableWalletRecoveryBundles,
+      "recoverable_wallet_recovery_sessions":
+        this.recoverableWalletRecoverySessions,
       "user_notification_channels": this.notificationChannels,
     }
 

--- a/apps/passport/tests/helpers.ts
+++ b/apps/passport/tests/helpers.ts
@@ -49,6 +49,7 @@ export class MockPassportSupabase {
   readonly lastUsedUpdates: number[] = []
   readonly oidcHumanSubjects: Array<Record<string, unknown>> = []
   readonly privateKeys: Array<Record<string, unknown>> = []
+  readonly recoverableWalletRecoveryBundles: Array<Record<string, unknown>> = []
   readonly notificationChannels: Array<Record<string, unknown>> = []
   readonly notificationAppGrants: Array<Record<string, unknown>> = []
   readonly notificationAppPolicies: Array<Record<string, unknown>> = []
@@ -140,6 +141,17 @@ export class MockPassportSupabase {
     if (name === "get_notification_challenge_hash_secret_v1") {
       return Promise.resolve({
         data: "test-passport-notification-challenge-secret",
+        error: null,
+      })
+    }
+
+    if (
+      name === "get_recoverable_wallet_recovery_bundle_wrapping_key_v1"
+    ) {
+      return Promise.resolve({
+        data: Buffer.from(
+          "recover0123456789abcdef012345678"
+        ).toString("base64"),
         error: null,
       })
     }
@@ -1233,6 +1245,8 @@ export class MockPassportSupabase {
       "notification_providers": this.notificationProviders,
       "private.notification_channel_destinations":
         this.privateNotificationChannelDestinations,
+      "private.recoverable_wallet_recovery_bundles":
+        this.recoverableWalletRecoveryBundles,
       "user_notification_channels": this.notificationChannels,
     }
 

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -33,8 +33,11 @@ import saveSecretV2Handler from "../pages/api/v2/save_secret"
 import generateAccountV3Handler from "../pages/api/v3/accounts/generate"
 import listAccountsV3Handler from "../pages/api/v3/accounts/list"
 import completeRecoveryReleaseHandler from "../pages/api/recovery-bundles/release/complete"
+import listRecoveryBundlesHandler from "../pages/api/recovery-bundles/list"
 import enrollRecoveryBundleV3Handler from "../pages/api/v3/recovery-bundles/enroll"
+import rotateRecoveryBundleV3Handler from "../pages/api/v3/recovery-bundles/rotate"
 import startRecoveryReleaseV3Handler from "../pages/api/v3/recovery-bundles/release/start"
+import revokeRecoveryBundleV3Handler from "../pages/api/v3/recovery-bundles/revoke"
 import recoveryBundleStatusV3Handler from "../pages/api/v3/recovery-bundles/status"
 import saveSecretV3Handler from "../pages/api/v3/save_secret"
 import cancelSiwcSigningRequestHandler from "../pages/api/v3/signing/requests/cancel"
@@ -3798,6 +3801,144 @@ test("Passport user recovery release rejects wrong users and expired sessions", 
     (expiredRes.body as { error: { code: string } }).error.code,
     "recovery_session_expired"
   )
+})
+
+test("Passport v3 recovery bundle rotation retires the prior active bundle", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000267"
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "old-client-share",
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_rotate_old",
+      },
+      headers: {
+        "idempotency-key": "recovery-rotate-enroll",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    createApiResponse()
+  )
+
+  const rotateRes = createApiResponse()
+  await rotateRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "new-client-share",
+        dapp_user_uuid: dappUserUuid,
+        new_recovery_bundle_id: "rw_bundle_rotate_new",
+        recovery_bundle_id: "rw_bundle_rotate_old",
+      },
+      headers: {
+        "idempotency-key": "recovery-rotate-primary",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/rotate",
+    }),
+    rotateRes
+  )
+
+  assert.equal(rotateRes.statusCode, 200)
+  const data = (rotateRes.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(data.recoveryBundleId, "rw_bundle_rotate_new")
+  assert.equal(data.bundleVersion, 2)
+  assert.equal(supabase.recoverableWalletRecoveryBundles.length, 2)
+  assert.equal(supabase.recoverableWalletRecoveryBundles[0].status, "rotated")
+  assert.equal(supabase.recoverableWalletRecoveryBundles[1].status, "active")
+  assert.equal(JSON.stringify(rotateRes.body).includes("new-client-share"), false)
+  assert.equal(
+    supabase.eventInserts.some(
+      (event) => event.event_type === "recoverable_wallet.bundle.rotated"
+    ),
+    true
+  )
+})
+
+test("Passport v3 recovery bundle revocation and user list return redacted lifecycle state", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000268"
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "revoked-client-share",
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_revoke",
+      },
+      headers: {
+        "idempotency-key": "recovery-revoke-enroll",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    createApiResponse()
+  )
+
+  const revokeRes = createApiResponse()
+  await revokeRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_revoke",
+      },
+      headers: {
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/revoke",
+    }),
+    revokeRes
+  )
+
+  assert.equal(revokeRes.statusCode, 200)
+  assert.equal(
+    (revokeRes.body as DataResponse<Record<string, unknown>>).data.status,
+    "revoked"
+  )
+  assert.equal(
+    supabase.eventInserts.some(
+      (event) => event.event_type === "recoverable_wallet.bundle.revoked"
+    ),
+    true
+  )
+
+  const listRes = createApiResponse()
+  await listRecoveryBundlesHandler(
+    createApiRequest({
+      body: {},
+      headers: {
+        authorization: "Bearer firebase-test-token",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/recovery-bundles/list",
+    }),
+    listRes
+  )
+
+  assert.equal(listRes.statusCode, 200)
+  const listData = (listRes.body as DataResponse<Array<Record<string, unknown>>>)
+    .data
+  assert.equal(listData.length, 1)
+  assert.equal(listData[0].status, "revoked")
+  assert.equal(listData[0].recoveryBundleId, "rw_bundle_revoke")
+  assert.equal(JSON.stringify(listRes.body).includes("revoked-client-share"), false)
+  assert.equal(JSON.stringify(listRes.body).includes("bundle_ciphertext"), false)
+  assert.equal(JSON.stringify(listRes.body).includes("wrapped_data_key"), false)
 })
 
 test.skip("legacy Cubid account generation encrypted private keys and linked the triggering dapp user", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -3532,6 +3532,39 @@ test("Passport v3 recovery bundle APIs reject cross-dapp users and replay idempo
   assert.deepEqual(replayRes.body, firstRes.body)
   assert.equal(supabase.recoverableWalletRecoveryBundles.length, 1)
 
+  supabase.setDappUser({
+    dapp_id: 42,
+    user_id: 4321,
+    uuid: "00000000-0000-4000-8000-000000000269",
+  })
+  const reboundRes = createApiResponse()
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "rebound-client-share",
+        dapp_user_uuid: "00000000-0000-4000-8000-000000000269",
+        recovery_bundle_id: "rw_bundle_idempotent",
+      },
+      headers: {
+        "idempotency-key": "recovery-bundle-rebind",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    reboundRes
+  )
+  assert.equal(reboundRes.statusCode, 409)
+  assert.equal(
+    (reboundRes.body as { error: { code: string } }).error.code,
+    "unsupported_app_context"
+  )
+  assert.equal(supabase.recoverableWalletRecoveryBundles.length, 1)
+  assert.equal(
+    supabase.recoverableWalletRecoveryBundles[0].dapp_user_uuid,
+    dappUserUuid
+  )
+
   const crossDappRes = createApiResponse()
   await enrollRecoveryBundleV3Handler(
     createApiRequest({
@@ -3608,6 +3641,50 @@ test("Passport v3 recovery release start creates a user-only release session", a
   assert.equal(JSON.stringify(res.body).includes("client-share"), false)
   assert.equal(JSON.stringify(res.body).includes("bundleMaterial"), false)
   assert.equal(supabase.recoverableWalletRecoverySessions.length, 1)
+})
+
+test("Passport v3 recovery release start does not leak revoked bundles across app contexts", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000270"
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.recoverableWalletRecoveryBundles.push({
+    created_at: new Date().toISOString(),
+    dapp_id: 99,
+    dapp_user_uuid: "00000000-0000-4000-8000-000000000271",
+    id: "foreign-revoked-bundle",
+    provider_key: "cubid",
+    recovery_bundle_id: "rw_bundle_foreign_revoked",
+    status: "revoked",
+    updated_at: new Date().toISOString(),
+    user_id: 9999,
+  })
+  setPassportSupabaseForTests(supabase as never)
+
+  const res = createApiResponse()
+  await startRecoveryReleaseV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_foreign_revoked",
+      },
+      headers: {
+        "idempotency-key": "recovery-release-foreign-revoked",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/release/start",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 404)
+  assert.equal(
+    (res.body as { error: { code: string } }).error.code,
+    "recovery_bundle_not_found"
+  )
+  assert.equal(supabase.recoverableWalletRecoverySessions.length, 0)
 })
 
 test("Passport user recovery release returns bundle material once to the verified user", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -1795,7 +1795,151 @@ const addSiwcSigningFixtures = (
   }
 }
 
-test("Passport API v3 SIWC signing request create/get/list use policy and idempotency", async () => {
+const addLegacyVisibleAccount = (
+  supabase: MockPassportSupabase,
+  input: {
+    chain: string
+    dappId?: number
+    dappUserUuid: string
+    id: string
+    label?: string
+    publicAddress: string
+    userId?: number
+  }
+) => {
+  supabase.userAccounts.push({
+    account_label: input.label ?? null,
+    chain_key: input.chain,
+    created_at: "2026-05-01T00:00:00.000Z",
+    custody_status: "legacy_cubid_custodied",
+    id: input.id,
+    public_address: input.publicAddress,
+    public_address_normalized:
+      input.chain === "solana"
+        ? input.publicAddress
+        : input.publicAddress.toLowerCase(),
+    status: "active",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    user_id: input.userId ?? 1234,
+  })
+  supabase.dappUserAccounts.push({
+    created_at: "2026-05-01T00:00:00.000Z",
+    dapp_id: input.dappId ?? 42,
+    dapp_user_uuid: input.dappUserUuid,
+    id: `${input.id}_link`,
+    status: "active",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    user_account_id: input.id,
+  })
+}
+
+test("Passport API v3 rejects new Cubid-generated wallet creation", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000152"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  const res = createApiResponse()
+  await generateAccountV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        chain: "evm",
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        "idempotency-key": "deprecated-generate-wallet",
+        origin: "https://passport.cubid.me",
+        "x-request-id": "passport_deprecated_generate",
+      },
+      url: "/api/v3/accounts/generate",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 410)
+  assert.equal(
+    (res.body as { error: { code: string; requestId: string } }).error.code,
+    "cubid_generated_wallets_deprecated"
+  )
+  assert.equal(
+    (res.body as { error: { code: string; requestId: string } }).error
+      .requestId,
+    "passport_deprecated_generate"
+  )
+  assert.equal(supabase.userAccounts.length, 0)
+  assert.equal(supabase.privateKeys.length, 0)
+  assert.equal(supabase.dappUserAccounts.length, 0)
+})
+
+test("Passport API v3 rejects new Cubid normal-signing requests", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  const fixtures = addSiwcSigningFixtures(supabase)
+
+  const res = createApiResponse()
+  await createSiwcSigningRequestHandler(
+    createApiRequest({
+      body: {
+        apikey: fixtures.apiKey,
+        dapp_user_uuid: fixtures.dappUserUuid,
+        payload: { message: "deprecated signing" },
+        request_type: "message",
+        user_account_id: fixtures.userAccountId,
+      },
+      headers: {
+        "idempotency-key": "deprecated-signing-request",
+        origin: "https://passport.cubid.me",
+        "x-request-id": "passport_deprecated_signing",
+      },
+      url: "/api/v3/signing/requests/create",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 410)
+  assert.equal(
+    (res.body as { error: { code: string; requestId: string } }).error.code,
+    "cubid_signing_deprecated"
+  )
+  assert.equal(
+    (res.body as { error: { code: string; requestId: string } }).error
+      .requestId,
+    "passport_deprecated_signing"
+  )
+  assert.equal(supabase.siwcSigningRequests.length, 0)
+})
+
+test("Passport SIWC approval refuses legacy signing without decrypting keys", async () => {
+  const supabase = new MockPassportSupabase()
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+  addSiwcSigningFixtures(supabase)
+
+  const res = createApiResponse()
+  await approveSiwcSigningRequestHandler(
+    createApiRequest({
+      body: { signingRequestId: "legacy_signing_request" },
+      headers: {
+        authorization: "Bearer firebase-test-token",
+        origin: "https://passport.cubid.me",
+        "x-request-id": "passport_deprecated_approval",
+      },
+      url: "/api/siwc/signing/requests/approve",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 410)
+  assert.equal(
+    (res.body as { error: { code: string; requestId: string } }).error.code,
+    "cubid_signing_deprecated"
+  )
+  assert.equal(supabase.privateKeys.length, 1)
+})
+
+test.skip("legacy Cubid signing request creation used policy and idempotency", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   const fixtures = addSiwcSigningFixtures(supabase)
@@ -1870,7 +2014,7 @@ test("Passport API v3 SIWC signing request create/get/list use policy and idempo
   assert.equal((listRes.body as DataResponse<unknown[]>).data.length, 1)
 })
 
-test("Passport API v3 SIWC signing request policy-denies deferred transactions", async () => {
+test.skip("legacy Cubid signing request policy-denied deferred transactions", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   const fixtures = addSiwcSigningFixtures(supabase, {
@@ -1913,7 +2057,7 @@ test("Passport API v3 SIWC signing request policy-denies deferred transactions",
   assert.equal(data.stepUpRequired, true)
 })
 
-test("Passport API v3 SIWC transaction risk records value and allowlist denials", async () => {
+test.skip("legacy Cubid signing transaction risk recorded value and allowlist denials", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   const fixtures = addSiwcSigningFixtures(supabase, {
@@ -1958,7 +2102,7 @@ test("Passport API v3 SIWC transaction risk records value and allowlist denials"
   ])
 })
 
-test("Passport API v3 SIWC transaction risk fails closed for unsupported chains", async () => {
+test.skip("legacy Cubid signing transaction risk failed closed for unsupported chains", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   const fixtures = addSiwcSigningFixtures(supabase, {
@@ -2010,7 +2154,7 @@ test("Passport API v3 SIWC transaction risk fails closed for unsupported chains"
   assert.deepEqual(data.riskReasons, ["transaction_chain_risk_unsupported"])
 })
 
-test("Passport API v3 SIWC signing request emits created and policy-denied webhooks", async () => {
+test.skip("legacy Cubid signing request emitted created and policy-denied webhooks", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   const fixtures = addSiwcSigningFixtures(supabase, {
@@ -2081,7 +2225,7 @@ test("Passport API v3 SIWC signing request emits created and policy-denied webho
   assert.equal(JSON.stringify(delivered).includes("human_subject_key"), false)
 })
 
-test("Passport SIWC signing approval requires passkey step-up then completes EVM message signatures", async () => {
+test.skip("legacy Cubid signing approval completed EVM message signatures", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   addFirebaseUserAuth()
@@ -2165,7 +2309,7 @@ test("Passport SIWC signing approval requires passkey step-up then completes EVM
   assert.equal(JSON.stringify(approveRes.body).includes(fixtures.wallet.privateKey), false)
 })
 
-test("Passport SIWC signing approval emits approved and signature completed webhooks", async () => {
+test.skip("legacy Cubid signing approval emitted completed webhooks", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   addFirebaseUserAuth()
@@ -2264,7 +2408,7 @@ test("Passport SIWC signing approval emits approved and signature completed webh
   assert.equal(JSON.stringify(completed).includes(fixtures.wallet.privateKey), false)
 })
 
-test("Passport SIWC signing approval rejects stale passkey step-up sessions", async () => {
+test.skip("legacy Cubid signing approval rejected stale passkey step-up sessions", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   addFirebaseUserAuth()
@@ -2354,7 +2498,7 @@ test("Passport SIWC signing approval rejects stale passkey step-up sessions", as
   )
 })
 
-test("Passport SIWC signing requests can be listed, rejected, and cancelled", async () => {
+test.skip("legacy Cubid signing requests could be listed rejected and cancelled", async () => {
   const supabase = new MockPassportSupabase()
   setPassportSupabaseForTests(supabase as never)
   addFirebaseUserAuth()
@@ -3213,7 +3357,7 @@ test("Passport v3 save_secret rejects dapp-id mismatches and rate-limit denials"
   assert.equal(supabase.privateDappUserSecrets.length, 0)
 })
 
-test("Passport v3 account generation encrypts private keys and links only the triggering dapp user", async () => {
+test.skip("legacy Cubid account generation encrypted private keys and linked the triggering dapp user", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000052"
@@ -3277,7 +3421,7 @@ test("Passport v3 account generation encrypts private keys and links only the tr
   assert.equal(decrypted.startsWith("0x"), true)
 })
 
-test("Passport v3 account generation rejects dapp users outside the authenticated app", async () => {
+test.skip("legacy Cubid account generation rejected dapp users outside the authenticated app", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000053"
@@ -3306,7 +3450,7 @@ test("Passport v3 account generation rejects dapp users outside the authenticate
   assert.equal(supabase.dappUserAccounts.length, 0)
 })
 
-test("Passport v3 account generation supports Sui without exposing private keys", async () => {
+test.skip("legacy Cubid account generation supported Sui without exposing private keys", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000054"
@@ -3343,7 +3487,7 @@ test("Passport v3 account generation supports Sui without exposing private keys"
   assert.equal(supabase.dappUserAccounts.length, 1)
 })
 
-test("Passport v3 account generation replays Idempotency-Key writes without creating duplicate accounts", async () => {
+test.skip("legacy Cubid account generation replayed Idempotency-Key writes", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000056"
@@ -3379,7 +3523,7 @@ test("Passport v3 account generation replays Idempotency-Key writes without crea
   assert.equal(supabase.dappUserAccounts.length, 1)
 })
 
-test("Passport v3 account generation rejects idempotency conflicts and pending requests", async () => {
+test.skip("legacy Cubid account generation rejected idempotency conflicts and pending requests", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000057"
@@ -3453,7 +3597,7 @@ test("Passport v3 account generation rejects idempotency conflicts and pending r
   )
 })
 
-test("Passport v3 account generation cleans up public account rows on private-key failure", async () => {
+test.skip("legacy Cubid account generation cleaned up public rows on private-key failure", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000058"
@@ -3485,7 +3629,7 @@ test("Passport v3 account generation cleans up public account rows on private-ke
   assert.equal(supabase.apiIdempotencyKeys[0]?.status, "failed")
 })
 
-test("Passport v3 account generation emits safe wallet.created webhooks", async () => {
+test.skip("legacy Cubid account generation emitted safe wallet.created webhooks", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000057"
@@ -3538,7 +3682,7 @@ test("Passport v3 account generation emits safe wallet.created webhooks", async 
   assert.equal(JSON.stringify(payload).includes("human_subject_key"), false)
 })
 
-test("Passport v3 account generation skips SIWC webhooks not enabled by policy", async () => {
+test.skip("legacy Cubid account generation skipped SIWC webhooks not enabled by policy", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000053"
@@ -3579,7 +3723,7 @@ test("Passport v3 account generation skips SIWC webhooks not enabled by policy",
   assert.equal(supabase.webhookEventDeliveries.length, 0)
 })
 
-test("Passport v3 account generation records failed SIWC webhook delivery without failing the response", async () => {
+test.skip("legacy Cubid account generation recorded failed SIWC webhook delivery", async () => {
   const supabase = new MockPassportSupabase()
   const apiKey = addDappAuth(supabase)
   const dappUserUuid = "00000000-0000-4000-8000-000000000054"
@@ -3629,19 +3773,12 @@ test("Passport v3 account list returns dapp-user-visible metadata without secret
   supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
   setPassportSupabaseForTests(supabase as never)
 
-  const generateReq = createApiRequest({
-    body: {
-      api_key: apiKey,
-      chain: "solana",
-      dapp_user_uuid: dappUserUuid,
-    },
-    headers: {
-      "idempotency-key": "generate-solana-for-list",
-      origin: "https://passport.cubid.me",
-    },
-    url: "/api/v3/accounts/generate",
+  addLegacyVisibleAccount(supabase, {
+    chain: "solana",
+    dappUserUuid,
+    id: "00000000-0000-4000-8000-000000000155",
+    publicAddress: "solana-visible-account",
   })
-  await generateAccountV3Handler(generateReq, createApiResponse())
 
   const listReq = createApiRequest({
     body: {
@@ -3721,36 +3858,18 @@ test("Passport v3 account list validates auth, payloads, ownership, and chain fi
   )
   assert.equal(crossDappRes.statusCode, 404)
 
-  await generateAccountV3Handler(
-    createApiRequest({
-      body: {
-        api_key: apiKey,
-        chain: "evm",
-        dapp_user_uuid: dappUserUuid,
-      },
-      headers: {
-        "idempotency-key": "generate-evm-for-filter",
-        origin: "https://passport.cubid.me",
-      },
-      url: "/api/v3/accounts/generate",
-    }),
-    createApiResponse()
-  )
-  await generateAccountV3Handler(
-    createApiRequest({
-      body: {
-        api_key: apiKey,
-        chain: "sui",
-        dapp_user_uuid: dappUserUuid,
-      },
-      headers: {
-        "idempotency-key": "generate-sui-for-filter",
-        origin: "https://passport.cubid.me",
-      },
-      url: "/api/v3/accounts/generate",
-    }),
-    createApiResponse()
-  )
+  addLegacyVisibleAccount(supabase, {
+    chain: "evm",
+    dappUserUuid,
+    id: "00000000-0000-4000-8000-000000000159",
+    publicAddress: "0x0000000000000000000000000000000000000159",
+  })
+  addLegacyVisibleAccount(supabase, {
+    chain: "sui",
+    dappUserUuid,
+    id: "00000000-0000-4000-8000-000000000160",
+    publicAddress: "0x0000000000000000000000000000000000000160",
+  })
 
   const filteredRes = createApiResponse()
   await listAccountsV3Handler(

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -32,7 +32,9 @@ import verifyEmailOtpHandler from "../pages/api/v2/email/verify_otp"
 import saveSecretV2Handler from "../pages/api/v2/save_secret"
 import generateAccountV3Handler from "../pages/api/v3/accounts/generate"
 import listAccountsV3Handler from "../pages/api/v3/accounts/list"
+import completeRecoveryReleaseHandler from "../pages/api/recovery-bundles/release/complete"
 import enrollRecoveryBundleV3Handler from "../pages/api/v3/recovery-bundles/enroll"
+import startRecoveryReleaseV3Handler from "../pages/api/v3/recovery-bundles/release/start"
 import recoveryBundleStatusV3Handler from "../pages/api/v3/recovery-bundles/status"
 import saveSecretV3Handler from "../pages/api/v3/save_secret"
 import cancelSiwcSigningRequestHandler from "../pages/api/v3/signing/requests/cancel"
@@ -3550,6 +3552,252 @@ test("Passport v3 recovery bundle APIs reject cross-dapp users and replay idempo
     "not_found"
   )
   assert.equal(supabase.recoverableWalletRecoveryBundles.length, 1)
+})
+
+test("Passport v3 recovery release start creates a user-only release session", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000264"
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "release-session-client-share",
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_release_start",
+      },
+      headers: {
+        "idempotency-key": "recovery-release-start-enroll",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    createApiResponse()
+  )
+
+  const res = createApiResponse()
+  await startRecoveryReleaseV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_release_start",
+      },
+      headers: {
+        "idempotency-key": "recovery-release-start-primary",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/release/start",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 200)
+  const data = (res.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(data.recoveryBundleId, "rw_bundle_release_start")
+  assert.equal(data.dappUserUuid, dappUserUuid)
+  assert.equal(data.status, "pending")
+  assert.equal(String(data.recoveryUrl).includes("/recovery/wallet"), true)
+  assert.equal(JSON.stringify(res.body).includes("client-share"), false)
+  assert.equal(JSON.stringify(res.body).includes("bundleMaterial"), false)
+  assert.equal(supabase.recoverableWalletRecoverySessions.length, 1)
+})
+
+test("Passport user recovery release returns bundle material once to the verified user", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000265"
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+  addFirebaseUserAuth()
+
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "verified-user-client-share",
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_release_complete",
+      },
+      headers: {
+        "idempotency-key": "recovery-release-complete-enroll",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    createApiResponse()
+  )
+
+  const startRes = createApiResponse()
+  await startRecoveryReleaseV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_release_complete",
+      },
+      headers: {
+        "idempotency-key": "recovery-release-complete-start",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/release/start",
+    }),
+    startRes
+  )
+
+  const recoverySessionId = String(
+    (startRes.body as DataResponse<Record<string, unknown>>).data
+      .recoverySessionId
+  )
+  const completeRes = createApiResponse()
+  await completeRecoveryReleaseHandler(
+    createApiRequest({
+      body: {
+        recovery_session_id: recoverySessionId,
+      },
+      headers: {
+        authorization: "Bearer firebase-test-token",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/recovery-bundles/release/complete",
+    }),
+    completeRes
+  )
+
+  assert.equal(completeRes.statusCode, 200)
+  const data = (completeRes.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(data.recoverySessionId, recoverySessionId)
+  assert.equal(data.bundleMaterial, "verified-user-client-share")
+  assert.equal(data.status, "released")
+  assert.equal(supabase.recoverableWalletRecoverySessions[0].status, "released")
+  assert.equal(
+    typeof supabase.recoverableWalletRecoveryBundles[0].last_released_at,
+    "string"
+  )
+
+  const replayRes = createApiResponse()
+  await completeRecoveryReleaseHandler(
+    createApiRequest({
+      body: {
+        recovery_session_id: recoverySessionId,
+      },
+      headers: {
+        authorization: "Bearer firebase-test-token",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/recovery-bundles/release/complete",
+    }),
+    replayRes
+  )
+  assert.equal(replayRes.statusCode, 409)
+  assert.equal(
+    (replayRes.body as { error: { code: string } }).error.code,
+    "recovery_session_consumed"
+  )
+})
+
+test("Passport user recovery release rejects wrong users and expired sessions", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000266"
+  supabase.setUser({ email: "person@example.com", id: 1234 })
+  supabase.setUser({ email: "other@example.com", id: 9999 })
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "wrong-user-client-share",
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_release_guards",
+      },
+      headers: {
+        "idempotency-key": "recovery-release-guards-enroll",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    createApiResponse()
+  )
+
+  const startRes = createApiResponse()
+  await startRecoveryReleaseV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_release_guards",
+      },
+      headers: {
+        "idempotency-key": "recovery-release-guards-start",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/release/start",
+    }),
+    startRes
+  )
+  const recoverySessionId = String(
+    (startRes.body as DataResponse<Record<string, unknown>>).data
+      .recoverySessionId
+  )
+
+  setPassportFirebaseAdminAuthForTests({
+    verifyIdToken: async () =>
+      ({
+        email: "other@example.com",
+        uid: "firebase_other",
+      }) as never,
+  })
+  const wrongUserRes = createApiResponse()
+  await completeRecoveryReleaseHandler(
+    createApiRequest({
+      body: {
+        recovery_session_id: recoverySessionId,
+      },
+      headers: {
+        authorization: "Bearer firebase-test-token",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/recovery-bundles/release/complete",
+    }),
+    wrongUserRes
+  )
+  assert.equal(wrongUserRes.statusCode, 403)
+  assert.equal(
+    (wrongUserRes.body as { error: { code: string } }).error.code,
+    "wrong_user"
+  )
+
+  supabase.recoverableWalletRecoverySessions[0].expires_at = new Date(
+    Date.now() - 1000
+  ).toISOString()
+  addFirebaseUserAuth()
+  const expiredRes = createApiResponse()
+  await completeRecoveryReleaseHandler(
+    createApiRequest({
+      body: {
+        recovery_session_id: recoverySessionId,
+      },
+      headers: {
+        authorization: "Bearer firebase-test-token",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/recovery-bundles/release/complete",
+    }),
+    expiredRes
+  )
+  assert.equal(expiredRes.statusCode, 410)
+  assert.equal(
+    (expiredRes.body as { error: { code: string } }).error.code,
+    "recovery_session_expired"
+  )
 })
 
 test.skip("legacy Cubid account generation encrypted private keys and linked the triggering dapp user", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -32,6 +32,8 @@ import verifyEmailOtpHandler from "../pages/api/v2/email/verify_otp"
 import saveSecretV2Handler from "../pages/api/v2/save_secret"
 import generateAccountV3Handler from "../pages/api/v3/accounts/generate"
 import listAccountsV3Handler from "../pages/api/v3/accounts/list"
+import enrollRecoveryBundleV3Handler from "../pages/api/v3/recovery-bundles/enroll"
+import recoveryBundleStatusV3Handler from "../pages/api/v3/recovery-bundles/status"
 import saveSecretV3Handler from "../pages/api/v3/save_secret"
 import cancelSiwcSigningRequestHandler from "../pages/api/v3/signing/requests/cancel"
 import createSiwcSigningRequestHandler from "../pages/api/v3/signing/requests/create"
@@ -3355,6 +3357,199 @@ test("Passport v3 save_secret rejects dapp-id mismatches and rate-limit denials"
   )
   assert.equal(rateLimitedRes.statusCode, 429)
   assert.equal(supabase.privateDappUserSecrets.length, 0)
+})
+
+test("Passport v3 recovery bundle enrollment stores encrypted bundle metadata only", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000260"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  const res = createApiResponse()
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "recoverable-wallet-client-share",
+        bundle_version: 1,
+        dapp_user_uuid: dappUserUuid,
+        provider_key: "cubid",
+        recovery_bundle_id: "rw_bundle_test_primary",
+        recovery_reference: "provider-reference-1",
+      },
+      headers: {
+        "idempotency-key": "recovery-bundle-enroll-primary",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    res
+  )
+
+  assert.equal(res.statusCode, 200)
+  const data = (res.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(data.recoveryBundleId, "rw_bundle_test_primary")
+  assert.equal(data.dappUserUuid, dappUserUuid)
+  assert.equal(data.providerKey, "cubid")
+  assert.equal(data.status, "active")
+  assert.equal(JSON.stringify(res.body).includes("bundle_material"), false)
+  assert.equal(JSON.stringify(res.body).includes("ciphertext"), false)
+  assert.equal(JSON.stringify(res.body).includes("wrapped_data_key"), false)
+  assert.equal(JSON.stringify(res.body).includes("auth_tag"), false)
+  assert.equal(supabase.recoverableWalletRecoveryBundles.length, 1)
+
+  const storedBundle = supabase.recoverableWalletRecoveryBundles[0]
+  assert.equal(
+    storedBundle.encryption_key_id,
+    "passport_recoverable_wallet_recovery_bundle_wrapping_key_v1"
+  )
+  assert.equal(storedBundle.encryption_algorithm, "aes-256-gcm-envelope")
+  assert.notEqual(
+    storedBundle.bundle_ciphertext,
+    "recoverable-wallet-client-share"
+  )
+  assert.equal(
+    String(storedBundle.bundle_ciphertext).includes(
+      "recoverable-wallet-client-share"
+    ),
+    false
+  )
+})
+
+test("Passport v3 recovery bundle status returns safe metadata and not enrolled state", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000261"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  setPassportSupabaseForTests(supabase as never)
+
+  const emptyRes = createApiResponse()
+  await recoveryBundleStatusV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: dappUserUuid,
+      },
+      headers: {
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/status",
+    }),
+    emptyRes
+  )
+
+  assert.equal(emptyRes.statusCode, 200)
+  assert.equal(
+    (emptyRes.body as DataResponse<Record<string, unknown>>).data.status,
+    "not_enrolled"
+  )
+
+  const enrollRes = createApiResponse()
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "status-visible-client-share",
+        dapp_user_uuid: dappUserUuid,
+        provider_key: "cubid",
+        recovery_bundle_id: "rw_bundle_status_visible",
+      },
+      headers: {
+        "idempotency-key": "recovery-bundle-status-visible",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    enrollRes
+  )
+
+  const statusRes = createApiResponse()
+  await recoveryBundleStatusV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_status_visible",
+      },
+      headers: {
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/status",
+    }),
+    statusRes
+  )
+
+  assert.equal(statusRes.statusCode, 200)
+  const data = (statusRes.body as DataResponse<Record<string, unknown>>).data
+  assert.equal(data.recoveryBundleId, "rw_bundle_status_visible")
+  assert.equal(data.status, "active")
+  assert.equal(JSON.stringify(statusRes.body).includes("bundle_ciphertext"), false)
+  assert.equal(JSON.stringify(statusRes.body).includes("wrapped_data_key"), false)
+  assert.equal(JSON.stringify(statusRes.body).includes("client-share"), false)
+})
+
+test("Passport v3 recovery bundle APIs reject cross-dapp users and replay idempotent enrollment", async () => {
+  const supabase = new MockPassportSupabase()
+  const apiKey = addDappAuth(supabase)
+  const dappUserUuid = "00000000-0000-4000-8000-000000000262"
+  supabase.setDappUser({ dapp_id: 42, user_id: 1234, uuid: dappUserUuid })
+  supabase.setDappUser({
+    dapp_id: 99,
+    user_id: 9999,
+    uuid: "00000000-0000-4000-8000-000000000263",
+  })
+  setPassportSupabaseForTests(supabase as never)
+
+  const body = {
+    api_key: apiKey,
+    bundle_material: "idempotent-client-share",
+    dapp_user_uuid: dappUserUuid,
+    recovery_bundle_id: "rw_bundle_idempotent",
+  }
+  const makeReq = () =>
+    createApiRequest({
+      body,
+      headers: {
+        "idempotency-key": "recovery-bundle-idempotent",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    })
+
+  const firstRes = createApiResponse()
+  await enrollRecoveryBundleV3Handler(makeReq(), firstRes)
+  const replayRes = createApiResponse()
+  await enrollRecoveryBundleV3Handler(makeReq(), replayRes)
+
+  assert.equal(firstRes.statusCode, 200)
+  assert.equal(replayRes.statusCode, 200)
+  assert.deepEqual(replayRes.body, firstRes.body)
+  assert.equal(supabase.recoverableWalletRecoveryBundles.length, 1)
+
+  const crossDappRes = createApiResponse()
+  await enrollRecoveryBundleV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        bundle_material: "cross-dapp-client-share",
+        dapp_user_uuid: "00000000-0000-4000-8000-000000000263",
+      },
+      headers: {
+        "idempotency-key": "recovery-bundle-cross-dapp",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/enroll",
+    }),
+    crossDappRes
+  )
+
+  assert.equal(crossDappRes.statusCode, 404)
+  assert.equal(
+    (crossDappRes.body as { error: { code: string } }).error.code,
+    "not_found"
+  )
+  assert.equal(supabase.recoverableWalletRecoveryBundles.length, 1)
 })
 
 test.skip("legacy Cubid account generation encrypted private keys and linked the triggering dapp user", async () => {

--- a/apps/passport/tests/passportRoutes.test.ts
+++ b/apps/passport/tests/passportRoutes.test.ts
@@ -3552,7 +3552,7 @@ test("Passport v3 recovery bundle APIs reject cross-dapp users and replay idempo
   assert.equal(crossDappRes.statusCode, 404)
   assert.equal(
     (crossDappRes.body as { error: { code: string } }).error.code,
-    "not_found"
+    "unsupported_app_context"
   )
   assert.equal(supabase.recoverableWalletRecoveryBundles.length, 1)
 })
@@ -3889,6 +3889,24 @@ test("Passport v3 recovery bundle revocation and user list return redacted lifec
     createApiResponse()
   )
 
+  const startRes = createApiResponse()
+  await startRecoveryReleaseV3Handler(
+    createApiRequest({
+      body: {
+        api_key: apiKey,
+        dapp_user_uuid: dappUserUuid,
+        recovery_bundle_id: "rw_bundle_revoke",
+      },
+      headers: {
+        "idempotency-key": "recovery-revoke-start-before-revoke",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/v3/recovery-bundles/release/start",
+    }),
+    startRes
+  )
+  assert.equal(startRes.statusCode, 200)
+
   const revokeRes = createApiResponse()
   await revokeRecoveryBundleV3Handler(
     createApiRequest({
@@ -3915,6 +3933,29 @@ test("Passport v3 recovery bundle revocation and user list return redacted lifec
       (event) => event.event_type === "recoverable_wallet.bundle.revoked"
     ),
     true
+  )
+
+  const revokedReleaseRes = createApiResponse()
+  await completeRecoveryReleaseHandler(
+    createApiRequest({
+      body: {
+        recovery_session_id: String(
+          (startRes.body as DataResponse<Record<string, unknown>>).data
+            .recoverySessionId
+        ),
+      },
+      headers: {
+        authorization: "Bearer firebase-test-token",
+        origin: "https://passport.cubid.me",
+      },
+      url: "/api/recovery-bundles/release/complete",
+    }),
+    revokedReleaseRes
+  )
+  assert.equal(revokedReleaseRes.statusCode, 409)
+  assert.equal(
+    (revokedReleaseRes.body as { error: { code: string } }).error.code,
+    "bundle_revoked"
   )
 
   const listRes = createApiResponse()

--- a/apps/passport/tests/recoverableWalletRecovery.test.ts
+++ b/apps/passport/tests/recoverableWalletRecovery.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  decryptRecoverableWalletBundleWithKey,
+  encryptRecoverableWalletBundleWithKey,
+} from "../lib/server/recoverableWalletRecovery"
+
+const wrappingKey = Buffer.from("rwallet0123456789abcdef012345678")
+const context = {
+  bundleVersion: 1,
+  dappId: 42,
+  dappUserUuid: "00000000-0000-4000-8000-000000000042",
+  providerKey: "cubid",
+  recoveryBundleId: "rw_bundle_123",
+  userId: 1234,
+}
+
+test("recoverable wallet bundle envelope round-trips with bound context", () => {
+  const encrypted = encryptRecoverableWalletBundleWithKey(
+    "user-side-share-recovery-material",
+    wrappingKey,
+    context
+  )
+
+  assert.equal(encrypted.encryption_algorithm, "aes-256-gcm-envelope")
+  assert.equal(
+    encrypted.encryption_key_id,
+    "passport_recoverable_wallet_recovery_bundle_wrapping_key_v1"
+  )
+  assert.equal(
+    encrypted.bundle_ciphertext.includes("user-side-share"),
+    false
+  )
+  assert.equal(
+    decryptRecoverableWalletBundleWithKey(encrypted, wrappingKey, context),
+    "user-side-share-recovery-material"
+  )
+})
+
+test("recoverable wallet bundle envelope rejects swapped authenticated context", () => {
+  const encrypted = encryptRecoverableWalletBundleWithKey(
+    "user-side-share-recovery-material",
+    wrappingKey,
+    context
+  )
+
+  assert.throws(() =>
+    decryptRecoverableWalletBundleWithKey(encrypted, wrappingKey, {
+      ...context,
+      recoveryBundleId: "rw_bundle_other",
+    })
+  )
+})
+
+test("recoverable wallet bundle envelope rejects the wrong wrapping key", () => {
+  const encrypted = encryptRecoverableWalletBundleWithKey(
+    "user-side-share-recovery-material",
+    wrappingKey,
+    context
+  )
+
+  assert.throws(() =>
+    decryptRecoverableWalletBundleWithKey(
+      encrypted,
+      Buffer.from("otherkey0123456789abcdef01234567"),
+      context
+    )
+  )
+})
+

--- a/docs/engineering/api-security-operations.md
+++ b/docs/engineering/api-security-operations.md
@@ -241,14 +241,13 @@ views. Provision the Supabase Vault secret
 `passport_webhook_signing_secret_wrapping_key_v1` before creating encrypted
 webhook subscriptions or running the legacy webhook backfill script.
 
-Blockchain private keys use the C05 envelope model in the v3 account custody
-surface. `/api/v3/accounts/generate` creates EVM, NEAR, or Solana accounts for
-an authenticated dapp user, stores public metadata in `user_accounts`, stores
-the encrypted key envelope in `private.private_keys`, and links visibility
-through `dapp_user_accounts`. Provision the Supabase Vault secret
-`passport_blockchain_private_key_wrapping_key_v1` before enabling v3 account
-generation. V3 responses never return raw private keys or encrypted key
-material.
+Blockchain private keys from the earlier v3 account custody surface are now a
+legacy quarantine surface. `/api/v3/accounts/generate` is deprecated and should
+fail closed for new integrations; historical `user_accounts`,
+`dapp_user_accounts`, and `private.private_keys` rows remain in place until
+hosted data is reviewed and a destructive cleanup migration is explicitly
+approved. New wallet work should use app-mediated recoverable wallets with
+Cubid recovery bundles rather than Cubid-generated private keys.
 
 ### Admin
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -38,6 +38,13 @@ The current backend-owned API v3 routes are:
   wallet bundle enrollment backed by private-schema envelope encryption.
 - `POST /api/v3/recovery-bundles/status`: dapp-authenticated safe recovery
   bundle status lookup for one app-scoped dapp user.
+- `POST /api/v3/recovery-bundles/release/start`: dapp-authenticated
+  short-lived recovery release session creation for a previously enrolled
+  bundle.
+- `POST /api/recovery-bundles/release/complete`: Passport user-authenticated
+  one-time recovery release completion. This is intentionally not a dapp API v3
+  credential route because it may return recovery material to the verified
+  browser/client path.
 
 Existing `/api/v2/*` routes remain legacy compatibility surfaces unless a
 future todo explicitly promotes a capability into API v3. New developer-facing
@@ -172,6 +179,57 @@ Rules:
 - `provider_key` and `recovery_bundle_id` are optional filters.
 - Missing bundles return a successful `status: "not_enrolled"` response.
 - The route returns safe metadata only.
+
+### `POST /api/v3/recovery-bundles/release/start`
+
+Purpose: let a dapp request a user-authorized recovery release session for an
+existing active bundle. This route starts recovery, but does not retrieve or
+return recovery material.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "dapp_user_uuid": "00000000-0000-4000-8000-000000000000",
+  "recovery_bundle_id": "rw_bundle_...",
+  "provider_key": "cubid"
+}
+```
+
+Rules:
+
+- `Idempotency-Key` is required.
+- `dapp_user_uuid` must belong to the authenticated dapp.
+- The referenced bundle must exist, be active, and belong to the same dapp user.
+- The route creates a short-lived pending release session.
+- The response includes a Passport-hosted `recoveryUrl`; it never includes
+  recovery material or encrypted custody fields.
+
+### `POST /api/recovery-bundles/release/complete`
+
+Purpose: complete a recovery release from the Passport browser/client path
+after Cubid verifies the user. This route is user-authenticated, not
+dapp-authenticated.
+
+Request body:
+
+```json
+{
+  "recovery_session_id": "rw_release_..."
+}
+```
+
+Rules:
+
+- The request must include a valid Passport/Firebase bearer token.
+- The signed-in user must resolve to the Cubid user bound to the release
+  session.
+- The session must be pending, unexpired, and unconsumed.
+- On success, the session is consumed before returning the recovery bundle
+  material to the verified browser/client path.
+- Replays return `409 recovery_session_consumed`; expired sessions return
+  `410 recovery_session_expired`; wrong users return `403 wrong_user`.
 
 ### `POST /api/v3/accounts/generate`
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -1,7 +1,7 @@
 # API v3 Developer Platform
 
-Last updated: 2026-05-06
-Status: E02.5 canonical contract
+Last updated: 2026-05-20
+Status: E02.5 canonical contract with recoverable-wallet correction
 
 ## Purpose
 
@@ -22,13 +22,12 @@ The current backend-owned API v3 routes are:
 
 - `POST /api/v3/save_secret`: dapp-authenticated encrypted dapp-user secret
   write path backed by `private.dapp_user_secrets`.
-- `POST /api/v3/accounts/generate`: dapp-authenticated custodial account
-  generation for supported chains, storing encrypted private-key material in
-  the `private` schema and returning only public account metadata.
+- `POST /api/v3/accounts/generate`: legacy Cubid-generated wallet creation
+  endpoint. This route is deprecated and fails closed for new use.
 - `POST /api/v3/accounts/list`: dapp-authenticated account metadata listing
-  scoped to the target dapp user.
-- `POST /api/v3/signing/requests/create`: dapp-authenticated creation of a
-  Passport-hosted signing request for an app-scoped account.
+  scoped to the target dapp user, retained for historical visibility.
+- `POST /api/v3/signing/requests/create`: legacy Cubid normal-signing request
+  creation endpoint. This route is deprecated and fails closed for new use.
 - `POST /api/v3/signing/requests/get`: dapp-authenticated signing request
   status lookup.
 - `POST /api/v3/signing/requests/list`: dapp-authenticated signing request
@@ -101,6 +100,11 @@ tags, human subject keys, raw Cubid user ids, or service-role data.
 Purpose: generate a Cubid-custodied blockchain account for one dapp user and
 store the private key using the v3 encrypted private-key custody model.
 
+Current status: **deprecated and fail-closed**. Cubid no longer generates
+wallets for new integrations. Host apps should create app-mediated
+recoverable wallets using audited threshold/MPC infrastructure and enroll
+Cubid recovery bundles instead.
+
 Request body:
 
 ```json
@@ -141,8 +145,20 @@ Success response shape:
 }
 ```
 
-The route never returns the raw private key, encrypted private-key material,
-wrapped data keys, or internal custody metadata.
+Current failure response:
+
+```json
+{
+  "error": {
+    "code": "cubid_generated_wallets_deprecated",
+    "message": "Cubid-generated wallet creation is deprecated. Use app-mediated recoverable wallets with Cubid recovery bundles instead.",
+    "requestId": "passport_..."
+  }
+}
+```
+
+The route must not create new account rows, private-key rows, dapp-user-account
+links, or `wallet.created` webhook events.
 
 ### `POST /api/v3/accounts/list`
 
@@ -197,6 +213,11 @@ custodial account. The route records the request, evaluates the current Admin
 SIWC policy, and returns a polling-safe state. It does not sign until the
 Passport user approves the request.
 
+Current status: **deprecated and fail-closed**. Cubid no longer performs normal
+wallet signing for host apps. Normal signing belongs to the host app or a
+specialized threshold/MPC signing service; Cubid should provide recovery-bundle
+storage and release.
+
 Request body:
 
 ```json
@@ -248,15 +269,20 @@ Success response shape:
 }
 ```
 
-Responses must not include private keys, encrypted custody material, Vault key
-material, raw Cubid user ids, human subject keys, or the raw `payload` field.
+Current failure response:
 
-Transaction responses may include `riskLevel`, `riskReasons`,
-`transactionOperationType`, `transactionRecipient`,
-`transactionContractAddress`, and `transactionDeclaredValueUsd`. These are
-non-secret summaries for SDKs and Passport UI. They are not a transaction
-simulation result, and they do not mean Cubid will sign the transaction in this
-slice.
+```json
+{
+  "error": {
+    "code": "cubid_signing_deprecated",
+    "message": "Cubid normal wallet signing is deprecated. Use app-mediated threshold signing with Cubid recovery bundles instead.",
+    "requestId": "passport_..."
+  }
+}
+```
+
+The route must not create new signing requests, decrypt private-key material,
+or emit signing lifecycle webhooks for new product traffic.
 
 ### `POST /api/v3/signing/requests/get`
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -34,6 +34,10 @@ The current backend-owned API v3 routes are:
   listing for the authenticated app.
 - `POST /api/v3/signing/requests/cancel`: dapp-authenticated cancellation for
   pending signing requests.
+- `POST /api/v3/recovery-bundles/enroll`: dapp-authenticated recoverable
+  wallet bundle enrollment backed by private-schema envelope encryption.
+- `POST /api/v3/recovery-bundles/status`: dapp-authenticated safe recovery
+  bundle status lookup for one app-scoped dapp user.
 
 Existing `/api/v2/*` routes remain legacy compatibility surfaces unless a
 future todo explicitly promotes a capability into API v3. New developer-facing
@@ -94,6 +98,80 @@ Success response:
 
 No response may contain the raw secret, ciphertext, wrapped data key, IVs, auth
 tags, human subject keys, raw Cubid user ids, or service-role data.
+
+### `POST /api/v3/recovery-bundles/enroll`
+
+Purpose: store app-provided recoverable-wallet recovery bundle material using
+the private-schema Supabase Vault envelope-encryption pattern. This is Cubid's
+replacement direction for wallet-adjacent recovery support; it does not create
+wallets and does not enable normal transaction signing.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "dapp_user_uuid": "00000000-0000-4000-8000-000000000000",
+  "bundle_material": "opaque encrypted or sealed recovery material from the app",
+  "provider_key": "cubid",
+  "bundle_version": 1,
+  "recovery_bundle_id": "rw_bundle_...",
+  "recovery_reference": "optional provider reference"
+}
+```
+
+Rules:
+
+- `Idempotency-Key` is required.
+- `dapp_user_uuid` must belong to the authenticated dapp.
+- `bundle_material` is encrypted before storage in
+  `private.recoverable_wallet_recovery_bundles`.
+- Supplying an existing `recovery_bundle_id` updates the encrypted bundle
+  metadata for the authenticated dapp.
+- The route returns status metadata only.
+
+Success response shape:
+
+```json
+{
+  "data": {
+    "bundleVersion": 1,
+    "dappUserUuid": "00000000-0000-4000-8000-000000000000",
+    "providerKey": "cubid",
+    "recoveryBundleId": "rw_bundle_...",
+    "recoveryReference": "optional provider reference",
+    "status": "active",
+    "createdAt": "2026-05-20T00:00:00.000Z",
+    "updatedAt": "2026-05-20T00:00:00.000Z"
+  }
+}
+```
+
+No response may contain bundle plaintext, ciphertext, wrapped data keys, IVs,
+auth tags, raw Cubid user ids, or service-role metadata.
+
+### `POST /api/v3/recovery-bundles/status`
+
+Purpose: let a dapp inspect whether one of its dapp users has an active or
+historical Cubid recovery bundle, without exposing recovery material.
+
+Request body:
+
+```json
+{
+  "api_key": "cubid_live_...",
+  "dapp_user_uuid": "00000000-0000-4000-8000-000000000000",
+  "provider_key": "cubid",
+  "recovery_bundle_id": "rw_bundle_..."
+}
+```
+
+Rules:
+
+- `dapp_user_uuid` must belong to the authenticated dapp.
+- `provider_key` and `recovery_bundle_id` are optional filters.
+- Missing bundles return a successful `status: "not_enrolled"` response.
+- The route returns safe metadata only.
 
 ### `POST /api/v3/accounts/generate`
 

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -237,6 +237,20 @@ Rules:
 - Replays return `409 recovery_session_consumed`; expired sessions return
   `410 recovery_session_expired`; wrong users return `403 wrong_user`.
 
+Browser-safe recovery error taxonomy:
+
+- `verification_required`
+- `wrong_user`
+- `recovery_session_expired`
+- `recovery_session_consumed`
+- `recovery_cancelled`
+- `unsupported_app_context`
+- `recovery_bundle_not_found`
+- `bundle_revoked`
+- `unavailable_credential`
+- `cooldown_active`
+- `provider_outage`
+
 ### `POST /api/v3/recovery-bundles/rotate`
 
 Purpose: rotate an app-scoped recovery bundle after recovery, app-side share

--- a/docs/engineering/api-v3-developer-platform.md
+++ b/docs/engineering/api-v3-developer-platform.md
@@ -45,6 +45,12 @@ The current backend-owned API v3 routes are:
   one-time recovery release completion. This is intentionally not a dapp API v3
   credential route because it may return recovery material to the verified
   browser/client path.
+- `POST /api/v3/recovery-bundles/rotate`: dapp-authenticated recovery bundle
+  rotation that retires the previous active bundle and stores a replacement.
+- `POST /api/v3/recovery-bundles/revoke`: dapp-authenticated recovery bundle
+  revocation.
+- `POST /api/recovery-bundles/list`: Passport user-authenticated redacted
+  recovery bundle lifecycle visibility.
 
 Existing `/api/v2/*` routes remain legacy compatibility surfaces unless a
 future todo explicitly promotes a capability into API v3. New developer-facing
@@ -230,6 +236,46 @@ Rules:
   material to the verified browser/client path.
 - Replays return `409 recovery_session_consumed`; expired sessions return
   `410 recovery_session_expired`; wrong users return `403 wrong_user`.
+
+### `POST /api/v3/recovery-bundles/rotate`
+
+Purpose: rotate an app-scoped recovery bundle after recovery, app-side share
+rotation, passkey changes, or provider-side refresh.
+
+Rules:
+
+- `Idempotency-Key` is required.
+- The old bundle must be active and belong to the authenticated dapp user.
+- The old bundle is marked `rotated`; the replacement is encrypted and stored
+  as the next bundle version.
+- The response returns only safe metadata for the replacement bundle.
+- A `recoverable_wallet.bundle.rotated` event is recorded.
+
+### `POST /api/v3/recovery-bundles/revoke`
+
+Purpose: invalidate an app-scoped recovery bundle so it can no longer be used
+for release.
+
+Rules:
+
+- `dapp_user_uuid` must belong to the authenticated dapp.
+- The target bundle is marked `revoked`.
+- The response returns only safe metadata.
+- A `recoverable_wallet.bundle.revoked` event is recorded.
+
+### `POST /api/recovery-bundles/list`
+
+Purpose: show a signed-in Passport user their recovery bundle lifecycle state.
+This is user-facing visibility, not dapp credential access.
+
+Rules:
+
+- The request must include a valid Passport/Firebase bearer token.
+- The route lists bundles for Cubid users resolved from the signed-in email or
+  phone.
+- The response may include lifecycle state and timestamps, but never includes
+  bundle material, ciphertext, wrapped keys, IVs, auth tags, raw Cubid user ids,
+  or service-role metadata.
 
 ### `POST /api/v3/accounts/generate`
 

--- a/docs/engineering/recoverable-wallet-sdk.md
+++ b/docs/engineering/recoverable-wallet-sdk.md
@@ -77,6 +77,26 @@ The backend may create, update, revoke, rotate, and report status for a bundle,
 but backend dapp credentials must not be able to read the decrypted payload.
 Decryption is reserved for a later user-authorized recovery release flow.
 
+## API v3 Recovery Bundle Routes
+
+RW04 adds the first dapp-authenticated recovery-bundle APIs:
+
+- `POST /api/v3/recovery-bundles/enroll`
+- `POST /api/v3/recovery-bundles/status`
+
+Enrollment accepts a dapp API key, `dapp_user_uuid`, opaque bundle material,
+provider metadata, and an optional caller-provided `recovery_bundle_id`.
+Enrollment requires `Idempotency-Key`, verifies that the dapp user belongs to
+the authenticated dapp, encrypts the bundle material, and returns only safe
+status metadata. It never returns plaintext bundle material, ciphertext,
+wrapped data keys, IVs, auth tags, raw Cubid user ids, or service-role fields.
+
+Status lookup accepts a dapp API key and `dapp_user_uuid`, with optional
+`recovery_bundle_id` or `provider_key` filters. It returns the latest safe
+bundle status for that dapp user, or `status: "not_enrolled"` when no bundle
+exists. Backend credentials can inspect enrollment state, but cannot retrieve
+or decrypt recovery material.
+
 ## Ownership Boundary
 
 SmarTrust or another host app owns:

--- a/docs/engineering/recoverable-wallet-sdk.md
+++ b/docs/engineering/recoverable-wallet-sdk.md
@@ -83,6 +83,8 @@ RW04 adds the first dapp-authenticated recovery-bundle APIs:
 
 - `POST /api/v3/recovery-bundles/enroll`
 - `POST /api/v3/recovery-bundles/status`
+- `POST /api/v3/recovery-bundles/release/start`
+- `POST /api/recovery-bundles/release/complete`
 
 Enrollment accepts a dapp API key, `dapp_user_uuid`, opaque bundle material,
 provider metadata, and an optional caller-provided `recovery_bundle_id`.
@@ -96,6 +98,17 @@ Status lookup accepts a dapp API key and `dapp_user_uuid`, with optional
 bundle status for that dapp user, or `status: "not_enrolled"` when no bundle
 exists. Backend credentials can inspect enrollment state, but cannot retrieve
 or decrypt recovery material.
+
+Release start is dapp-authenticated and creates a short-lived, one-time
+recovery session for an existing active bundle. It returns a Passport-hosted
+`recoveryUrl` and session metadata only. It does not return bundle material and
+does not give backend credentials any recovery read capability.
+
+Release completion is Passport user-authenticated. It verifies that the signed
+in user maps to the Cubid user bound to the recovery session, rejects expired or
+already-consumed sessions, decrypts the bundle, marks the session consumed, and
+returns the bundle material only to the verified browser/client path. This is
+the only RW05 path that returns recovery material.
 
 ## Ownership Boundary
 

--- a/docs/engineering/recoverable-wallet-sdk.md
+++ b/docs/engineering/recoverable-wallet-sdk.md
@@ -85,6 +85,9 @@ RW04 adds the first dapp-authenticated recovery-bundle APIs:
 - `POST /api/v3/recovery-bundles/status`
 - `POST /api/v3/recovery-bundles/release/start`
 - `POST /api/recovery-bundles/release/complete`
+- `POST /api/v3/recovery-bundles/rotate`
+- `POST /api/v3/recovery-bundles/revoke`
+- `POST /api/recovery-bundles/list`
 
 Enrollment accepts a dapp API key, `dapp_user_uuid`, opaque bundle material,
 provider metadata, and an optional caller-provided `recovery_bundle_id`.
@@ -109,6 +112,16 @@ in user maps to the Cubid user bound to the recovery session, rejects expired or
 already-consumed sessions, decrypts the bundle, marks the session consumed, and
 returns the bundle material only to the verified browser/client path. This is
 the only RW05 path that returns recovery material.
+
+Rotation is dapp-authenticated and idempotent. It marks the current active
+bundle `rotated`, writes a new encrypted active bundle with an incremented
+version, and returns only safe metadata for the replacement bundle. Revocation
+is dapp-authenticated and marks the bundle `revoked`; revoked bundles cannot be
+released by the user completion flow.
+
+Passport users can list their recovery bundles through the user-authenticated
+visibility route. The list includes lifecycle state such as active, rotated, and
+revoked, but never includes bundle material or encrypted custody fields.
 
 ## Ownership Boundary
 

--- a/docs/engineering/recoverable-wallet-sdk.md
+++ b/docs/engineering/recoverable-wallet-sdk.md
@@ -55,6 +55,28 @@ Backend dapp credentials alone must never retrieve recovery material. Recovery
 material must release only through a user-authorized browser/client path after
 Cubid recovery verification.
 
+## Recovery Bundle Storage
+
+Recovery bundles are stored in
+`private.recoverable_wallet_recovery_bundles`, a service-role-only table. The
+table binds encrypted bundle material to:
+
+- dapp id
+- dapp user UUID
+- Cubid user id
+- provider key
+- recovery bundle id and version
+- status, expiry, rotation, revocation, stale, and release metadata
+
+The bundle payload uses AES-256-GCM envelope encryption with a Supabase
+Vault-backed wrapping key. Provision the Vault secret
+`passport_recoverable_wallet_recovery_bundle_wrapping_key_v1` as a
+base64/base64url encoded 32-byte key before enabling recovery-bundle writes.
+
+The backend may create, update, revoke, rotate, and report status for a bundle,
+but backend dapp credentials must not be able to read the decrypted payload.
+Decryption is reserved for a later user-authorized recovery release flow.
+
 ## Ownership Boundary
 
 SmarTrust or another host app owns:
@@ -82,4 +104,3 @@ the corrected wallet direction. The old SIWC roadmap is superseded for wallet
 generation and normal signing, but Login with Cubid, passkey ACR, selective
 disclosure, Admin policy patterns, and API v3 security baseline remain valid
 platform foundations.
-

--- a/docs/engineering/recoverable-wallet-sdk.md
+++ b/docs/engineering/recoverable-wallet-sdk.md
@@ -123,6 +123,30 @@ Passport users can list their recovery bundles through the user-authenticated
 visibility route. The list includes lifecycle state such as active, rotated, and
 revoked, but never includes bundle material or encrypted custody fields.
 
+## Browser-Safe Error Taxonomy
+
+Recovery routes expose stable, browser-safe error codes so SDKs and host apps
+can decide whether to retry, restart, ask the user to sign in, or stop hard:
+
+- `verification_required`: the user must complete Passport/Cubid verification.
+- `wrong_user`: the signed-in Passport user does not match the recovery session.
+- `recovery_session_expired`: the recovery session is past its expiry.
+- `recovery_session_consumed`: the one-time recovery session was already used.
+- `recovery_cancelled`: the user or app cancelled the recovery flow.
+- `unsupported_app_context`: the dapp user or app context is not valid for the
+  authenticated app.
+- `recovery_bundle_not_found`: no matching bundle exists for the app/user.
+- `bundle_revoked`: the bundle exists but was revoked before release.
+- `unavailable_credential`: the needed passkey, account, or local credential is
+  unavailable in the browser context.
+- `cooldown_active`: recovery is temporarily blocked by cooldown policy.
+- `provider_outage`: a configured wallet/recovery provider is unavailable.
+
+Backend routes should avoid leaking whether a different app owns a user or
+bundle. SDKs should treat `unsupported_app_context` and
+`recovery_bundle_not_found` as hard app-context failures unless the user
+explicitly restarts enrollment.
+
 ## Ownership Boundary
 
 SmarTrust or another host app owns:

--- a/docs/engineering/recoverable-wallet-sdk.md
+++ b/docs/engineering/recoverable-wallet-sdk.md
@@ -1,0 +1,85 @@
+# Cubid Recoverable Wallet SDK Direction
+
+Last updated: 2026-05-20
+
+## Position
+
+Cubid's wallet-adjacent product direction is now **passkey-first,
+app-mediated, recoverable embedded wallets**. Cubid is not trying to become a
+typical third-party wallet, a custodial wallet, or a normal transaction signer.
+
+The target model is assisted self-custody:
+
+- the host app or specialized signing infrastructure creates wallet material
+- normal signing requires a user-side signing share and an app/server-side
+  policy signing share
+- Cubid does not generate wallets or sign normal app transactions
+- Cubid stores and releases recovery material only after user-authorized Cubid
+  recovery
+- the full wallet private key is never reconstructed server-side
+
+## Superseded Work
+
+The earlier SIWC custody/signing implementation used Cubid-generated
+app-scoped accounts and server-side signing from Vault-encrypted private keys.
+That work is now a quarantined legacy surface. It remains useful as historical
+context and for redacted account visibility, but it is no longer the product
+path.
+
+New integrations must not rely on:
+
+- `/api/v3/accounts/generate` for Cubid-generated accounts
+- `/api/v3/signing/requests/create` for Cubid normal signing
+- Passport SIWC approval as a normal-signing flow
+- `private.private_keys` as an active signing source
+
+Those surfaces should fail closed for new use while existing tables remain in
+place until hosted data is reviewed and a destructive cleanup migration is
+explicitly approved.
+
+## Replacement Role For Cubid Passport
+
+Cubid Passport should provide recovery-provider infrastructure:
+
+- app-scoped recovery-bundle enrollment
+- encrypted recovery-bundle custody using the existing private schema and
+  Supabase Vault envelope pattern
+- recovery status lookup without exposing bundle contents
+- Passport-hosted user recovery verification
+- one-time browser/client-path recovery release
+- bundle rotation and revocation
+- audit/security events for recovery lifecycle changes
+- SDK-facing error taxonomy and handoff notes
+
+Backend dapp credentials alone must never retrieve recovery material. Recovery
+material must release only through a user-authorized browser/client path after
+Cubid recovery verification.
+
+## Ownership Boundary
+
+SmarTrust or another host app owns:
+
+- wallet creation
+- threshold/MPC provider selection
+- normal signing
+- transaction broadcasting
+- app-specific transaction policy
+- chain-specific wallet UX
+
+Cubid owns:
+
+- identity and app-scoped user binding
+- passkey and recovery verification
+- recovery-bundle storage/release
+- disclosure-safe API and webhook contracts
+- auditability and operator support
+- public SDK coordination through `Cubid-Me/cubid-sdk`
+
+## Implementation Roadmap
+
+Use `agent-context/recoverable-wallet-sdk/todo.md` as the active roadmap for
+the corrected wallet direction. The old SIWC roadmap is superseded for wallet
+generation and normal signing, but Login with Cubid, passkey ACR, selective
+disclosure, Admin policy patterns, and API v3 security baseline remain valid
+platform foundations.
+

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -1,6 +1,6 @@
 # SIWC V3 Signing And Transaction Authorization Architecture
 
-Last updated: 2026-05-06
+Last updated: 2026-05-20
 Status: Superseded for wallet generation and normal signing on 2026-05-20
 
 ## Superseded Direction Notice

--- a/docs/engineering/siwc-v3-signing-architecture.md
+++ b/docs/engineering/siwc-v3-signing-architecture.md
@@ -1,7 +1,25 @@
 # SIWC V3 Signing And Transaction Authorization Architecture
 
 Last updated: 2026-05-06
-Status: SIWC08 production runbook added; transaction signing remains disabled
+Status: Superseded for wallet generation and normal signing on 2026-05-20
+
+## Superseded Direction Notice
+
+This document records the earlier SIWC V3 signing architecture. Its
+server-side custodial wallet generation and normal-signing direction is now
+superseded by the recoverable wallet SDK target state in
+`docs/engineering/recoverable-wallet-sdk.md`.
+
+The still-valid parts of the SIWC work are Login with Cubid, passkey ACR,
+app-scoped identity, selective disclosure, API v3 security primitives, Admin
+policy patterns, redacted historical account visibility, and webhook/audit
+infrastructure. The superseded parts are Cubid-generated wallet creation,
+Cubid normal signing, and any product direction that treats Cubid Passport as a
+typical third-party wallet provider.
+
+New integrations should not use `/api/v3/accounts/generate` or
+`/api/v3/signing/requests/create`. Those routes are being quarantined for
+historical support and should fail closed for new product traffic.
 
 ## Purpose
 

--- a/supabase/migrations/20260520185500_recoverable_wallet_recovery_bundles.sql
+++ b/supabase/migrations/20260520185500_recoverable_wallet_recovery_bundles.sql
@@ -1,0 +1,95 @@
+create extension if not exists pgcrypto with schema extensions;
+
+create schema if not exists private;
+
+revoke all on schema private from public;
+revoke all on schema private from anon;
+revoke all on schema private from authenticated;
+grant usage on schema private to service_role;
+
+create table if not exists private.recoverable_wallet_recovery_bundles (
+  id uuid primary key default extensions.gen_random_uuid(),
+  recovery_bundle_id text not null unique,
+  dapp_id bigint not null references public.dapps(id) on delete restrict,
+  dapp_user_uuid uuid not null references public.dapp_users(uuid) on delete cascade,
+  user_id bigint not null references public.users(id) on delete restrict,
+  provider_key text not null default 'cubid',
+  bundle_version integer not null default 1,
+  status text not null default 'active',
+  recovery_reference text,
+  bundle_ciphertext text not null,
+  bundle_iv text not null,
+  bundle_auth_tag text not null,
+  wrapped_data_key text not null,
+  wrapped_data_key_iv text not null,
+  wrapped_data_key_auth_tag text not null,
+  encryption_algorithm text not null,
+  encryption_key_id text not null,
+  encryption_key_version integer not null,
+  encryption_purpose text not null,
+  encryption_context jsonb not null default '{}'::jsonb,
+  encrypted_at timestamptz not null default now(),
+  expires_at timestamptz,
+  rotated_at timestamptz,
+  revoked_at timestamptz,
+  stale_at timestamptz,
+  last_released_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint recoverable_wallet_recovery_bundles_status_check
+    check (status in ('active', 'rotated', 'revoked', 'expired', 'stale')),
+  constraint recoverable_wallet_recovery_bundles_algorithm_check
+    check (encryption_algorithm = 'aes-256-gcm-envelope'),
+  constraint recoverable_wallet_recovery_bundles_key_version_check
+    check (encryption_key_version > 0),
+  constraint recoverable_wallet_recovery_bundles_bundle_version_check
+    check (bundle_version > 0)
+);
+
+create index if not exists recoverable_wallet_recovery_bundles_dapp_user_idx
+  on private.recoverable_wallet_recovery_bundles(dapp_id, dapp_user_uuid, status);
+
+create index if not exists recoverable_wallet_recovery_bundles_user_idx
+  on private.recoverable_wallet_recovery_bundles(user_id, status);
+
+create index if not exists recoverable_wallet_recovery_bundles_reference_idx
+  on private.recoverable_wallet_recovery_bundles(recovery_reference)
+  where recovery_reference is not null;
+
+alter table private.recoverable_wallet_recovery_bundles enable row level security;
+
+revoke all on table private.recoverable_wallet_recovery_bundles from public;
+revoke all on table private.recoverable_wallet_recovery_bundles from anon;
+revoke all on table private.recoverable_wallet_recovery_bundles from authenticated;
+grant select, insert, update, delete on table private.recoverable_wallet_recovery_bundles to service_role;
+
+create or replace function public.get_recoverable_wallet_recovery_bundle_wrapping_key_v1()
+returns text
+language plpgsql
+security definer
+set search_path = public, vault, extensions
+as $$
+declare
+  secret_value text;
+begin
+  select decrypted_secret
+    into secret_value
+    from vault.decrypted_secrets
+   where name = 'passport_recoverable_wallet_recovery_bundle_wrapping_key_v1'
+   limit 1;
+
+  if secret_value is null or length(secret_value) < 43 then
+    raise exception 'passport_recoverable_wallet_recovery_bundle_wrapping_key_v1 is missing from Supabase Vault'
+      using errcode = '22023';
+  end if;
+
+  return secret_value;
+end;
+$$;
+
+revoke all on function public.get_recoverable_wallet_recovery_bundle_wrapping_key_v1() from public;
+grant execute on function public.get_recoverable_wallet_recovery_bundle_wrapping_key_v1() to service_role;
+
+comment on table private.recoverable_wallet_recovery_bundles is
+  'Encrypted app-mediated wallet recovery bundles. Service-role only; recovery material must not be returned to backend-only callers.';

--- a/supabase/migrations/20260520191400_recoverable_wallet_recovery_sessions.sql
+++ b/supabase/migrations/20260520191400_recoverable_wallet_recovery_sessions.sql
@@ -1,0 +1,39 @@
+create extension if not exists pgcrypto with schema extensions;
+
+create table if not exists public.recoverable_wallet_recovery_sessions (
+  id uuid primary key default extensions.gen_random_uuid(),
+  recovery_session_id text not null unique,
+  dapp_id bigint not null references public.dapps(id) on delete cascade,
+  dapp_user_uuid uuid not null references public.dapp_users(uuid) on delete cascade,
+  user_id bigint not null references public.users(id) on delete cascade,
+  recovery_bundle_id text not null,
+  provider_key text not null default 'cubid',
+  status text not null default 'pending',
+  request_id text,
+  created_by_actor_identifier text,
+  expires_at timestamptz not null,
+  consumed_at timestamptz,
+  released_at timestamptz,
+  cancelled_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint recoverable_wallet_recovery_sessions_status_check
+    check (status in ('pending', 'released', 'expired', 'cancelled'))
+);
+
+create index if not exists recoverable_wallet_recovery_sessions_lookup_idx
+  on public.recoverable_wallet_recovery_sessions (recovery_session_id, status);
+
+create index if not exists recoverable_wallet_recovery_sessions_dapp_user_idx
+  on public.recoverable_wallet_recovery_sessions (dapp_id, dapp_user_uuid, status);
+
+create index if not exists recoverable_wallet_recovery_sessions_user_idx
+  on public.recoverable_wallet_recovery_sessions (user_id, status);
+
+alter table public.recoverable_wallet_recovery_sessions enable row level security;
+
+revoke all on table public.recoverable_wallet_recovery_sessions from public;
+revoke all on table public.recoverable_wallet_recovery_sessions from anon;
+revoke all on table public.recoverable_wallet_recovery_sessions from authenticated;
+grant select, insert, update, delete on table public.recoverable_wallet_recovery_sessions to service_role;


### PR DESCRIPTION
## Summary
- Pivots the wallet direction away from Cubid-generated wallets and Cubid normal signing toward passkey-first, app-mediated recoverable wallets.
- Hard-disables new generated-wallet and normal-signing request creation while preserving redacted historical visibility.
- Adds API v3 recovery-bundle enrollment, status, release, rotation, revocation, and user-visible lifecycle surfaces.
- Documents SDK/SmarTrust coordination and leaves sibling cross-repo notes for the SDK and SmarTrust agents.

## Objective
Correct the wallet product direction so Cubid acts as a recovery provider, not as the app wallet generator or normal transaction signer. The new path lets host apps own wallet/MPC/signing/business logic while Cubid owns identity-bound recovery bundle custody and user-authorized release.

## Changes
- Added private-schema recovery-bundle storage with Supabase Vault envelope-encryption helpers.
- Added dapp-authenticated recovery APIs: enroll, status, release start, rotate, and revoke.
- Added Passport user-authenticated release completion and recovery bundle lifecycle listing.
- Added stable browser-safe recovery error codes and lifecycle audit events.
- Quarantined legacy generated-wallet/signing routes for new product traffic.
- Updated recoverable-wallet docs, API v3 docs, todo/session metadata, and cross-repo comms notes.

## Validation
- `pnpm --filter @cubid/passport test`
- `pnpm --filter @cubid/passport typecheck`
- `pnpm --filter @cubid/passport build`
- `pnpm --filter @cubid/admin test`
- `pnpm --filter @cubid/admin typecheck`
- `pnpm --filter @cubid/admin build`
- `git diff --check`

## Reviewer Notes
- Review the direction-reset docs first, then the route quarantine, then the new recovery-bundle APIs.
- The SmarTrust and SDK sibling notes are intentionally left dirty in those sibling repos as cross-repo notifications.
- The release completion route is intentionally user-authenticated rather than dapp-authenticated because it may return recovery material to the verified browser/client path.

## Follow-ups
- RW10: deploy hosted migrations, provision Vault secret `passport_recoverable_wallet_recovery_bundle_wrapping_key_v1`, and run hosted smoke checks.
- SDK repo: add provider-abstract recovery orchestration helpers before SmarTrust implements app-side integration.
- SmarTrust repo: hold direct integration until the Cubid SDK/repo support lands; SmarTrust still owns policy/backend/business logic.
