### PR TITLE
Restore Admin dapp API-key UX

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7668,3 +7668,39 @@ protocol-relative or malformed localStorage values.
 #### Follow-up
 
 - push the patch, reply to both review threads, and resolve them
+
+### session: v238
+
+- timestamp: 2026-05-25T06:45:33Z
+- agent: **OpenAI Codex**
+- branch: **codex/admin-dapp-api-key-ux**
+- head: **`49fc9d5`**
+- session name: **Restore Admin dapp API key UX**
+
+#### Objective
+
+Repair Admin app/key management after the legacy `dapps.apikey` removal while
+keeping API-key reads and rotations anchored on `dapp_api_keys`.
+
+#### Actions Taken
+
+- normalized missing active key rows to explicit non-secret metadata
+- updated the Admin app list to show API-key status instead of legacy key copy
+- rotated keys by stable numeric dapp id rather than public `uid`
+- added Admin route and UI tests for metadata-only listing, missing-key display,
+  one-time rotation behavior, and absence of legacy plaintext key exposure
+- audited the Admin Vercel project env state and copied the configured Preview
+  Admin env contract into Production settings without printing secret values
+
+#### Verification
+
+- `pnpm --filter @cubid/admin test`
+- `pnpm --filter @cubid/admin typecheck`
+- `pnpm --filter @cubid/admin build`
+- `git diff --check`
+
+#### Follow-up
+
+- push the branch so Vercel can build a fresh Admin preview, then add
+  branch-specific Preview Firebase Admin server envs if the preview needs
+  authenticated Admin API smoke after sign-in

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7742,3 +7742,37 @@ properly configured.
 
 - push the fail-closed patch and trigger a fresh Admin Preview deployment to
   verify the blank-page crash is gone
+
+### session: v240
+
+- timestamp: 2026-05-25T06:59:37Z
+- agent: **OpenAI Codex**
+- branch: **codex/admin-dapp-api-key-ux**
+- head: **`ffa4583`**
+- session name: **Fix Admin Firebase public env detection**
+
+#### Objective
+
+Fix the Admin Firebase readiness check so Vercel-provided
+`NEXT_PUBLIC_FIREBASE_*` values are detected correctly in browser bundles.
+
+#### Actions Taken
+
+- replaced dynamic `process.env[key]` lookup with explicit static
+  `process.env.NEXT_PUBLIC_*` references
+- preserved the fail-closed missing-config message for genuinely unconfigured
+  deployments
+- confirmed Vercel can pull the Admin Preview Firebase env values for the
+  branch
+
+#### Verification
+
+- `pnpm --filter @cubid/admin test`
+- `pnpm --filter @cubid/admin typecheck`
+- `pnpm --filter @cubid/admin build`
+- `git diff --check`
+
+#### Follow-up
+
+- push the static env detection fix and verify the fresh Admin Preview no
+  longer shows the Firebase configuration warning

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -7704,3 +7704,41 @@ keeping API-key reads and rotations anchored on `dapp_api_keys`.
 - push the branch so Vercel can build a fresh Admin preview, then add
   branch-specific Preview Firebase Admin server envs if the preview needs
   authenticated Admin API smoke after sign-in
+
+### session: v239
+
+- timestamp: 2026-05-25T06:56:00Z
+- agent: **OpenAI Codex**
+- branch: **codex/admin-dapp-api-key-ux**
+- head: **`ca097f9`**
+- session name: **Fail closed for missing Admin Firebase config**
+
+#### Objective
+
+Prevent Admin deployments with missing Firebase public config from rendering a
+blank white page while keeping sign-in disabled until the deployment is
+properly configured.
+
+#### Actions Taken
+
+- changed the Admin Firebase client helper to expose missing-config state
+  instead of throwing at module import time
+- made Admin auth hooks and authenticated API helpers fail closed when Firebase
+  config is unavailable
+- added an operator-facing sign-in message for deployments missing Firebase
+  public settings
+- verified the Admin Vercel project has Preview public Firebase settings and
+  populated missing Production environment settings from the existing Preview
+  contract
+
+#### Verification
+
+- `pnpm --filter @cubid/admin test`
+- `pnpm --filter @cubid/admin typecheck`
+- `pnpm --filter @cubid/admin build`
+- `git diff --check`
+
+#### Follow-up
+
+- push the fail-closed patch and trigger a fresh Admin Preview deployment to
+  verify the blank-page crash is gone

--- a/apps/admin/app/admin/appList.test.tsx
+++ b/apps/admin/app/admin/appList.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type React from 'react';
+
+import AppList from './appList';
+
+const authedPostMock = jest.fn();
+const toastErrorMock = jest.fn();
+const toastSuccessMock = jest.fn();
+
+jest.mock('hooks/useAuth', () => ({
+  __esModule: true,
+  ...(() => {
+    const user = { email: 'admin@example.com' };
+
+    return {
+      default: () => ({ user }),
+      useAuth: () => ({ user }),
+    };
+  })(),
+}));
+
+jest.mock('lib/api', () => ({
+  authedPost: (...args: unknown[]) => authedPostMock(...args),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+  },
+}));
+
+jest.mock('components/admin/create-app', () => ({
+  CreateApp: () => <button type="button">Create App</button>,
+}));
+
+jest.mock('app/admin/addSubpage', () => ({
+  AddSubpage: () => null,
+}));
+
+jest.mock('app/admin/childApps', () => ({
+  ChildApps: () => null,
+}));
+
+jest.mock('./rotateKeyModal', () => ({
+  RotateApiKeyModal: ({
+    openModal,
+    rotate,
+  }: {
+    openModal: boolean;
+    rotate: () => Promise<void>;
+  }) =>
+    openModal ? (
+      <button type="button" onClick={rotate}>
+        Confirm rotate
+      </button>
+    ) : null,
+}));
+
+jest.mock('rc-tooltip', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe('AppList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders dapp_api_keys metadata without undefined or plaintext keys', async () => {
+    authedPostMock.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            admin_uid: 'admin_uid',
+            apiKeyLastUsedAt: null,
+            apiKeyPrefix: 'prefix42',
+            apiKeyRotatedAt: '2026-04-27T00:00:00.000Z',
+            apiKeyStatus: 'active',
+            appname: 'Active Key App',
+            id: 42,
+            uid: 'public-app-uid-42',
+          },
+          {
+            admin_uid: 'admin_uid',
+            apiKeyLastUsedAt: null,
+            apiKeyPrefix: null,
+            apiKeyRotatedAt: null,
+            apiKeyStatus: 'missing',
+            appname: 'Missing Key App',
+            id: 43,
+            uid: 'public-app-uid-43',
+          },
+        ],
+      },
+    });
+
+    const { container } = render(<AppList />);
+
+    expect(await screen.findByText('Active Key App')).toBeTruthy();
+    expect(screen.getByText('prefix42...')).toBeTruthy();
+    expect(screen.getByText('Missing active key')).toBeTruthy();
+    expect(
+      screen.getByText('Rotate this app key to create a new one-time API key.')
+    ).toBeTruthy();
+    expect(container.textContent).not.toContain('undefined');
+    expect(container.textContent).not.toContain('legacy-plaintext-key');
+  });
+
+  it('rotates by numeric dapp id instead of public uid', async () => {
+    authedPostMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              admin_uid: 'admin_uid',
+              apiKeyPrefix: null,
+              apiKeyStatus: 'missing',
+              appname: 'Recoverable App',
+              id: 43,
+              uid: 'public-app-uid-43',
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            apiKey: 'cubid_live_prefix_secret',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              admin_uid: 'admin_uid',
+              apiKeyPrefix: 'prefix',
+              apiKeyStatus: 'active',
+              appname: 'Recoverable App',
+              id: 43,
+              uid: 'public-app-uid-43',
+            },
+          ],
+        },
+      });
+
+    render(<AppList />);
+
+    fireEvent.click(
+      await screen.findByLabelText('Rotate API key for Recoverable App')
+    );
+    fireEvent.click(await screen.findByText('Confirm rotate'));
+
+    await waitFor(() => {
+      expect(authedPostMock).toHaveBeenCalledWith(
+        '/api/admin/apps/rotate-key',
+        {
+          dappId: 43,
+        }
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Confirm rotate')).toBeNull();
+    });
+    expect(authedPostMock).not.toHaveBeenCalledWith(
+      '/api/admin/apps/rotate-key',
+      {
+        dappId: 'public-app-uid-43',
+      }
+    );
+  });
+});

--- a/apps/admin/app/admin/appList.tsx
+++ b/apps/admin/app/admin/appList.tsx
@@ -14,17 +14,55 @@ interface SuperApp {
   apiKeyPrefix?: string | null;
   apiKeyRotatedAt?: string | null;
   apiKeyStatus?: string | null;
-  uid: string;
+  uid?: string | null;
   appname: string;
-  id: string;
+  id: number | string;
   admin_uid: string;
 }
+
+const getAppDisplayId = (app: SuperApp) => app.uid ?? String(app.id);
+
+const getApiKeyStatusLabel = (app: SuperApp) => {
+  if (app.apiKeyPrefix) {
+    return `${app.apiKeyPrefix}...`;
+  }
+
+  if (app.apiKeyStatus === 'missing') {
+    return 'Missing active key';
+  }
+
+  if (app.apiKeyStatus === 'revoked') {
+    return 'No active key';
+  }
+
+  return 'Key metadata unavailable';
+};
+
+const getApiKeyStatusDetail = (app: SuperApp) => {
+  if (app.apiKeyPrefix) {
+    return [
+      app.apiKeyStatus ?? 'active',
+      app.apiKeyRotatedAt ? `rotated ${app.apiKeyRotatedAt}` : null,
+      app.apiKeyLastUsedAt ? `last used ${app.apiKeyLastUsedAt}` : null,
+    ]
+      .filter(Boolean)
+      .join(' • ');
+  }
+
+  if (app.apiKeyStatus === 'missing') {
+    return 'Rotate this app key to create a new one-time API key.';
+  }
+
+  return app.apiKeyStatus ?? 'unavailable';
+};
 
 export default function AppList() {
   const [superApps, setSuperApps] = useState<SuperApp[]>([]);
   const { user } = useAuth();
   const [loading, setLoading] = useState<boolean>(true);
-  const [apiKeyToRotate, setApiKeyToRotate] = useState<string | null>(null);
+  const [apiKeyToRotate, setApiKeyToRotate] = useState<number | string | null>(
+    null
+  );
   const [oneTimeApiKey, setOneTimeApiKey] = useState<string | null>(null);
 
   const fetchSuperApps = useCallback(async () => {
@@ -50,9 +88,11 @@ export default function AppList() {
     fetchSuperApps();
   }, [fetchSuperApps]);
 
-  const rotateApiKeys = async (uuidSupabase: string) => {
+  const rotateApiKeys = async (dappId: number | string) => {
     try {
-      const selectedApp = superApps.find((item) => item.uid === uuidSupabase);
+      const selectedApp = superApps.find(
+        (item) => String(item.id) === String(dappId)
+      );
 
       if (!selectedApp) {
         throw new Error('Unable to find app to rotate');
@@ -63,7 +103,7 @@ export default function AppList() {
           apiKey?: string;
         };
       }>('/api/admin/apps/rotate-key', {
-        dappId: selectedApp.id,
+        dappId,
       });
       if (response.data.data.apiKey) {
         setOneTimeApiKey(response.data.data.apiKey);
@@ -130,7 +170,7 @@ export default function AppList() {
               <tr>
                 <th scope="col" className="px-6 py-3">App Name</th>
                 <th scope="col" className="px-6 py-3">App ID</th>
-                <th scope="col" className="px-6 py-3">API Key</th>
+                <th scope="col" className="px-6 py-3">API key status</th>
                 <th scope="col" className="px-6 py-3">Actions</th>
               </tr>
             </thead>
@@ -143,30 +183,31 @@ export default function AppList() {
                 </tr>
               ) : (
                 superApps.map((item) => (
-                  <React.Fragment key={item.uid}>
+                  <React.Fragment key={String(item.id)}>
                     <tr className="border-b border-gray-700 bg-gray-800">
                       <th scope="row" className="whitespace-nowrap px-6 py-4 font-medium text-gray-500">
                         {item.appname}
                       </th>
-                      <td className="px-6 py-4">{item.uid}</td>
+                      <td className="px-6 py-4">{getAppDisplayId(item)}</td>
                       <td className="px-6 py-4">
                         <div>
                           <p className="font-mono text-xs">
-                            {item.apiKeyPrefix
-                              ? `${item.apiKeyPrefix}...`
-                              : 'No active key'}
+                            {getApiKeyStatusLabel(item)}
                           </p>
                           <p className="text-xs text-gray-500">
-                            {item.apiKeyStatus ?? 'missing'}
+                            {getApiKeyStatusDetail(item)}
                           </p>
                         </div>
                       </td>
                       <td className="px-6 py-4">
                         <div className="flex items-center  space-x-2">
-                          <Tooltip placement="left" trigger={['hover']} overlay={<span>Rotate API KEYS</span>}>
-                            <button onClick={() => setApiKeyToRotate(item.uid)}>
+                          <Tooltip placement="left" trigger={['hover']} overlay={<span>Rotate API key</span>}>
+                            <button
+                              aria-label={`Rotate API key for ${item.appname}`}
+                              onClick={() => setApiKeyToRotate(item.id)}
+                            >
                               <svg xmlns="http://www.w3.org/2000/svg" height="20px" width="20px" viewBox="0 0 24 24" >
-                                <path xmlns="http://www.w3.org/2000/svg" d="M20.5 9.00006C19 5.00024 15.5334 3.00122 11.9991 3.00122C7.36722 3.00122 3.55265 6.50073 3.05499 11.0001M20.9428 13.005C20.4434 17.5025 16.6297 21 11.9991 21C8.46723 21 5 19.0001 3.5 15.0002M21 5.00006V9.00006H17M3 19.0001V15.0001H7M12 8.00006V13.0001M12 16.0001H12.01" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                                <path xmlns="http://www.w3.org/2000/svg" d="M20.5 9.00006C19 5.00024 15.5334 3.00122 11.9991 3.00122C7.36722 3.00122 3.55265 6.50073 3.05499 11.0001M20.9428 13.005C20.4434 17.5025 16.6297 21 11.9991 21C8.46723 21 5 19.0001 3.5 15.0002M21 5.00006V9.00006H17M3 19.0001V15.0001H7M12 8.00006V13.0001M12 16.0001H12.01" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                               </svg>
                             </button>
                           </Tooltip>

--- a/apps/admin/app/admin/childApps.tsx
+++ b/apps/admin/app/admin/childApps.tsx
@@ -10,7 +10,7 @@ interface ChildPage {
 
 interface ChildAppsProps {
   fetchSuperApps: () => Promise<void>;
-  parentDappId: string;
+  parentDappId: number | string;
 }
 
 export const ChildApps = ({ parentDappId, fetchSuperApps }: ChildAppsProps) => {

--- a/apps/admin/app/sign-in/page.tsx
+++ b/apps/admin/app/sign-in/page.tsx
@@ -5,7 +5,7 @@ import { useRef } from 'react';
 import { toast } from 'react-toastify';
 
 import { authedPost } from '../../lib/api';
-import firebase from '../../lib/firebase';
+import firebase, { firebaseConfigError } from '../../lib/firebase';
 
 interface OwnIdLoginPayload {
   idToken: string;
@@ -37,6 +37,16 @@ export default function SignIn() {
               <h1 className='text-xl font-bold leading-tight tracking-tight text-gray-900 dark:text-white md:text-2xl'>
                 Sign in
               </h1>
+              {firebaseConfigError ? (
+                <div className="rounded border border-red-500 bg-red-950/40 p-3 text-sm text-red-100">
+                  <p className="font-semibold">Admin sign-in is not configured.</p>
+                  <p className="mt-1">
+                    A deployment environment variable is missing. Ask an
+                    operator to configure the Admin Firebase public settings and
+                    redeploy this environment.
+                  </p>
+                </div>
+              ) : null}
               <form className='space-y-4 md:space-y-6'>
                 <div>
                   <label
@@ -71,22 +81,24 @@ export default function SignIn() {
                   />
                 </div>
 
-                <OwnID
-                  type='login'
-                  options={{
-                    appId: process.env.NEXT_PUBLIC_OWNID_APP_ID ?? '',
-                    variant: 'ownid-auth-button',
-                    infoTooltip: true,
-                    widgetPosition: 'start',
-                  }}
-                  onLogin={submit}
-                  infoTooltip={true}
-                  passwordField={passwordField}
-                  loginIdField={emailField}
-                  onError={() => {
-                    toast.error('Authentication failed');
-                  }}
-                />
+                {!firebaseConfigError ? (
+                  <OwnID
+                    type='login'
+                    options={{
+                      appId: process.env.NEXT_PUBLIC_OWNID_APP_ID ?? '',
+                      variant: 'ownid-auth-button',
+                      infoTooltip: true,
+                      widgetPosition: 'start',
+                    }}
+                    onLogin={submit}
+                    infoTooltip={true}
+                    passwordField={passwordField}
+                    loginIdField={emailField}
+                    onError={() => {
+                      toast.error('Authentication failed');
+                    }}
+                  />
+                ) : null}
               </form>
             </div>
           </div>

--- a/apps/admin/hooks/useAuth.tsx
+++ b/apps/admin/hooks/useAuth.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import firebase from '../lib/firebase';
+import firebase, { firebaseConfigError } from '../lib/firebase';
 import { login, logout } from '../redux/userSlice';
 
 export const useAuth = () => {
@@ -10,6 +10,11 @@ export const useAuth = () => {
   const [user, setUser] = useState<any>(null);
 
   useEffect(() => {
+    if (firebaseConfigError) {
+      setLoading(false);
+      return undefined;
+    }
+
     const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
       if (user) {
         const setUserData = {

--- a/apps/admin/lib/api.ts
+++ b/apps/admin/lib/api.ts
@@ -1,10 +1,14 @@
 import axios from 'axios';
 
-import firebase from './firebase';
+import firebase, { firebaseConfigError } from './firebase';
 
 type RequestBody = Record<string, unknown> | undefined;
 
 const getAuthHeaders = async () => {
+  if (firebaseConfigError) {
+    throw new Error(firebaseConfigError);
+  }
+
   const currentUser = firebase.auth().currentUser;
 
   if (!currentUser) {

--- a/apps/admin/lib/firebase.ts
+++ b/apps/admin/lib/firebase.ts
@@ -1,24 +1,6 @@
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
 
-const requiredFirebaseEnv = [
-  'NEXT_PUBLIC_FIREBASE_API_KEY',
-  'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
-  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
-  'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
-  'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
-  'NEXT_PUBLIC_FIREBASE_APP_ID',
-] as const;
-
-export const missingFirebaseEnv = requiredFirebaseEnv.filter(
-  (key) => !process.env[key]?.trim()
-);
-
-export const firebaseConfigError =
-  missingFirebaseEnv.length > 0
-    ? `Missing Firebase environment configuration: ${missingFirebaseEnv.join(', ')}`
-    : null;
-
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -28,6 +10,27 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
+
+const requiredFirebaseEnv = [
+  ['NEXT_PUBLIC_FIREBASE_API_KEY', firebaseConfig.apiKey],
+  ['NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN', firebaseConfig.authDomain],
+  ['NEXT_PUBLIC_FIREBASE_PROJECT_ID', firebaseConfig.projectId],
+  ['NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET', firebaseConfig.storageBucket],
+  [
+    'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+    firebaseConfig.messagingSenderId,
+  ],
+  ['NEXT_PUBLIC_FIREBASE_APP_ID', firebaseConfig.appId],
+] as const;
+
+export const missingFirebaseEnv = requiredFirebaseEnv
+  .filter(([, value]) => !value?.trim())
+  .map(([key]) => key);
+
+export const firebaseConfigError =
+  missingFirebaseEnv.length > 0
+    ? `Missing Firebase environment configuration: ${missingFirebaseEnv.join(', ')}`
+    : null;
 
 if (!firebaseConfigError && !firebase.apps.length) {
   firebase.initializeApp(firebaseConfig);

--- a/apps/admin/lib/firebase.ts
+++ b/apps/admin/lib/firebase.ts
@@ -10,11 +10,14 @@ const requiredFirebaseEnv = [
   'NEXT_PUBLIC_FIREBASE_APP_ID',
 ] as const;
 
-const missingFirebaseEnv = requiredFirebaseEnv.filter((key) => !process.env[key]?.trim());
+export const missingFirebaseEnv = requiredFirebaseEnv.filter(
+  (key) => !process.env[key]?.trim()
+);
 
-if (missingFirebaseEnv.length > 0) {
-  throw new Error(`Missing Firebase environment configuration: ${missingFirebaseEnv.join(', ')}`);
-}
+export const firebaseConfigError =
+  missingFirebaseEnv.length > 0
+    ? `Missing Firebase environment configuration: ${missingFirebaseEnv.join(', ')}`
+    : null;
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -26,7 +29,7 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-if (!firebase.apps.length) {
+if (!firebaseConfigError && !firebase.apps.length) {
   firebase.initializeApp(firebaseConfig);
 }
 

--- a/apps/admin/lib/server/adminRoutes.test.ts
+++ b/apps/admin/lib/server/adminRoutes.test.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+import listApps from '../../pages/api/admin/apps/list';
 import rotateKey from '../../pages/api/admin/apps/rotate-key';
 import syncAdminUser from '../../pages/api/admin/auth/sync';
 import disclosureOpsOverviewRoute from '../../pages/api/admin/disclosures/operations/overview';
@@ -20,6 +21,8 @@ const ensureAdminUserRecordMock = jest.fn();
 const getOwnedDappMock = jest.fn();
 const getOwnedDappIdsMock = jest.fn();
 const getPlatformUserByEmailMock = jest.fn();
+const createDappApiKeyMock = jest.fn();
+const mapDappApiKeySummaryMock = jest.fn();
 const rotateDappApiKeyMock = jest.fn();
 const updateOidcClientOpsMock = jest.fn();
 const loadDisclosureOpsOverviewMock = jest.fn();
@@ -59,6 +62,9 @@ jest.mock('./disclosureOperations', () => ({
 }));
 
 jest.mock('./dappApiKeys', () => ({
+  createDappApiKey: (...args: unknown[]) => createDappApiKeyMock(...args),
+  mapDappApiKeySummary: (...args: unknown[]) =>
+    mapDappApiKeySummaryMock(...args),
   rotateDappApiKey: (...args: unknown[]) => rotateDappApiKeyMock(...args),
 }));
 
@@ -100,6 +106,12 @@ const createResponse = () => {
 describe('Admin route baseline wiring', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mapDappApiKeySummaryMock.mockImplementation((row) => ({
+      apiKeyLastUsedAt: row?.last_used_at ?? null,
+      apiKeyPrefix: row?.key_prefix ?? null,
+      apiKeyRotatedAt: row?.rotated_at ?? null,
+      apiKeyStatus: row?.status ?? 'missing',
+    }));
   });
 
   it('uses the user actor and auth-sync rate limit for auth/sync', async () => {
@@ -190,6 +202,92 @@ describe('Admin route baseline wiring', () => {
         }),
       })
     );
+  });
+
+  it('lists apps with dapp_api_keys metadata and no legacy apikey field', async () => {
+    const dapps = [
+      {
+        admin_uid: 'admin_uid',
+        apikey: 'legacy-plaintext-key',
+        appname: 'App With Key',
+        id: 42,
+        uid: 'public-app-uid-42',
+      },
+      {
+        admin_uid: 'admin_uid',
+        apikey: 'legacy-missing-key',
+        appname: 'App Missing Key',
+        id: 43,
+        uid: 'public-app-uid-43',
+      },
+    ];
+    const activeKeys = [
+      {
+        dapp_id: 42,
+        key_prefix: 'prefix42',
+        last_used_at: null,
+        rotated_at: '2026-04-27T00:00:00.000Z',
+        status: 'active',
+      },
+    ];
+    const supabase = {
+      from: jest.fn((table: string) => {
+        if (table === 'dapps') {
+          return {
+            select: () => ({
+              match: async () => ({ data: dapps, error: null }),
+            }),
+          };
+        }
+
+        if (table === 'dapp_api_keys') {
+          return {
+            select: () => ({
+              in: () => ({
+                eq: async () => ({ data: activeKeys, error: null }),
+              }),
+            }),
+          };
+        }
+
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+
+    prepareAdminApiRequestMock.mockResolvedValue({
+      body: {},
+      context: {
+        adminUser: { uid: 'admin_uid' },
+        supabase,
+      },
+      requestId: 'admin_request_apps_list',
+    });
+
+    const response = createResponse();
+    await listApps({} as NextApiRequest, response);
+
+    expect(supabase.from).toHaveBeenCalledWith('dapp_api_keys');
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          apiKeyPrefix: 'prefix42',
+          apiKeyStatus: 'active',
+          appname: 'App With Key',
+          id: 42,
+        }),
+        expect.objectContaining({
+          apiKeyPrefix: null,
+          apiKeyStatus: 'missing',
+          appname: 'App Missing Key',
+          id: 43,
+        }),
+      ],
+    });
+    const payload = (response.json as jest.Mock).mock.calls[0][0];
+    expect(JSON.stringify(payload)).not.toContain('legacy-plaintext-key');
+    expect(payload.data[0].apikey).toBeUndefined();
+    expect(payload.data[1].apikey).toBeUndefined();
   });
 
   it('uses the sensitive policy for OIDC client ops updates', async () => {

--- a/apps/admin/lib/server/dappApiKeys.ts
+++ b/apps/admin/lib/server/dappApiKeys.ts
@@ -8,6 +8,13 @@ export type DappApiKeySummary = {
   apiKeyStatus: string | null;
 };
 
+export const MISSING_DAPP_API_KEY_SUMMARY: DappApiKeySummary = {
+  apiKeyLastUsedAt: null,
+  apiKeyPrefix: null,
+  apiKeyRotatedAt: null,
+  apiKeyStatus: 'missing',
+};
+
 export const createDappApiKey = async (
   supabase: SupabaseClient,
   dappId: number
@@ -72,9 +79,17 @@ export const rotateDappApiKey = async (
 
 export const mapDappApiKeySummary = (
   row: Record<string, unknown> | null | undefined
-): DappApiKeySummary => ({
-  apiKeyLastUsedAt: typeof row?.last_used_at === 'string' ? row.last_used_at : null,
-  apiKeyPrefix: typeof row?.key_prefix === 'string' ? row.key_prefix : null,
-  apiKeyRotatedAt: typeof row?.rotated_at === 'string' ? row.rotated_at : null,
-  apiKeyStatus: typeof row?.status === 'string' ? row.status : null,
-});
+): DappApiKeySummary => {
+  if (!row) {
+    return MISSING_DAPP_API_KEY_SUMMARY;
+  }
+
+  return {
+    apiKeyLastUsedAt:
+      typeof row.last_used_at === 'string' ? row.last_used_at : null,
+    apiKeyPrefix: typeof row.key_prefix === 'string' ? row.key_prefix : null,
+    apiKeyRotatedAt:
+      typeof row.rotated_at === 'string' ? row.rotated_at : null,
+    apiKeyStatus: typeof row.status === 'string' ? row.status : 'unavailable',
+  };
+};


### PR DESCRIPTION
## Summary
- Restores Admin dapp API-key list/rotate UX after the legacy dapps.apikey column removal.
- Keeps Admin list/create/rotate anchored on dapp_api_keys metadata and one-time key reveal only.
- Fixes the Admin Firebase config check so Vercel Preview builds no longer crash from dynamic NEXT_PUBLIC env lookups.

## Objective
Restore the Admin app/key management surface and make Preview deployments readable again without reintroducing plaintext dapp API keys.

## Changes
- Normalize missing dapp_api_keys rows to explicit non-secret metadata.
- Update the Apps table copy and states to show API key status, active prefixes, and missing-key recovery guidance without undefined text.
- Rotate keys by stable numeric dapp id instead of public uid.
- Add Admin route/UI tests for metadata-only list responses and numeric-id rotation.
- Add fail-closed Firebase config handling and switch public env detection to static Next-compatible references.
- Populated Admin Vercel Production env settings from the existing Preview contract and added branch Preview Firebase Admin server envs.

## Validation
- pnpm --filter @cubid/admin test
- pnpm --filter @cubid/admin typecheck
- pnpm --filter @cubid/admin build
- git diff --check
- Hosted Preview smoke: https://cubid-admin-lv60ifd9e-cubid-team.vercel.app/sign-in loads the sign-in page without the Firebase config crash.

## Reviewer Notes
- This intentionally does not restore or depend on dapps.apikey.
- The Admin build still reports pre-existing Tailwind/import-order lint warnings outside this focused repair.
- Review the dapp_api_keys metadata path first, then the Firebase env detection guardrail.

## Follow-ups
- After merge, redeploy/promote Admin production and smoke sign-in plus Apps list/create/rotate against https://admin.cubid.me/admin.
- Consider a separate cleanup pass for the Admin Tailwind/import-order warnings.