### PR TITLE
[codex] add recoverable wallet recovery UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ apps/passport/.env.local
 .env
 
 
+.env*

--- a/agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
+++ b/agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
@@ -10,9 +10,9 @@ sibling_notes:
   cubid-passport: agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
   cubid-sdk-v2: agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-sdk-direction.md
 last_update:
-  date: 2026-05-20
+  date: 2026-05-25
   actor: cubid-passport-agent
-  summary: Passport added concrete recoverable-wallet backend route and SDK package-boundary guidance.
+  summary: Passport requested SDK package updates and npm releases for the recoverable-wallet surface.
 ---
 
 # Recoverable Wallet SDK Direction Reset
@@ -101,3 +101,41 @@ Cubid-generated account/signing APIs as the preferred wallet path. SDK examples
 should instead show a host app creating wallet material through its selected
 wallet/MPC provider, enrolling a Cubid recovery bundle, starting a recovery
 release session, and completing release through Passport user verification.
+
+### 2026-05-25 — cubid-passport-agent
+
+Passport now has the backend recovery surface and hosted recovery page. SDK
+updates plus npm releases are needed before apps like SmarTrust should
+integrate.
+
+Recommended package split:
+
+- `@cubid/core`: typed wrappers for enroll/status/release-start/rotate/revoke
+  and structured recoverable-wallet error mapping.
+- `@cubid/browser` or new `@cubid/wallet-recovery`: browser-safe hosted
+  recovery launcher helpers, especially
+  `/recovery/wallet?recovery_session_id=...`.
+- `@cubid/react`: hooks/components around recovery launch and status UX.
+- `@cubid/auth` / `@cubid/auth-react`: no major protocol change expected unless
+  recovery becomes tightly coupled to Sign in with Cubid sessions.
+- Chain packages such as `@cubid/evm` and `@cubid/solana`: do not expose Cubid
+  as wallet generator/signer; future adapters must stay provider-abstract.
+
+Relevant Passport artifacts:
+
+- Architecture/spec:
+  `agent-context/recoverable-wallet-sdk/cubid-wallet-agent-spec.md`
+- Roadmap/status:
+  `agent-context/recoverable-wallet-sdk/todo.md`
+- Session log:
+  `agent-context/recoverable-wallet-sdk/session-log.md`
+- Runtime doc:
+  `docs/engineering/recoverable-wallet-api-v3.md`
+- Hosted UI:
+  `apps/passport/app/recovery/wallet/page.tsx`
+- Backend helpers/routes:
+  `apps/passport/lib/server/recoverableWalletRecovery.ts`,
+  `apps/passport/pages/api/v3/recovery-bundles/*`,
+  `apps/passport/pages/api/recovery-bundles/*`
+- Error taxonomy sibling:
+  `agent-context/cross-repo-comms/2026-05-20-recoverable-wallet-error-taxonomy.md`

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7606,3 +7606,34 @@ URLs created by the API have a user-facing approval and release surface.
 #### Follow-up
 
 - commit the page and decide whether to yeet this small branch to `dev`
+
+### session: v236
+
+- timestamp: 2026-05-25T02:43:30Z
+- agent: **OpenAI Codex**
+- branch: **codex/gitignore-env-hardening**
+- head: **`ede4beb`**
+- session name: **Send recoverable wallet SDK handoff**
+
+#### Objective
+
+Tell the public SDK agents what Passport has built for recoverable wallets and
+what package updates/releases are needed before downstream apps integrate.
+
+#### Actions Taken
+
+- updated the recoverable-wallet SDK direction cross-repo thread with a concise
+  package split for `@cubid/core`, `@cubid/browser` or a future
+  `@cubid/wallet-recovery`, `@cubid/react`, auth packages, and chain packages
+- linked the SDK agents to the relevant Passport architecture, roadmap, session
+  log, runtime docs, hosted UI, routes, helpers, and error taxonomy
+- copied the same note into the SDK repo as an intentionally dirty sibling note
+
+#### Verification
+
+- pending `git diff --check`
+
+#### Follow-up
+
+- commit the Passport-side note while leaving the SDK-side note dirty for the
+  SDK agents to pick up

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7542,3 +7542,31 @@ artifacts called out in PR #170 review.
 #### Follow-up
 
 - push the patch, reply to the PR thread, and resolve it
+
+### session: v234
+
+- timestamp: 2026-05-24T21:21:50Z
+- agent: **OpenAI Codex**
+- branch: **codex/gitignore-env-hardening**
+- head: **`68feae9`**
+- session name: **Commit env ignore hardening**
+
+#### Objective
+
+Preserve the local `.env*` ignore hardening tweak on a feature branch so local
+environment files stay out of Git.
+
+#### Actions Taken
+
+- created a small follow-up branch from current `dev`
+- kept the `.gitignore` change that ignores `.env*`
+- added this session-log entry before committing
+
+#### Verification
+
+- pending `git diff --check`
+
+#### Follow-up
+
+- commit the ignore hardening, then start Passport locally to inspect the
+  recoverable-wallet recovery UI surface

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7637,3 +7637,34 @@ what package updates/releases are needed before downstream apps integrate.
 
 - commit the Passport-side note while leaving the SDK-side note dirty for the
   SDK agents to pick up
+
+### session: v237
+
+- timestamp: 2026-05-25T02:57:50Z
+- agent: **OpenAI Codex**
+- branch: **codex/gitignore-env-hardening**
+- head: **`589247c`**
+- session name: **Address PR 171 redirect review**
+
+#### Objective
+
+Fix the review feedback that the post-login redirect guard could accept
+protocol-relative or malformed localStorage values.
+
+#### Actions Taken
+
+- added an explicit app-internal path validator for the recovery post-login
+  redirect
+- rejected protocol-relative paths and backslash-containing paths
+- cleared the stored redirect before validation so invalid values cannot linger
+  across sessions
+
+#### Verification
+
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+- `git diff --check`
+
+#### Follow-up
+
+- push the patch, reply to both review threads, and resolve them

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7570,3 +7570,39 @@ environment files stay out of Git.
 
 - commit the ignore hardening, then start Passport locally to inspect the
   recoverable-wallet recovery UI surface
+
+### session: v235
+
+- timestamp: 2026-05-24T21:27:50Z
+- agent: **OpenAI Codex**
+- branch: **codex/gitignore-env-hardening**
+- head: **`3bc1090`**
+- session name: **Add recoverable wallet recovery page**
+
+#### Objective
+
+Add the missing Passport-hosted `/recovery/wallet` page so recovery session
+URLs created by the API have a user-facing approval and release surface.
+
+#### Actions Taken
+
+- added an App Router recovery page that reads `recovery_session_id`
+- requires an explicit user click before calling the release-complete API
+- obtains the Firebase ID token from the signed-in browser session and sends it
+  as a bearer token to the existing user-authenticated API
+- shows safe request metadata, error states, release status, and guarded reveal
+  and copy controls for the released recovery material
+- added a safe post-login redirect in the Guest auth wrapper so users can sign
+  in and return to the recovery URL
+- opened the local page and confirmed it renders instead of the previous 404
+
+#### Verification
+
+- `pnpm --filter @cubid/passport typecheck`
+- `pnpm --filter @cubid/passport build`
+- local browser check at `/recovery/wallet?recovery_session_id=demo`
+- `git diff --check`
+
+#### Follow-up
+
+- commit the page and decide whether to yeet this small branch to `dev`

--- a/apps/passport/app/recovery/wallet/page.tsx
+++ b/apps/passport/app/recovery/wallet/page.tsx
@@ -1,0 +1,264 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import axios from "axios"
+import useAuth from "@/hooks/useAuth"
+import firebase from "@/lib/firebase"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+type ReleaseResult = {
+  bundleMaterial: string
+  dappUserUuid: string
+  providerKey: string
+  recoveryBundleId: string
+  recoverySessionId: string
+  releasedAt: string
+  status: string
+}
+
+const getErrorMessage = (error: unknown) => {
+  if (axios.isAxiosError(error)) {
+    return (
+      error.response?.data?.error?.message ??
+      error.response?.data?.message ??
+      error.message
+    )
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return "Unable to complete this recovery request."
+}
+
+export default function RecoverableWalletRecoveryPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const recoverySessionId = searchParams?.get("recovery_session_id") ?? ""
+  const { loading, user } = useAuth({})
+  const [releaseLoading, setReleaseLoading] = useState(false)
+  const [release, setRelease] = useState<ReleaseResult | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [showMaterial, setShowMaterial] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const shortSessionId = useMemo(() => {
+    if (!recoverySessionId) {
+      return ""
+    }
+
+    if (recoverySessionId.length <= 18) {
+      return recoverySessionId
+    }
+
+    return `${recoverySessionId.slice(0, 12)}...${recoverySessionId.slice(-6)}`
+  }, [recoverySessionId])
+
+  const signInAndReturn = () => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(
+        "passport_post_login_redirect",
+        `${window.location.pathname}${window.location.search}`
+      )
+    }
+
+    router.push("/login")
+  }
+
+  const releaseBundle = async () => {
+    setReleaseLoading(true)
+    setErrorMessage(null)
+    setCopied(false)
+
+    try {
+      const firebaseUser = firebase.auth().currentUser
+      const idToken = await firebaseUser?.getIdToken()
+
+      if (!idToken) {
+        throw new Error("Please sign in to Cubid before releasing recovery material.")
+      }
+
+      const { data } = await axios.post(
+        "/api/recovery-bundles/release/complete",
+        {
+          recovery_session_id: recoverySessionId,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${idToken}`,
+          },
+        }
+      )
+
+      setRelease(data.data)
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error))
+    } finally {
+      setReleaseLoading(false)
+    }
+  }
+
+  const copyMaterial = async () => {
+    if (!release?.bundleMaterial || !navigator.clipboard) {
+      return
+    }
+
+    await navigator.clipboard.writeText(release.bundleMaterial)
+    setCopied(true)
+  }
+
+  return (
+    <main className="min-h-[calc(100vh-5rem)] bg-slate-950 px-4 py-16 text-white">
+      <section className="mx-auto flex max-w-3xl flex-col gap-6">
+        <div className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-300">
+            Cubid recovery
+          </p>
+          <h1 className="text-4xl font-black tracking-tight md:text-5xl">
+            Recover an app-mediated wallet
+          </h1>
+          <p className="max-w-2xl text-base leading-7 text-slate-300">
+            Cubid verifies that this recovery request belongs to you, then
+            releases the recovery bundle only to this signed-in browser. Cubid
+            does not create wallets or perform normal transaction signing for
+            the app.
+          </p>
+        </div>
+
+        <Card className="border-white/10 bg-white text-slate-950 shadow-2xl">
+          <CardHeader>
+            <CardTitle>Recovery request</CardTitle>
+            <CardDescription>
+              Session{" "}
+              <span className="font-mono text-xs">
+                {shortSessionId || "missing"}
+              </span>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            {!recoverySessionId && (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900">
+                This recovery link is missing a recovery session id. Ask the app
+                to start a new recovery request.
+              </div>
+            )}
+
+            {recoverySessionId && loading && (
+              <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+                Checking your Cubid sign-in...
+              </div>
+            )}
+
+            {recoverySessionId && !loading && !user && (
+              <div className="space-y-4">
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                  Sign in with the Cubid identity that owns this recovery
+                  request. Recovery material will not be released until your
+                  signed-in identity matches the request.
+                </div>
+                <Button onClick={signInAndReturn}>Sign in to continue</Button>
+              </div>
+            )}
+
+            {recoverySessionId && !loading && user && !release && (
+              <div className="space-y-4">
+                <div className="rounded-lg border border-cyan-200 bg-cyan-50 p-4 text-sm text-cyan-950">
+                  You are signed in as{" "}
+                  <span className="font-medium">
+                    {user.email || user.phone || "this Cubid user"}
+                  </span>
+                  . If this recovery request belongs to a different Cubid
+                  identity, it will be rejected.
+                </div>
+                <Button onClick={releaseBundle} disabled={releaseLoading}>
+                  {releaseLoading
+                    ? "Releasing recovery bundle..."
+                    : "Release recovery bundle"}
+                </Button>
+              </div>
+            )}
+
+            {errorMessage && (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900">
+                {errorMessage}
+              </div>
+            )}
+
+            {release && (
+              <div className="space-y-4">
+                <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-950">
+                  Recovery bundle released at{" "}
+                  <span className="font-mono text-xs">{release.releasedAt}</span>
+                  . Copy it into the requesting app only if you recognize the
+                  recovery flow.
+                </div>
+
+                <dl className="grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm md:grid-cols-2">
+                  <div>
+                    <dt className="text-slate-500">Provider</dt>
+                    <dd className="font-medium">{release.providerKey}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-slate-500">Status</dt>
+                    <dd className="font-medium">{release.status}</dd>
+                  </div>
+                  <div className="md:col-span-2">
+                    <dt className="text-slate-500">Recovery bundle</dt>
+                    <dd className="break-all font-mono text-xs">
+                      {release.recoveryBundleId}
+                    </dd>
+                  </div>
+                </dl>
+
+                <div className="space-y-3 rounded-lg border border-slate-200 p-4">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h2 className="font-semibold">Recovery material</h2>
+                      <p className="text-sm text-slate-600">
+                        This is sensitive. Cubid shows it only after your
+                        signed-in identity is verified for this one-time
+                        session.
+                      </p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      onClick={() => setShowMaterial((current) => !current)}
+                    >
+                      {showMaterial ? "Hide" : "Reveal"}
+                    </Button>
+                  </div>
+
+                  {showMaterial && (
+                    <textarea
+                      readOnly
+                      className="min-h-32 w-full rounded-md border border-slate-300 bg-slate-950 p-3 font-mono text-xs text-slate-50"
+                      value={release.bundleMaterial}
+                    />
+                  )}
+
+                  <Button
+                    variant="secondary"
+                    onClick={copyMaterial}
+                    disabled={!showMaterial}
+                  >
+                    {copied ? "Copied" : "Copy recovery material"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  )
+}

--- a/apps/passport/components/auth/guest.tsx
+++ b/apps/passport/components/auth/guest.tsx
@@ -19,7 +19,17 @@ export const Guest = ({ children, allowAuthenticated = false }: GuestProps) => {
     }
 
     if (user && !allowAuthenticated) {
-      router.push('/app')
+      const postLoginRedirect = localStorage.getItem(
+        "passport_post_login_redirect"
+      )
+
+      if (postLoginRedirect?.startsWith("/")) {
+        localStorage.removeItem("passport_post_login_redirect")
+        router.push(postLoginRedirect)
+        return
+      }
+
+      router.push("/app")
     } else {
       setUnverified(true)
     }

--- a/apps/passport/components/auth/guest.tsx
+++ b/apps/passport/components/auth/guest.tsx
@@ -8,6 +8,14 @@ type GuestProps = {
   allowAuthenticated?: boolean
 }
 
+const isSafePostLoginPath = (path: string | null): path is string => {
+  if (!path) {
+    return false
+  }
+
+  return path.startsWith("/") && !path.startsWith("//") && !path.includes("\\")
+}
+
 export const Guest = ({ children, allowAuthenticated = false }: GuestProps) => {
   const router = useRouter()
   const { user, loading } = useAuth({});
@@ -23,8 +31,9 @@ export const Guest = ({ children, allowAuthenticated = false }: GuestProps) => {
         "passport_post_login_redirect"
       )
 
-      if (postLoginRedirect?.startsWith("/")) {
-        localStorage.removeItem("passport_post_login_redirect")
+      localStorage.removeItem("passport_post_login_redirect")
+
+      if (isSafePostLoginPath(postLoginRedirect)) {
         router.push(postLoginRedirect)
         return
       }


### PR DESCRIPTION
## Summary
- Adds a Passport-hosted `/recovery/wallet` page for recoverable-wallet release sessions.
- Preserves local secret safety by ignoring `.env*` files.
- Sends a concise cross-repo SDK handoff note for the recoverable-wallet package work and npm releases.

## Objective
Provide the missing user-facing recovery release UI so recovery-session URLs can send users to Passport for sign-in, explicit release approval, and guarded access to released recovery material.

## Changes
- Added the App Router recovery page that reads `recovery_session_id`, requires sign-in, calls the existing release-complete API with the Firebase bearer token, and keeps recovery material hidden until explicit reveal/copy.
- Updated the guest auth wrapper to return users to a safe local post-login path.
- Added `.env*` ignore hardening for local-only environment files.
- Updated the recoverable-wallet SDK cross-repo thread with the expected `@cubid/core`, browser/recovery, React, auth, and chain-package split.

## Validation
- `pnpm --filter @cubid/passport typecheck`
- `pnpm --filter @cubid/passport build`
- `git diff --check origin/dev..HEAD`
- Local browser check of `/recovery/wallet?recovery_session_id=demo` before publish.

## Reviewer Notes
- Review the recovery UI page first, then the small auth redirect helper.
- The SDK handoff note is intentionally docs-only; the matching SDK sibling note is left dirty in the SDK repo for its agents.
- This PR does not add new recovery APIs or migrations; it uses the already-landed recovery bundle routes.

## Follow-ups
- Implement and publish the recoverable-wallet SDK wrappers in `Cubid-Me/cubid-sdk`.
- Smoke the recovery UI on the Vercel preview once deployed.
